### PR TITLE
fix(agent-runner): surface API errors and handle empty message_end content

### DIFF
--- a/src/main/claude/agent-runner-message-end.ts
+++ b/src/main/claude/agent-runner-message-end.ts
@@ -1,0 +1,53 @@
+import type { AssistantMessage, TextContent, ToolCall } from '@mariozechner/pi-ai';
+
+type MessageEndContentBlock = TextContent | ToolCall;
+
+type MessageEndMessage = Pick<AssistantMessage, 'role' | 'content' | 'stopReason' | 'errorMessage'>;
+
+interface ResolveMessageEndPayloadOptions {
+  message?: MessageEndMessage;
+  streamedText: string;
+}
+
+interface ResolvedMessageEndPayload {
+  effectiveContent: MessageEndContentBlock[];
+  errorText?: string;
+  nextStreamedText: string;
+  shouldEmitMessage: boolean;
+}
+
+export function toUserFacingErrorText(errorText: string): string {
+  if (errorText.toLowerCase().includes('first_response_timeout')) {
+    return '模型响应超时：长时间未收到上游返回，请稍后重试或检查当前模型/网关负载。';
+  }
+  if (errorText.toLowerCase().includes('empty_success_result')) {
+    return '模型返回了一个空的成功结果，当前模型或网关兼容性可能有问题，请重试或切换协议后再试。';
+  }
+  return errorText;
+}
+
+export function resolveMessageEndPayload(
+  options: ResolveMessageEndPayloadOptions,
+): ResolvedMessageEndPayload {
+  const { message, streamedText } = options;
+  const nextStreamedText = '';
+
+  if (message?.stopReason === 'error' && message.errorMessage) {
+    return {
+      effectiveContent: [],
+      errorText: toUserFacingErrorText(message.errorMessage),
+      nextStreamedText,
+      shouldEmitMessage: false,
+    };
+  }
+
+  const effectiveContent = Array.isArray(message?.content) && message.content.length > 0
+    ? message.content
+    : (streamedText ? [{ type: 'text', text: streamedText }] : []);
+
+  return {
+    effectiveContent,
+    nextStreamedText,
+    shouldEmitMessage: effectiveContent.length > 0 && (message?.role === 'assistant' || !message),
+  };
+}

--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -26,6 +26,7 @@ import { extractArtifactsFromText, buildArtifactTraceSteps } from '../utils/arti
 import { PluginRuntimeService } from '../skills/plugin-runtime-service';
 import type { SkillsAdapter } from '../skills/skills-adapter';
 import { configStore } from '../config/config-store';
+import { resolveMessageEndPayload, toUserFacingErrorText } from './agent-runner-message-end';
 import { buildSyntheticPiModel, resolvePiRegistryModel } from './pi-model-resolution';
 
 // Virtual workspace path shown to the model (hides real sandbox path)
@@ -138,27 +139,6 @@ function toErrorText(error: unknown): string {
   }
   return serialized;
 }
