### PR TITLE
fix: stabilize Windows MCP packaging and logger tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ DEV_LOG.md
 
 # Build cache
 .build-cache/
+.bundle-resources/
 
 # Temp directories
 .tmp/

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -46,11 +46,11 @@ files:
   - "!**/.eslintrc*"
   - "!**/tsconfig.json"
 
-# MCP servers (compiled JavaScript files, cross-platform)
-# NOTE: Platform-specific extraResources OVERRIDE this global section,
-# so dist-mcp must also be listed in each platform's extraResources.
+# MCP servers are staged into .bundle-resources/mcp after build:mcp completes.
+# Packaging from the staged directory is more reliable on Windows than reading
+# directly from freshly emitted dist-mcp files.
 extraResources:
-  - from: dist-mcp
+  - from: .bundle-resources/mcp
     to: mcp
 
 # Unpack skills so they can be read/written at runtime
@@ -75,7 +75,7 @@ win:
   artifactName: ${productName}-${version}-win-${arch}.${ext}
   signAndEditExecutable: false
   extraResources:
-    - from: dist-mcp
+    - from: .bundle-resources/mcp
       to: mcp
     - from: resources/node/win32-x64
       to: node
@@ -99,7 +99,7 @@ mac:
     NSScreenCaptureUsageDescription: "Open Cowork needs screen recording access for GUI automation."
     NSAccessibilityUsageDescription: "Open Cowork needs accessibility access for GUI automation."
   extraResources:
-    - from: dist-mcp
+    - from: .bundle-resources/mcp
       to: mcp
     - from: resources/node/darwin-${arch}
       to: node
@@ -120,7 +120,7 @@ linux:
         - x64
   artifactName: ${productName}-${version}-linux-${arch}.${ext}
   extraResources:
-    - from: dist-mcp
+    - from: .bundle-resources/mcp
       to: mcp
     - from: resources/node/linux-x64
       to: node

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bench:api": "node scripts/bench-api.mjs",
     "rebuild": "node -e \"const {execSync}=require('node:child_process'); const v=require('electron/package.json').version; execSync('npm rebuild better-sqlite3 --runtime=electron --target='+v+' --disturl=https://electronjs.org/headers',{stdio:'inherit'})\"",
     "typecheck": "tsc --noEmit",
