### PR TITLE
fix: improve Windows packaging and config status sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "npm run download:node && npm run build:wsl-agent && npm run build:lima-agent && npm run build:mcp && vite",
     "dev:with-python": "npm run download:node && npm run prepare:python && npm run build:wsl-agent && npm run build:lima-agent && npm run build:mcp && vite",
     "build": "npm run download:node && npm run prepare:gui-tools && npm run prepare:python:all && npm run build:wsl-agent && npm run build:lima-agent && npm run build:mcp && tsc && vite build && electron-builder",
+    "build:win": "node scripts/build-windows.js",
     "build:wsl-agent": "tsc -p src/main/sandbox/wsl-agent/tsconfig.json",
     "build:lima-agent": "tsc -p src/main/sandbox/lima-agent/tsconfig.json",
     "build:mcp": "node scripts/bundle-mcp.js",

--- a/scripts/build-windows.js
+++ b/scripts/build-windows.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn, spawnSync } = require('node:child_process');
+
+const PROJECT_ROOT = path.join(__dirname, '..');
+const CACHE_ROOT = path.resolve(
+  process.env.OPEN_COWORK_BUILD_ROOT || path.join(PROJECT_ROOT, '.build-cache')
+);
+
+const DIRS = {
+  root: CACHE_ROOT,
+  temp: path.join(CACHE_ROOT, 'temp'),
+  appDataRoaming: path.join(CACHE_ROOT, 'appdata', 'Roaming'),
+  appDataLocal: path.join(CACHE_ROOT, 'appdata', 'Local'),
+  electronCache: path.join(CACHE_ROOT, 'electron'),
+  electronBuilderCache: path.join(CACHE_ROOT, 'electron-builder'),
+  npmCache: path.join(CACHE_ROOT, 'npm-cache'),
+};
+const LOCAL_ELECTRON_DIST = path.join(PROJECT_ROOT, 'node_modules', 'electron', 'dist');
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function resolveNpmCommand() {
+  if (process.platform === 'win32') {
+    return 'npm.cmd';
+  }
+  return 'npm';
+}
+
+function toPowerShellLiteral(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function isValidZipArchive(zipPath, requiredEntry) {
+  const inspectScript = [
+    '$ErrorActionPreference = "Stop"',
+    'Add-Type -AssemblyName System.IO.Compression.FileSystem',
+    `$zip = ${toPowerShellLiteral(zipPath)}`,
+    `$requiredEntry = ${toPowerShellLiteral(requiredEntry)}`,
+    '$archive = [System.IO.Compression.ZipFile]::OpenRead($zip)',
+    'try {',
+    '  if ($archive.Entries.Count -le 0) { exit 2 }',
+    '  $match = $archive.Entries | Where-Object { $_.FullName -eq $requiredEntry } | Select-Object -First 1',
+    '  if (-not $match) { exit 3 }',
+    '} finally {',
+    '  $archive.Dispose()',
+    '}',
+  ].join('; ');
+
+  const result = spawnSync('powershell.exe', ['-NoProfile', '-Command', inspectScript], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+
+  return result.status === 0;
+}
+
+function cleanInvalidElectronCache(electronCacheDir) {
+  if (process.platform !== 'win32' || !fs.existsSync(electronCacheDir)) {
+    return;
+  }
+
+  const zipFiles = fs.readdirSync(electronCacheDir)
+    .filter((name) => /^electron-v.+-win32-.+\.zip$/i.test(name))
+    .map((name) => path.join(electronCacheDir, name));
+
+  for (const zipPath of zipFiles) {
+    if (isValidZipArchive(zipPath, 'electron.exe')) {
+      console.log('[build:win] Electron cache OK:', zipPath);
+      continue;
+    }
+
+    console.warn('[build:win] Removing invalid Electron cache:', zipPath);
+    fs.rmSync(zipPath, { force: true });
+  }
+}
+
+function main() {
+  if (process.platform !== 'win32') {
+    console.warn('[build:win] This helper is intended for Windows hosts.');
+  }
+
+  Object.values(DIRS).forEach(ensureDir);
+
+  const forwardedArgs = process.argv.slice(2);
+  const builderArgs = forwardedArgs.length > 0 ? [...forwardedArgs] : ['--win', 'nsis'];
+  const env = {
+    ...process.env,
+    APPDATA: DIRS.appDataRoaming,
+    LOCALAPPDATA: DIRS.appDataLocal,
+    TEMP: DIRS.temp,
+    TMP: DIRS.temp,
+    ELECTRON_CACHE: DIRS.electronCache,
+    ELECTRON_BUILDER_CACHE: DIRS.electronBuilderCache,
+    NPM_CONFIG_CACHE: DIRS.npmCache,
+    npm_config_cache: DIRS.npmCache,
+  };
+
+  delete env.ELECTRON_RUN_AS_NODE;
+  cleanInvalidElectronCache(DIRS.electronCache);
+
+  const hasElectronDistOverride = builderArgs.some((arg) => arg.includes('electronDist'));
+  if (!hasElectronDistOverride && fs.existsSync(LOCAL_ELECTRON_DIST)) {
+    builderArgs.push(`--config.electronDist=${LOCAL_ELECTRON_DIST}`);
+  }
+
+  console.log('[build:win] Using cache root:', DIRS.root);
+  console.log('[build:win] TEMP:', DIRS.temp);
+  console.log('[build:win] APPDATA:', DIRS.appDataRoaming);
+  console.log('[build:win] LOCALAPPDATA:', DIRS.appDataLocal);
+  console.log('[build:win] ELECTRON_CACHE:', DIRS.electronCache);
+  console.log('[build:win] ELECTRON_BUILDER_CACHE:', DIRS.electronBuilderCache);
+  console.log('[build:win] NPM_CONFIG_CACHE:', DIRS.npmCache);
+  if (builderArgs.some((arg) => arg.includes('electronDist'))) {
+    console.log('[build:win] electronDist:', LOCAL_ELECTRON_DIST);
+  }
+  console.log('[build:win] Running build with args:', builderArgs.join(' '));
+
+  const child = spawn(resolveNpmCommand(), ['run', 'build', '--', ...builderArgs], {
+    cwd: PROJECT_ROOT,
+    env,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      console.error(`[build:win] Build terminated by signal: ${signal}`);
+      process.exit(1);
+    }
+    process.exit(code ?? 1);
+  });
+
+  child.on('error', (error) => {
+    console.error('[build:win] Failed to start build:', error.message);
+    process.exit(1);
+  });
+}
+
+main();

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -237,7 +237,6 @@ function initializeSchema(database: Database.Database): void {
 
   ensureColumn(database, 'sessions', 'openai_thread_id', 'openai_thread_id TEXT');
   ensureColumn(database, 'sessions', 'model', 'model TEXT');
-  ensureColumn(database, 'messages', 'execution_time_ms', 'execution_time_ms INTEGER');
   
   // Create messages table
   database.exec(`
@@ -251,6 +250,8 @@ function initializeSchema(database: Database.Database): void {
       FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
     )
   `);
+
+  ensureColumn(database, 'messages', 'execution_time_ms', 'execution_time_ms INTEGER');
 
   // Create trace steps table
   database.exec(`

--- a/src/renderer/hooks/useApiConfigState.ts
+++ b/src/renderer/hooks/useApiConfigState.ts
@@ -560,6 +560,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
   const { t } = useTranslation();
   const { enabled = true, initialConfig, onSave } = options;
   const setAppConfig = useAppStore((s) => s.setAppConfig);
+  const setIsConfigured = useAppStore((s) => s.setIsConfigured);
   const initialBootstrapRef = useRef<ApiConfigBootstrap | null>(null);
   if (!initialBootstrapRef.current) {
     initialBootstrapRef.current = buildApiConfigBootstrap(initialConfig, FALLBACK_PROVIDER_PRESETS);
@@ -894,6 +895,15 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       );
     },
     []
+  );
+
+  const applyPersistedConfigToStore = useCallback(
+    (config: AppConfig, loadedPresets: ProviderPresets) => {
+      applyLoadedState(config, loadedPresets);
+      setAppConfig(config);
+      setIsConfigured(Boolean(config.isConfigured));
+    },
+    [applyLoadedState, setAppConfig, setIsConfigured]
   );
 
   const updateActiveProfile = useCallback(
@@ -1487,8 +1497,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
           await onSave(payload);
         } else {
           const result = await window.electronAPI.config.save(payload);
-          applyLoadedState(result.config, presets);
-          setAppConfig(result.config);
+          applyPersistedConfigToStore(result.config, presets);
         }
 
         setSavedDraftSignature(currentDraftSignature);
@@ -1513,7 +1522,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       activeConfigSetId,
       activeProfileKey,
       apiKey,
-      applyLoadedState,
+      applyPersistedConfigToStore,
       baseUrl,
       currentDraftSignature,
       currentPreset.baseUrl,
@@ -1526,7 +1535,6 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       profiles,
       provider,
       requiresApiKey,
-      setAppConfig,
       clearError,
       clearSuccessMessage,
       showErrorKey,
@@ -1547,8 +1555,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       clearError();
       try {
         const result = await window.electronAPI.config.switchSet({ id: setId });
-        applyLoadedState(result.config, presets);
-        setAppConfig(result.config);
+        applyPersistedConfigToStore(result.config, presets);
         if (!options?.silentSuccess) {
           showSuccessKey('api.configSetSwitched');
           setTimeout(() => clearSuccessMessage(), 1500);
@@ -1566,11 +1573,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       }
     },
     [
-      applyLoadedState,
+      applyPersistedConfigToStore,
       clearError,
       clearSuccessMessage,
       presets,
-      setAppConfig,
       showErrorKey,
       showErrorText,
       showSuccessKey,
@@ -1603,8 +1609,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
           mode: payload.mode,
           fromSetId: payload.mode === 'clone' ? activeConfigSetId : undefined,
         });
-        applyLoadedState(result.config, presets);
-        setAppConfig(result.config);
+        applyPersistedConfigToStore(result.config, presets);
         showSuccessKey('api.configSetCreated');
         setTimeout(() => clearSuccessMessage(), 1500);
         return true;
@@ -1621,12 +1626,11 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     },
     [
       activeConfigSetId,
-      applyLoadedState,
+      applyPersistedConfigToStore,
       clearError,
       clearSuccessMessage,
       configSets.length,
       presets,
-      setAppConfig,
       showErrorKey,
       showErrorText,
       showSuccessKey,
@@ -1717,8 +1721,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       clearError();
       try {
         const result = await window.electronAPI.config.renameSet({ id, name: trimmed });
-        applyLoadedState(result.config, presets);
-        setAppConfig(result.config);
+        applyPersistedConfigToStore(result.config, presets);
         showSuccessKey('api.configSetRenamed');
         setTimeout(() => clearSuccessMessage(), 1500);
         return true;
@@ -1734,11 +1737,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       }
     },
     [
-      applyLoadedState,
+      applyPersistedConfigToStore,
       clearError,
       clearSuccessMessage,
       presets,
-      setAppConfig,
       showErrorKey,
       showErrorText,
       showSuccessKey,
@@ -1756,8 +1758,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       clearError();
       try {
         const result = await window.electronAPI.config.deleteSet({ id });
-        applyLoadedState(result.config, presets);
-        setAppConfig(result.config);
+        applyPersistedConfigToStore(result.config, presets);
         showSuccessKey('api.configSetDeleted');
         setTimeout(() => clearSuccessMessage(), 1500);
         return true;
@@ -1773,11 +1774,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       }
     },
     [
-      applyLoadedState,
+      applyPersistedConfigToStore,
       clearError,
       clearSuccessMessage,
       presets,
-      setAppConfig,
       showErrorKey,
       showErrorText,
       showSuccessKey,


### PR DESCRIPTION
## Summary
- add a Windows-focused build helper that redirects Electron and builder caches into the repo, validates cached Electron zips, and reuses the local Electron dist
- fix database initialization so the messages table exists before adding the execution_time_ms column
- keep renderer config state in sync after saving or switching config sets so the sidebar API status updates immediately

## Validation
- 
px.cmd tsc --noEmit
- 
px.cmd vitest run tests/api-config-state.test.ts tests/api-config-state-config-sets.test.ts tests/config-store-profiles.test.ts tests/config-store-config-sets.test.ts tests/config-store-env.test.ts tests/api-diagnostics.test.ts tests/api-tester.test.ts tests/database-path-recovery.test.ts
- verified Windows packaging previously succeeds with 
pm.cmd run build:win -- --win nsis --publish never

## Notes
- left local user changes in package-lock.json, scripts/download-node.js, and .build-cache/ out of this PR