-
-function toUserFacingErrorText(errorText: string): string {
-  if (errorText.toLowerCase().includes('first_response_timeout')) {
-    return '模型响应超时：长时间未收到上游返回，请稍后重试或检查当前模型/网关负载。';
-  }
-  if (errorText.toLowerCase().includes('empty_success_result')) {
-    return '模型返回了一个空的成功结果，当前模型或网关兼容性可能有问题，请重试或切换协议后再试。';
-  }
-  return errorText;
-}
-
-
-
-
-
-
-
-
-
-
-
 
 interface AgentRunnerOptions {
   sendToRenderer: (event: ServerEvent) => void;
@@ -1167,6 +1147,9 @@ Tool routing:
 
       // Set up event handler to bridge pi-coding-agent events → our ServerEvent protocol
 
+      // Accumulate streamed text deltas in case message_end.content is empty (pi SDK streaming behaviour)
+      let streamedText = '';
+
       const unsubscribe = piSession.subscribe((event) => {
         if (controller.signal.aborted) return;
 
@@ -1186,6 +1169,7 @@ Tool routing:
             if (controller.signal.aborted) break;
             const ame = event.assistantMessageEvent;
             if (ame.type === 'text_delta') {
+              streamedText += ame.delta;
               this.sendPartial(session.id, ame.delta);
             } else if (ame.type === 'thinking_delta') {
               // Thinking output — optionally forward to UI
@@ -1220,9 +1204,24 @@ Tool routing:
             // Works for all providers (some emit 'done' via message_update, others don't).
             if (controller.signal.aborted) break;
             const msg = event.message;
-            if (msg && msg.role === 'assistant') {
+            const resolvedPayload = resolveMessageEndPayload({
+              message: msg as any,
+              streamedText,
+            });
+            streamedText = resolvedPayload.nextStreamedText;
+            if (resolvedPayload.errorText) {
+              this.sendMessage(session.id, {
+                id: uuidv4(),
+                sessionId: session.id,
+                role: 'assistant',
+                content: [{ type: 'text', text: `**Error**: ${resolvedPayload.errorText}` }],
+                timestamp: Date.now(),
+              });
+              break;
+            }
+            if (resolvedPayload.shouldEmitMessage) {
               const contentBlocks: ContentBlock[] = [];
-              for (const block of (msg as any).content || []) {
+              for (const block of resolvedPayload.effectiveContent) {
                 if (block.type === 'text') {
                   const { cleanText, artifacts } = extractArtifactsFromText(block.text);
                   if (cleanText) {

--- a/tests/agent-runner-message-end.test.ts
+++ b/tests/agent-runner-message-end.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveMessageEndPayload } from '../src/main/claude/agent-runner-message-end';
+
+describe('resolveMessageEndPayload', () => {
+  it('falls back to accumulated streamed text when message_end content is empty', () => {
+    const result = resolveMessageEndPayload({
+      message: {
+        role: 'assistant',
+        content: [],
+        stopReason: 'stop',
+      },
+      streamedText: 'streamed fallback',
+    });
+
+    expect(result.nextStreamedText).toBe('');
+    expect(result.errorText).toBeUndefined();
+    expect(result.shouldEmitMessage).toBe(true);
+    expect(result.effectiveContent).toEqual([
+      { type: 'text', text: 'streamed fallback' },
+    ]);
+  });
+
+  it('surfaces user-facing error text when message_end stops with error', () => {
+    const result = resolveMessageEndPayload({
+      message: {
+        role: 'assistant',
+        content: [],
+        stopReason: 'error',
+        errorMessage: 'first_response_timeout',
+      },
+      streamedText: 'partial text',
+    });
+
+    expect(result.nextStreamedText).toBe('');
+    expect(result.shouldEmitMessage).toBe(false);
+    expect(result.effectiveContent).toEqual([]);
+    expect(result.errorText).toBe('模型响应超时：长时间未收到上游返回，请稍后重试或检查当前模型/网关负载。');
+  });
+});

--- a/tests/agent-runner-pi.test.ts
+++ b/tests/agent-runner-pi.test.ts
@@ -33,9 +33,8 @@ describe('ClaudeAgentRunner pi-coding-agent integration', () => {
     expect(agentRunnerContent).toContain("log('[ClaudeAgentRunner] Final mcpServers config:'");
   });
 
-  it('maps watchdog timeout to a user-friendly message', () => {
-    expect(agentRunnerContent).toContain('function toUserFacingErrorText');
-    expect(agentRunnerContent).toContain('模型响应超时：长时间未收到上游返回');
+  it('reuses the shared user-facing error helper', () => {
+    expect(agentRunnerContent).toContain("import { resolveMessageEndPayload, toUserFacingErrorText } from './agent-runner-message-end'");
     expect(agentRunnerContent).toContain('const errorText = toUserFacingErrorText(toErrorText(error));');
   });
 


### PR DESCRIPTION
- Check stopReason === 'error' in message_end and display errorMessage to user instead of silently swallowing API errors (e.g. 403 forbidden)
- Accumulate text_delta chunks as fallback when message_end.content is empty (pi-coding-agent SDK streaming behaviour)
- Relax assistant role check so accumulated streamed text is always sent