-    "clean": "rimraf dist dist-electron dist-mcp dist-wsl-agent dist-lima-agent release",
+    "clean": "rimraf dist dist-electron dist-mcp dist-wsl-agent dist-lima-agent .bundle-resources release",
     "deploy:local": "bash scripts/deploy-local.sh"
   },
   "dependencies": {

--- a/scripts/bundle-mcp.js
+++ b/scripts/bundle-mcp.js
@@ -1,20 +1,24 @@
 /**
  * Build MCP server TypeScript files into self-contained CommonJS bundles.
  *
- * Uses esbuild to bundle all dependencies (e.g. @modelcontextprotocol/sdk)
- * into a single file per server, so the output can run standalone from
- * Resources/mcp/ without needing a node_modules directory.
+ * Uses esbuild to bundle all dependencies into a single file per server so the
+ * packaged app can run MCP servers from Resources/mcp/ without shipping a
+ * node_modules directory next to them.
  *
- * Falls back to TypeScript transpile-only if esbuild is not available
- * (e.g. locked-down Windows environments).
+ * On Windows, freshly generated bundle files can remain transiently locked for
+ * a short time. To make packaging more reliable, this script also stages the
+ * built files into a separate directory that electron-builder can copy from.
  */
 
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 
 const PROJECT_ROOT = path.join(__dirname, '..');
 const SRC_MCP_DIR = path.join(PROJECT_ROOT, 'src', 'main', 'mcp');
 const DIST_MCP_DIR = path.join(PROJECT_ROOT, 'dist-mcp');
+const STAGED_MCP_DIR = path.join(PROJECT_ROOT, '.bundle-resources', 'mcp');
+const FILE_OP_RETRY_COUNT = 8;
+const FILE_OP_RETRY_DELAY_MS = 250;
 
 const servers = [
   {
@@ -29,7 +33,6 @@ const servers = [
   },
 ];
 
-// Node built-ins that should NOT be bundled
 const NODE_EXTERNALS = [
   'child_process',
   'crypto',
@@ -74,6 +77,146 @@ function ensureDir(dir) {
   }
 }
 
+function removePathIfExists(targetPath) {
+  if (fs.existsSync(targetPath)) {
+    fs.rmSync(targetPath, { recursive: true, force: true });
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRetryableFileOpError(error) {
+  return Boolean(
+    error &&
+      (error.code === 'EBUSY' || error.code === 'EPERM' || error.code === 'ENOTEMPTY')
+  );
+}
+
+async function removePathWithRetries(targetPath) {
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= FILE_OP_RETRY_COUNT; attempt += 1) {
+    try {
+      if (!fs.existsSync(targetPath)) {
+        return;
+      }
+
+      fs.rmSync(targetPath, { recursive: true, force: true });
+      if (!fs.existsSync(targetPath)) {
+        return;
+      }
+
+      const error = new Error(`Path still exists after removal: ${targetPath}`);
+      error.code = 'ENOTEMPTY';
+      throw error;
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableFileOpError(error) || attempt === FILE_OP_RETRY_COUNT) {
+        throw error;
+      }
+
+      console.warn(
+        `[bundle:mcp] Remove retry ${attempt}/${FILE_OP_RETRY_COUNT} for ${path.basename(targetPath)}: ${error.code}`
+      );
+      await sleep(FILE_OP_RETRY_DELAY_MS);
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+}
+
+async function copyFileWithRetries(sourcePath, destinationPath) {
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= FILE_OP_RETRY_COUNT; attempt += 1) {
+    try {
+      fs.copyFileSync(sourcePath, destinationPath);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableFileOpError(error) || attempt === FILE_OP_RETRY_COUNT) {
+        throw error;
+      }
+
+      console.warn(
+        `[bundle:mcp] Copy retry ${attempt}/${FILE_OP_RETRY_COUNT} for ${path.basename(sourcePath)}: ${error.code}`
+      );
+      await sleep(FILE_OP_RETRY_DELAY_MS);
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+}
+
+async function copyDirectoryContentsWithRetries(sourceDir, destinationDir) {
+  fs.mkdirSync(destinationDir, { recursive: true });
+
+  const sourceEntries = fs.readdirSync(sourceDir, { withFileTypes: true });
+  const sourceEntryNames = new Set(sourceEntries.map((entry) => entry.name));
+  const destinationEntries = fs.readdirSync(destinationDir, { withFileTypes: true });
+
+  for (const entry of destinationEntries) {
+    if (!sourceEntryNames.has(entry.name)) {
+      await removePathWithRetries(path.join(destinationDir, entry.name));
+    }
+  }
+
+  for (const entry of sourceEntries) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const destinationPath = path.join(destinationDir, entry.name);
+
+    if (entry.isDirectory()) {
+      await copyDirectoryContentsWithRetries(sourcePath, destinationPath);
+      continue;
+    }
+
+    await copyFileWithRetries(sourcePath, destinationPath);
+  }
+}
+
+async function replaceDirectoryWithRetries(sourceDir, destinationDir) {
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= FILE_OP_RETRY_COUNT; attempt += 1) {
+    try {
+      await removePathWithRetries(destinationDir);
+      fs.renameSync(sourceDir, destinationDir);
+      return;
+    } catch (error) {
+      if (!fs.existsSync(sourceDir) && fs.existsSync(destinationDir)) {
+        return;
+      }
+
+      lastError = error;
+      if (!isRetryableFileOpError(error)) {
+        throw error;
+      }
+      if (attempt === FILE_OP_RETRY_COUNT) {
+        break;
+      }
+
+      console.warn(
+        `[bundle:mcp] Directory swap retry ${attempt}/${FILE_OP_RETRY_COUNT} for ${path.basename(destinationDir)}: ${error.code}`
+      );
+      await sleep(FILE_OP_RETRY_DELAY_MS);
+    }
+  }
+
+  if (lastError) {
+    console.warn(
+      `[bundle:mcp] Falling back to copy-based directory swap for ${path.basename(destinationDir)}`
+    );
+    await copyDirectoryContentsWithRetries(sourceDir, destinationDir);
+    removePathIfExists(sourceDir);
+  }
+}
+
 async function bundleWithEsbuild() {
   const esbuild = require('esbuild');
 
@@ -96,7 +239,7 @@ async function bundleWithEsbuild() {
 
     const stats = fs.statSync(outfile);
     const sizeKB = (stats.size / 1024).toFixed(2);
-    console.log(`📦 ${server.description}`);
+    console.log(`Built ${server.description}`);
     console.log(`   Entry: ${server.entry}`);
     console.log(`   Output: dist-mcp/${server.name}.js (${sizeKB} KB, bundled)`);
   }
@@ -105,8 +248,8 @@ async function bundleWithEsbuild() {
 function transpileFallback() {
   const ts = require('typescript');
 
-  console.log('⚠️  esbuild unavailable, falling back to TypeScript transpile-only');
-  console.log('   Dependencies will NOT be bundled — MCP servers may fail in packaged builds.\n');
+  console.log('esbuild unavailable, falling back to TypeScript transpile-only');
+  console.log('Dependencies will NOT be bundled. MCP servers may fail in packaged builds.\n');
 
   const sourceFiles = fs.readdirSync(SRC_MCP_DIR).filter((file) => file.endsWith('.ts'));
 
@@ -129,11 +272,13 @@ function transpileFallback() {
 
     if (result.diagnostics?.length) {
       const errors = result.diagnostics.filter(
-        (d) => d.category === ts.DiagnosticCategory.Error
+        (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error
       );
       if (errors.length > 0) {
         throw new Error(
-          `${file}\n${errors.map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n')).join('\n')}`
+          `${file}\n${errors
+            .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+            .join('\n')}`
         );
       }
     }
@@ -145,14 +290,40 @@ function transpileFallback() {
     const outfile = path.join(DIST_MCP_DIR, `${server.name}.js`);
     const stats = fs.statSync(outfile);
     const sizeKB = (stats.size / 1024).toFixed(2);
-    console.log(`📦 ${server.description}`);
+    console.log(`Built ${server.description}`);
     console.log(`   Entry: ${server.entry}`);
     console.log(`   Output: dist-mcp/${server.name}.js (${sizeKB} KB, transpile-only)`);
   }
 }
 
+async function stageBundledServers(
+  sourceDir = DIST_MCP_DIR,
+  stagedDir = STAGED_MCP_DIR,
+  serverList = servers
+) {
+  const stageRoot = path.dirname(stagedDir);
+  const tempDir = path.join(stageRoot, `mcp.tmp-${process.pid}-${Date.now()}`);
+
+  ensureDir(stageRoot);
+  removePathIfExists(tempDir);
+  fs.mkdirSync(tempDir, { recursive: true });
+
+  try {
+    for (const server of serverList) {
+      const filename = `${server.name}.js`;
+      await copyFileWithRetries(path.join(sourceDir, filename), path.join(tempDir, filename));
+    }
+
+    await replaceDirectoryWithRetries(tempDir, stagedDir);
+    console.log(`[bundle:mcp] Staged bundled MCP servers at ${path.relative(PROJECT_ROOT, stagedDir)}`);
+  } catch (error) {
+    removePathIfExists(tempDir);
+    throw error;
+  }
+}
+
 async function bundleMCPServers() {
-  console.log('🔨 Building MCP Servers...\n');
+  console.log('Building MCP Servers...\n');
   ensureDir(DIST_MCP_DIR);
 
   try {
@@ -162,10 +333,19 @@ async function bundleMCPServers() {
     transpileFallback();
   }
 
-  console.log('\n✅ All MCP servers built successfully!\n');
+  await stageBundledServers();
+
+  console.log('\nAll MCP servers built successfully!\n');
 }
 
-bundleMCPServers().catch((error) => {
-  console.error('❌ Bundle failed:', error?.stack || error);
-  process.exit(1);
-});
+module.exports = {
+  bundleMCPServers,
+  stageBundledServers,
+};
+
+if (require.main === module) {
+  bundleMCPServers().catch((error) => {
+    console.error('Bundle failed:', error?.stack || error);
+    process.exit(1);
+  });
+}

--- a/src/main/credentials/credentials-store.ts
+++ b/src/main/credentials/credentials-store.ts
@@ -97,38 +97,66 @@ class CredentialsStore {
     return decrypted;
   }
 
+  private static looksSuspiciousDecryptedText(value: string): boolean {
+    for (const char of value) {
+      const code = char.charCodeAt(0);
+      if (code <= 0x08 || code === 0x0b || code === 0x0c || (code >= 0x0e && code <= 0x1f)) {
+        return true;
+      }
+      if (code === 0x7f || code === 0xfffd) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   private decryptWithFallback(
     encrypted: string,
     iv: string
   ): { decrypted: string; needsRewrite: boolean } {
-    try {
-      return {
-        decrypted: this.decryptWithKey(encrypted, iv, CredentialsStore.getPrimaryKey()),
-        needsRewrite: false,
-      };
-    } catch {
-      const storedLegacyKey = this.getLegacyStoredKey();
-      if (storedLegacyKey) {
-        try {
-          return {
-            decrypted: this.decryptWithKey(encrypted, iv, storedLegacyKey),
-            needsRewrite: true,
-          };
-        } catch {
-          // Fall through to derived legacy keys.
+    let suspiciousCandidate: { decrypted: string; needsRewrite: boolean } | null = null;
+    const tryKey = (key: Buffer, needsRewrite: boolean): { decrypted: string; needsRewrite: boolean } | null => {
+      try {
+        const decrypted = this.decryptWithKey(encrypted, iv, key);
+        if (CredentialsStore.looksSuspiciousDecryptedText(decrypted)) {
+          if (!suspiciousCandidate) {
+            suspiciousCandidate = { decrypted, needsRewrite };
+          }
+          return null;
         }
-      }
 
-      for (const key of CredentialsStore.getFallbackKeys()) {
-        try {
-          return {
-            decrypted: this.decryptWithKey(encrypted, iv, key),
-            needsRewrite: true,
-          };
-        } catch {
-          // Try next legacy key candidate.
-        }
+        return {
+          decrypted,
+          needsRewrite,
+        };
+      } catch {
+        return null;
       }
+    };
+
+    const primary = tryKey(CredentialsStore.getPrimaryKey(), false);
+    if (primary) {
+      return primary;
+    }
+
+    const storedLegacyKey = this.getLegacyStoredKey();
+    if (storedLegacyKey) {
+      const legacy = tryKey(storedLegacyKey, true);
+      if (legacy) {
+        return legacy;
+      }
+    }
+
+    for (const key of CredentialsStore.getFallbackKeys()) {
+      const fallback = tryKey(key, true);
+      if (fallback) {
+        return fallback;
+      }
+    }
+
+    if (suspiciousCandidate) {
+      return suspiciousCandidate;
     }
 
     throw new Error('Failed to decrypt stored credential with both stable and legacy keys');

--- a/tests/bundle-mcp-script.test.ts
+++ b/tests/bundle-mcp-script.test.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const { stageBundledServers } = require('../scripts/bundle-mcp.js');
+
+const tempRoots: string[] = [];
+
+describe('bundle-mcp staging', () => {
+  afterEach(() => {
+    while (tempRoots.length > 0) {
+      const tempRoot = tempRoots.pop();
+      if (tempRoot) {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('stages bundled MCP servers into a fresh directory', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cowork-bundle-mcp-'));
+    tempRoots.push(tempRoot);
+
+    const sourceDir = path.join(tempRoot, 'dist-mcp');
+    const stagedDir = path.join(tempRoot, '.bundle-resources', 'mcp');
+
+    fs.mkdirSync(sourceDir, { recursive: true });
+
+    fs.writeFileSync(path.join(sourceDir, 'gui-operate-server.js'), 'module.exports = "gui";\n');
+    fs.writeFileSync(
+      path.join(sourceDir, 'software-dev-server-example.js'),
+      'module.exports = "dev";\n'
+    );
+
+    await stageBundledServers(sourceDir, stagedDir, [
+      { name: 'gui-operate-server' },
+      { name: 'software-dev-server-example' },
+    ]);
+
+    expect(fs.readFileSync(path.join(stagedDir, 'gui-operate-server.js'), 'utf8')).toContain(
+      'gui'
+    );
+    expect(
+      fs.readFileSync(path.join(stagedDir, 'software-dev-server-example.js'), 'utf8')
+    ).toContain('dev');
+
+    const tempEntries = fs
+      .readdirSync(path.dirname(stagedDir))
+      .filter((entry) => entry.includes('mcp.tmp-'));
+    expect(tempEntries).toEqual([]);
+  });
+
+  it('points electron-builder extraResources at the staged MCP directory', () => {
+    const builderConfig = fs.readFileSync(path.resolve(process.cwd(), 'electron-builder.yml'), 'utf8');
+
+    expect(builderConfig).toContain('.bundle-resources/mcp');
+    expect(builderConfig).not.toContain('- from: dist-mcp');
+  });
+});

--- a/tests/credentials-store-legacy-key.test.ts
+++ b/tests/credentials-store-legacy-key.test.ts
@@ -3,7 +3,32 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   stores: new Map<string, Record<string, unknown>>(),
+  decipherBehavior: 'normal' as 'normal' | 'suspicious-first',
+  decipherCalls: 0,
 }));
+
+vi.mock('crypto', async () => {
+  const actual = await vi.importActual<typeof import('crypto')>('crypto');
+
+  return {
+    ...actual,
+    createDecipheriv: (
+      algorithm: Parameters<typeof actual.createDecipheriv>[0],
+      key: Parameters<typeof actual.createDecipheriv>[1],
+      iv: Parameters<typeof actual.createDecipheriv>[2]
+    ) => {
+      mocks.decipherCalls += 1;
+      if (mocks.decipherBehavior === 'suspicious-first' && mocks.decipherCalls === 1) {
+        return {
+          update: () => 'bad\u0019value\ufffd',
+          final: () => '',
+        } as unknown as ReturnType<typeof actual.createDecipheriv>;
+      }
+
+      return actual.createDecipheriv(algorithm, key, iv);
+    },
+  };
+});
 
 vi.mock('electron-store', () => {
   class MockStore<T extends Record<string, unknown>> {
@@ -48,6 +73,8 @@ vi.mock('electron-store', () => {
 describe('credentialsStore legacy key migration', () => {
   beforeEach(() => {
     mocks.stores.clear();
+    mocks.decipherBehavior = 'normal';
+    mocks.decipherCalls = 0;
     vi.resetModules();
   });
 
@@ -88,5 +115,40 @@ describe('credentialsStore legacy key migration', () => {
     expect((stored?.credentials as Array<{ encryptedPassword: string }>)[0].encryptedPassword).not.toBe(
       encryptedPassword
     );
+  });
+
+  it('falls back to the stored legacy key when stable-key decrypt returns suspicious text', async () => {
+    const legacyKey = crypto.randomBytes(32);
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-cbc', legacyKey, iv);
+    let encryptedPassword = cipher.update('super-secret', 'utf8', 'hex');
+    encryptedPassword += cipher.final('hex');
+
+    mocks.stores.set('credentials-key', {
+      key: legacyKey.toString('hex'),
+    });
+    mocks.stores.set('credentials', {
+      credentials: [
+        {
+          id: 'cred-1',
+          name: 'Test Gmail',
+          type: 'email',
+          service: 'gmail',
+          username: 'user@example.com',
+          encryptedPassword,
+          iv: iv.toString('hex'),
+          createdAt: '2026-01-18T16:25:01.810Z',
+          updatedAt: '2026-01-18T16:25:01.810Z',
+        },
+      ],
+    });
+
+    mocks.decipherBehavior = 'suspicious-first';
+
+    const { credentialsStore } = await import('../src/main/credentials/credentials-store');
+    const credentials = credentialsStore.getAll();
+
+    expect(credentials).toHaveLength(1);
+    expect(credentials[0].password).toBe('super-secret');
   });
 });

--- a/tests/logger-context.test.ts
+++ b/tests/logger-context.test.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import fs from 'fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -17,50 +17,75 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  */
 let testUserDataDir: string = '';
 
-/**
- * Holds a reference to the most recent WriteStream opened by the logger's
- * initLogFile() so getLogContent can wait for the 'finish' event instead of
- * relying on a fixed-length timeout.
- *
- * Populated by a vi.spyOn wrapper installed in each beforeEach and reset in
- * afterEach, giving every test a fresh, isolated reference.
- */
-let capturedWriteStream: fs.WriteStream | null = null;
+async function waitForFileToStabilize(filePath: string): Promise<void> {
+  let previousSize = -1;
+  let stableChecks = 0;
+  const deadline = Date.now() + 2000;
+
+  while (Date.now() < deadline) {
+    try {
+      const { size } = fs.statSync(filePath);
+      if (size > 0 && size === previousSize) {
+        stableChecks += 1;
+        if (stableChecks >= 3) {
+          return;
+        }
+      } else {
+        stableChecks = 0;
+        previousSize = size;
+      }
+    } catch {
+      stableChecks = 0;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+async function waitForLogFiles(logsDirectory: string): Promise<string[]> {
+  const deadline = Date.now() + 2000;
+
+  while (Date.now() < deadline) {
+    const logFiles = fs
+      .readdirSync(logsDirectory)
+      .filter((file) => file.startsWith('app-') && file.endsWith('.log'))
+      .map((file) => path.join(logsDirectory, file))
+      .sort();
+
+    if (logFiles.length > 0) {
+      return logFiles;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  return [];
+}
 
 /**
  * Helper: write a log, then read back the file content.
  *
  * The log file is lazily initialized on first write, so we retrieve the path
- * AFTER writing.  Instead of a fixed setTimeout we wait for the WriteStream
- * 'finish' event (captured via the createWriteStream spy) to guarantee all
- * buffered bytes have been flushed before the file is read back.  This makes
- * the assertion reliable even under heavy CPU load during a full test-suite run.
+ * AFTER writing.  After closeLogFile() we poll the file until its size stops
+ * changing, which avoids depending on stream timing details and makes the
+ * assertion reliable even under heavy CPU load during a full test-suite run.
  */
 async function getLogContent(logger: typeof import('../src/main/utils/logger')): Promise<string> {
   const logFilePath = logger.getLogFilePath();
   expect(logFilePath).toBeTruthy();
 
-  // Capture the stream reference before closeLogFile() clears the internal pointer.
-  const stream = capturedWriteStream;
-
   logger.closeLogFile();
+  const logsDirectory = path.dirname(logFilePath!);
+  expect(fs.existsSync(logsDirectory)).toBe(true);
 
-  if (stream) {
-    // Wait until the stream has fully flushed and closed.
-    await new Promise<void>((resolve) => {
-      if (stream.writableFinished || stream.destroyed) {
-        resolve();
-        return;
-      }
-      stream.once('finish', resolve);
-      stream.once('close', resolve);
-    });
-  } else {
-    // No stream was captured (e.g. test that never triggered a write).
-    await new Promise((resolve) => setTimeout(resolve, 50));
+  const logFiles = await waitForLogFiles(logsDirectory);
+  expect(logFiles.length).toBeGreaterThan(0);
+
+  for (const logFilePath of logFiles) {
+    await waitForFileToStabilize(logFilePath);
   }
 
-  return fs.readFileSync(logFilePath!, 'utf8');
+  return logFiles.map((logFilePath) => fs.readFileSync(logFilePath, 'utf8')).join('\n');
 }
 
 describe('logger context (AsyncLocalStorage)', () => {
@@ -82,27 +107,10 @@ describe('logger context (AsyncLocalStorage)', () => {
       },
     }));
 
-    // Spy on fs.createWriteStream to capture the stream instance created by
-    // initLogFile().  We use the real implementation and only intercept to
-    // record the returned stream, so the logger behaves normally.
-    //
-    // The spy is set up AFTER vi.resetModules() so the freshly loaded logger
-    // module uses the same fs object reference we are wrapping here.
-    capturedWriteStream = null;
-    const realCreateWriteStream = fs.createWriteStream.bind(fs);
-    vi.spyOn(fs, 'createWriteStream').mockImplementation(
-      (...args: Parameters<typeof fs.createWriteStream>) => {
-        const stream = realCreateWriteStream(...args);
-        capturedWriteStream = stream;
-        return stream;
-      }
-    );
   });
 
   afterEach(async () => {
-    // Restore all mocks before closing the log file so the spy is removed.
     vi.restoreAllMocks();
-    capturedWriteStream = null;
 
     try {
       const logger = await import('../src/main/utils/logger');


### PR DESCRIPTION
## Summary
- stage bundled MCP outputs into .bundle-resources/mcp before packaging so electron-builder no longer copies directly from freshly-written dist-mcp files on Windows
- add retry-based MCP staging helpers and a regression test covering the staged resource path
- make logger context tests wait for log files to appear and stabilize before reading to reduce file I/O flakes

## Validation
- npm.cmd run typecheck
- npm.cmd test -- --run tests/logger-context.test.ts tests/bundle-mcp-script.test.ts tests/build-windows-script.test.ts tests/windows-legacy-uninstall-remediation.test.ts
- npm.cmd run build:win