### PR TITLE
fix: clean CI warnings and stabilize tests

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -84,6 +84,14 @@ import {
 import { listRecentWorkspaceFiles } from './utils/recent-workspace-files';
 import { buildDiagnosticsSummary } from './utils/diagnostics-summary';
 
+function omitCredentialPassword<T extends { password?: unknown }>(
+  credential: T
+): Omit<T, 'password'> {
+  const safeCredential = { ...credential };
+  delete safeCredential.password;
+  return safeCredential;
+}
+
 // Current working directory (persisted between sessions)
 let currentWorkingDir: string | null = null;
 
@@ -1634,8 +1642,7 @@ ipcMain.handle('credentials.getById', (_event, id: string) => {
     const cred = credentialsStore.getById(id);
     if (!cred) return undefined;
     // Strip password field before sending to renderer
-    const safeCred = { ...cred, password: undefined };
-    return safeCred;
+    return omitCredentialPassword(cred);
   } catch (error) {
     logError('[Credentials] Error getting credential:', error);
     return undefined;
@@ -1646,7 +1653,7 @@ ipcMain.handle('credentials.getByType', (_event, type: UserCredential['type']) =
   try {
     const creds = credentialsStore.getByType(type);
     // Strip password field before sending to renderer
-    return creds.map((c) => ({ ...c, password: undefined }));
+    return creds.map(omitCredentialPassword);
   } catch (error) {
     logError('[Credentials] Error getting credentials by type:', error);
     return [];
@@ -1657,7 +1664,7 @@ ipcMain.handle('credentials.getByService', (_event, service: string) => {
   try {
     const creds = credentialsStore.getByService(service);
     // Strip password field before sending to renderer
-    return creds.map((c) => ({ ...c, password: undefined }));
+    return creds.map(omitCredentialPassword);
   } catch (error) {
     logError('[Credentials] Error getting credentials by service:', error);
     return [];
@@ -1669,8 +1676,7 @@ ipcMain.handle(
   (_event, credential: Omit<UserCredential, 'id' | 'createdAt' | 'updatedAt'>) => {
     try {
       const saved = credentialsStore.save(credential);
-      const { password: _pw, ...safe } = saved;
-      return safe;
+      return omitCredentialPassword(saved);
     } catch (error) {
       logError('[Credentials] Error saving credential:', error);
       throw error;
@@ -1688,8 +1694,7 @@ ipcMain.handle(
     try {
       const updated = credentialsStore.update(id, updates);
       if (!updated) return undefined;
-      const { password: _pw, ...safe } = updated;
-      return safe;
+      return omitCredentialPassword(updated);
     } catch (error) {
       logError('[Credentials] Error updating credential:', error);
       throw error;

--- a/src/main/sandbox/lima-bridge.ts
+++ b/src/main/sandbox/lima-bridge.ts
@@ -721,7 +721,7 @@ export class LimaBridge implements SandboxExecutor {
       this.limaProcess = null;
       this.isInitialized = false;
 
-      for (const [_id, pending] of this.pendingRequests) {
+      for (const pending of this.pendingRequests.values()) {
         pending.reject(new Error('Lima agent process exited'));
         clearTimeout(pending.timeout);
       }

--- a/src/main/sandbox/wsl-bridge.ts
+++ b/src/main/sandbox/wsl-bridge.ts
@@ -868,7 +868,7 @@ export class WSLBridge implements SandboxExecutor {
       this.isInitialized = false;
 
       // Reject all pending requests
-      for (const [_id, pending] of this.pendingRequests) {
+      for (const pending of this.pendingRequests.values()) {
         pending.reject(new Error('WSL agent process exited'));
         clearTimeout(pending.timeout);
       }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -29,10 +29,18 @@ import type { GlobalNoticeAction } from './store';
 // Check if running in Electron
 const isElectronEnv = typeof window !== 'undefined' && window.electronAPI !== undefined;
 
-const ChatView = lazy(() => import('./components/ChatView').then((module) => ({ default: module.ChatView })));
-const ContextPanel = lazy(() => import('./components/ContextPanel').then((module) => ({ default: module.ContextPanel })));
-const ConfigModal = lazy(() => import('./components/ConfigModal').then((module) => ({ default: module.ConfigModal })));
-const SettingsPanel = lazy(() => import('./components/SettingsPanel').then((module) => ({ default: module.SettingsPanel })));
+const ChatView = lazy(() =>
+  import('./components/ChatView').then((module) => ({ default: module.ChatView }))
+);
+const ContextPanel = lazy(() =>
+  import('./components/ContextPanel').then((module) => ({ default: module.ContextPanel }))
+);
+const ConfigModal = lazy(() =>
+  import('./components/ConfigModal').then((module) => ({ default: module.ConfigModal }))
+);
+const SettingsPanel = lazy(() =>
+  import('./components/SettingsPanel').then((module) => ({ default: module.SettingsPanel }))
+);
 
 function MainPanelFallback() {
   return (
@@ -43,7 +51,12 @@ function MainPanelFallback() {
 }
 
 function ContextPanelFallback() {
-  return <div className="hidden xl:block w-[340px] shrink-0 border-l border-border-subtle bg-background/60" aria-hidden="true" />;
+  return (
+    <div
+      className="hidden xl:block w-[340px] shrink-0 border-l border-border-subtle bg-background/60"
+      aria-hidden="true"
+    />
+  );
 }
 
 function App() {
@@ -55,7 +68,8 @@ function App() {
   const { sidebarCollapsed } = useLayoutState();
   const { showConfigModal, isConfigured, appConfig } = useConfigModalState();
   const globalNotice = useGlobalNotice();
-  const { progress: sandboxSetupProgress, isComplete: isSandboxSetupComplete } = useSandboxSetupState();
+  const { progress: sandboxSetupProgress, isComplete: isSandboxSetupComplete } =
+    useSandboxSetupState();
   const sandboxSyncStatus = useSandboxSyncStatus();
   const { pendingPermission, pendingSudoPassword } = usePendingDialogs();
 
@@ -75,21 +89,18 @@ function App() {
   const sidebarBeforeSettings = useRef(false);
 
   useEffect(() => {
-    // Only run once on mount
     if (initialized.current) return;
     initialized.current = true;
 
     if (isElectron) {
       listSessions();
     }
-  }, []); // Empty deps - run once
+  }, [isElectron, listSessions]);
 
   // Apply theme to document root
   useEffect(() => {
     const effectiveTheme =
-      settings.theme === 'system'
-        ? (systemDarkMode ? 'dark' : 'light')
-        : settings.theme;
+      settings.theme === 'system' ? (systemDarkMode ? 'dark' : 'light') : settings.theme;
 
     if (effectiveTheme === 'light') {
       document.documentElement.classList.add('light');
@@ -113,22 +124,25 @@ function App() {
       setSidebarCollapsed(false);
       sidebarBeforeSettings.current = false;
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showSettings]);
 
   // Handle config save
-  const handleConfigSave = useCallback(async (newConfig: Partial<AppConfig>) => {
-    if (!isElectronEnv) {
-      console.log('[App] Browser mode - config save simulated');
-      return;
-    }
-    
-    const result = await window.electronAPI.config.save(newConfig);
-    if (result.success) {
-      setIsConfigured(Boolean(result.config?.isConfigured));
-      setAppConfig(result.config);
-    }
-  }, [setIsConfigured, setAppConfig]);
+  const handleConfigSave = useCallback(
+    async (newConfig: Partial<AppConfig>) => {
+      if (!isElectronEnv) {
+        console.log('[App] Browser mode - config save simulated');
+        return;
+      }
+
+      const result = await window.electronAPI.config.save(newConfig);
+      if (result.success) {
+        setIsConfigured(Boolean(result.config?.isConfigured));
+        setAppConfig(result.config);
+      }
+    },
+    [setIsConfigured, setAppConfig]
+  );
 
   // Handle config modal close
   const handleConfigClose = useCallback(() => {
@@ -140,12 +154,15 @@ function App() {
     setSandboxSetupComplete(true);
   }, [setSandboxSetupComplete]);
 
-  const handleGlobalNoticeAction = useCallback((action: GlobalNoticeAction) => {
-    if (action === 'open_api_settings') {
-      setShowConfigModal(true);
-    }
-    clearGlobalNotice();
-  }, [clearGlobalNotice, setShowConfigModal]);
+  const handleGlobalNoticeAction = useCallback(
+    (action: GlobalNoticeAction) => {
+      if (action === 'open_api_settings') {
+        setShowConfigModal(true);
+      }
+      clearGlobalNotice();
+    },
+    [clearGlobalNotice, setShowConfigModal]
+  );
 
   // Determine if we should show the sandbox setup dialog
   // Show if there's progress and setup is not complete
@@ -155,7 +172,7 @@ function App() {
     <div className="h-full w-full min-h-0 flex flex-col overflow-hidden bg-background">
       {/* Titlebar - draggable region */}
       <Titlebar />
-      
+
       {/* Main Content */}
       <div className="flex-1 min-h-0 flex overflow-hidden">
         {/* Sidebar */}
@@ -166,13 +183,21 @@ function App() {
         {/* Main Content Area */}
         <main className="flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden bg-background">
           {showSettings ? (
-            <PanelErrorBoundary name="SettingsPanel" resetKey="settings" fallback={<MainPanelFallback />}>
+            <PanelErrorBoundary
+              name="SettingsPanel"
+              resetKey="settings"
+              fallback={<MainPanelFallback />}
+            >
               <Suspense fallback={<MainPanelFallback />}>
                 <SettingsPanel onClose={() => setShowSettings(false)} />
               </Suspense>
             </PanelErrorBoundary>
           ) : activeSessionId ? (
-            <PanelErrorBoundary name="ChatView" resetKey={activeSessionId} fallback={<MainPanelFallback />}>
+            <PanelErrorBoundary
+              name="ChatView"
+              resetKey={activeSessionId}
+              fallback={<MainPanelFallback />}
+            >
               <Suspense fallback={<MainPanelFallback />}>
                 <ChatView />
               </Suspense>
@@ -184,20 +209,24 @@ function App() {
 
         {/* Context Panel - only show when in session and not in settings */}
         {activeSessionId && !showSettings && (
-          <PanelErrorBoundary name="ContextPanel" resetKey={activeSessionId} fallback={<ContextPanelFallback />}>
+          <PanelErrorBoundary
+            name="ContextPanel"
+            resetKey={activeSessionId}
+            fallback={<ContextPanelFallback />}
+          >
             <Suspense fallback={<ContextPanelFallback />}>
               <ContextPanel />
             </Suspense>
           </PanelErrorBoundary>
         )}
       </div>
-      
+
       {/* Permission Dialog */}
       {pendingPermission && <PermissionDialog permission={pendingPermission} />}
 
       {/* Sudo Password Dialog */}
       {pendingSudoPassword && <SudoPasswordDialog request={pendingSudoPassword} />}
-      
+
       {/* Config Modal */}
       <PanelErrorBoundary name="ConfigModal" fallback={null}>
         <Suspense fallback={null}>
@@ -213,12 +242,12 @@ function App() {
 
       {/* Sandbox Setup Dialog */}
       {showSandboxSetup && (
-        <SandboxSetupDialog 
+        <SandboxSetupDialog
           progress={sandboxSetupProgress}
           onComplete={handleSandboxSetupComplete}
         />
       )}
-      
+
       {/* Sandbox Sync Toast */}
       <SandboxSyncToast status={sandboxSyncStatus} />
 

--- a/src/renderer/components/ChatView.tsx
+++ b/src/renderer/components/ChatView.tsx
@@ -132,43 +132,46 @@ export function ChatView() {
   const timerActive = Boolean(executionClock?.startAt && executionClock.endAt === null);
 
   // Debounced scroll function to prevent scroll conflicts
-  const scrollToBottom = useRef((behavior: ScrollBehavior = 'auto', immediate: boolean = false) => {
-    // Cancel any pending scroll requests
-    if (scrollTimeoutRef.current) {
-      clearTimeout(scrollTimeoutRef.current);
-      scrollTimeoutRef.current = null;
-    }
-    if (scrollRequestRef.current) {
-      cancelAnimationFrame(scrollRequestRef.current);
-      scrollRequestRef.current = null;
-    }
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior = 'auto', immediate: boolean = false) => {
+      // Cancel any pending scroll requests
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+        scrollTimeoutRef.current = null;
+      }
+      if (scrollRequestRef.current) {
+        cancelAnimationFrame(scrollRequestRef.current);
+        scrollRequestRef.current = null;
+      }
 
-    const performScroll = () => {
-      if (!isUserAtBottomRef.current) return;
+      const performScroll = () => {
+        if (!isUserAtBottomRef.current) return;
 
-      // Mark as scrolling to prevent concurrent scrolls
-      isScrollingRef.current = true;
+        // Mark as scrolling to prevent concurrent scrolls
+        isScrollingRef.current = true;
 
-      messagesEndRef.current?.scrollIntoView({ behavior });
+        messagesEndRef.current?.scrollIntoView({ behavior });
 
-      // Reset scrolling flag after a short delay
-      setTimeout(
-        () => {
-          isScrollingRef.current = false;
-        },
-        behavior === 'smooth' ? 300 : 50
-      );
-    };
+        // Reset scrolling flag after a short delay
+        setTimeout(
+          () => {
+            isScrollingRef.current = false;
+          },
+          behavior === 'smooth' ? 300 : 50
+        );
+      };
 
-    if (immediate) {
-      performScroll();
-    } else {
-      // Use RAF + timeout for debouncing
-      scrollRequestRef.current = requestAnimationFrame(() => {
-        scrollTimeoutRef.current = setTimeout(performScroll, 16); // ~1 frame delay
-      });
-    }
-  }).current;
+      if (immediate) {
+        performScroll();
+      } else {
+        // Use RAF + timeout for debouncing
+        scrollRequestRef.current = requestAnimationFrame(() => {
+          scrollTimeoutRef.current = setTimeout(performScroll, 16); // ~1 frame delay
+        });
+      }
+    },
+    []
+  );
 
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -211,9 +214,11 @@ export function ChatView() {
 
     prevMessageCountRef.current = messageCount;
     prevPartialLengthRef.current = partialLength;
-  }, [messages.length, partialMessage.length, partialThinking.length]);
+  }, [messages.length, partialMessage.length, partialThinking.length, scrollToBottom]);
 
   // Additional scroll trigger for content height changes (e.g., TodoWrite expand/collapse)
+  // scrollToBottom is stable via useCallback; recreating the observer is unnecessary.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     const container = scrollContainerRef.current;
     const messagesContainer = messagesContainerRef.current;
@@ -232,6 +237,7 @@ export function ChatView() {
     return () => {
       resizeObserver.disconnect();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // ResizeObserver is stable — no need to recreate on message count changes
 
   // Cleanup scroll timeouts on unmount

--- a/src/renderer/components/MessageCard.tsx
+++ b/src/renderer/components/MessageCard.tsx
@@ -17,9 +17,13 @@ export const MessageCard = memo(function MessageCard({ message, isStreaming }: M
   const isQueued = message.localStatus === 'queued';
   const isCancelled = message.localStatus === 'cancelled';
   const rawContent = message.content as unknown;
-  const contentBlocks = Array.isArray(rawContent)
-    ? (rawContent as ContentBlock[])
-    : [{ type: 'text', text: String(rawContent ?? '') } as ContentBlock];
+  const contentBlocks = useMemo(
+    () =>
+      Array.isArray(rawContent)
+        ? (rawContent as ContentBlock[])
+        : ([{ type: 'text', text: String(rawContent ?? '') }] as ContentBlock[]),
+    [rawContent]
+  );
   const [copied, setCopied] = useState(false);
 
   // Build a set of tool_result IDs that have a matching tool_use (for merging)

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -92,9 +92,7 @@ export function SettingsPanel({ onClose, initialTab = 'api' }: SettingsPanelProp
 
   // Mark tab as viewed when it becomes active
   useEffect(() => {
-    if (!viewedTabs.has(activeTab)) {
-      setViewedTabs((prev) => new Set([...prev, activeTab]));
-    }
+    setViewedTabs((prev) => (prev.has(activeTab) ? prev : new Set([...prev, activeTab])));
   }, [activeTab]);
 
   const tabs = [

--- a/src/renderer/hooks/useApiConfigState.ts
+++ b/src/renderer/hooks/useApiConfigState.ts
@@ -14,10 +14,7 @@ import type {
   ProviderType,
 } from '../types';
 import { isLoopbackBaseUrl } from '../../shared/network/loopback';
-import {
-  DEFAULT_OLLAMA_BASE_URL,
-  normalizeOllamaBaseUrl,
-} from '../../shared/ollama-base-url';
+import { DEFAULT_OLLAMA_BASE_URL, normalizeOllamaBaseUrl } from '../../shared/ollama-base-url';
 import { API_PROVIDER_PRESETS, getModelInputGuidance } from '../../shared/api-model-presets';
 import {
   COMMON_PROVIDER_SETUPS,
@@ -196,7 +193,7 @@ function defaultProfileForKey(
   return {
     apiKey: '',
     baseUrl: preset.baseUrl,
-    model: profileKey === 'ollama' ? '' : (preset.models[0]?.id || ''),
+    model: profileKey === 'ollama' ? '' : preset.models[0]?.id || '',
     customModel: '',
     useCustomModel: prefersCustomInput,
     contextWindow: '',
@@ -265,9 +262,8 @@ function normalizeProfile(
   );
   return {
     apiKey: profile?.apiKey || '',
-    baseUrl: profileKey === 'ollama'
-      ? (normalizeOllamaBaseUrl(rawBaseUrl) || fallback.baseUrl)
-      : rawBaseUrl,
+    baseUrl:
+      profileKey === 'ollama' ? normalizeOllamaBaseUrl(rawBaseUrl) || fallback.baseUrl : rawBaseUrl,
     model: hasPresetModel ? modelValue : fallback.model,
     customModel: hasPresetModel ? '' : modelValue,
     useCustomModel: !hasPresetModel,
@@ -726,7 +722,10 @@ function apiConfigReducer(state: ApiConfigState, action: ApiConfigAction): ApiCo
     case 'CLEAR_DISCOVERED_MODELS':
       return {
         ...state,
-        discoveredModels: clearDiscoveredModelsForProfile(state.discoveredModels, action.profileKey),
+        discoveredModels: clearDiscoveredModelsForProfile(
+          state.discoveredModels,
+          action.profileKey
+        ),
       };
 
     case 'DELETE_DISCOVERED_MODELS': {
@@ -824,34 +823,38 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
         ? 'gemini'
         : 'anthropic';
 
-  const [state, dispatch] = useReducer(apiConfigReducer, undefined, (): ApiConfigState => ({
-    presets: FALLBACK_PROVIDER_PRESETS,
-    profiles: initialBootstrap.snapshot.profiles,
-    activeProfileKey: initialBootstrap.snapshot.activeProfileKey,
-    configSets: initialBootstrap.configSets,
-    activeConfigSetId: initialBootstrap.activeConfigSetId,
-    pendingConfigSetAction: null,
-    isMutatingConfigSet: false,
-    lastCustomProtocol: initialLastCustomProtocol,
-    enableThinking: Boolean(initialConfig?.enableThinking),
-    discoveredModels: {},
-    isLoadingConfig: true,
-    savedDraftSignature: '',
-    isSaving: false,
-    isTesting: false,
-    isRefreshingModels: false,
-    isDiscoveringLocalOllama: false,
-    errorText: '',
-    errorKey: null,
-    errorValues: undefined,
-    successText: '',
-    successKey: null,
-    successValues: undefined,
-    lastSaveCompletedAt: 0,
-    testResult: null,
-    diagnosticResult: null,
-    isDiagnosing: false,
-  }));
+  const [state, dispatch] = useReducer(
+    apiConfigReducer,
+    undefined,
+    (): ApiConfigState => ({
+      presets: FALLBACK_PROVIDER_PRESETS,
+      profiles: initialBootstrap.snapshot.profiles,
+      activeProfileKey: initialBootstrap.snapshot.activeProfileKey,
+      configSets: initialBootstrap.configSets,
+      activeConfigSetId: initialBootstrap.activeConfigSetId,
+      pendingConfigSetAction: null,
+      isMutatingConfigSet: false,
+      lastCustomProtocol: initialLastCustomProtocol,
+      enableThinking: Boolean(initialConfig?.enableThinking),
+      discoveredModels: {},
+      isLoadingConfig: true,
+      savedDraftSignature: '',
+      isSaving: false,
+      isTesting: false,
+      isRefreshingModels: false,
+      isDiscoveringLocalOllama: false,
+      errorText: '',
+      errorKey: null,
+      errorValues: undefined,
+      successText: '',
+      successKey: null,
+      successValues: undefined,
+      lastSaveCompletedAt: 0,
+      testResult: null,
+      diagnosticResult: null,
+      isDiagnosing: false,
+    })
+  );
 
   // Destructure state for convenience — avoids `state.X` in every expression
   const {
@@ -930,12 +933,14 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
   const modelPreset = modelPresetForProfile(activeProfileKey, presets);
   const currentPreset = modelPreset;
   const hasDiscoveredOllamaModels =
-    provider === 'ollama' && Object.prototype.hasOwnProperty.call(discoveredModels, activeProfileKey);
-  const modelOptions = provider === 'ollama'
-    ? (discoveredModels[activeProfileKey] || [])
-    : hasDiscoveredOllamaModels
-      ? (discoveredModels[activeProfileKey] || [])
-      : modelPreset.models;
+    provider === 'ollama' &&
+    Object.prototype.hasOwnProperty.call(discoveredModels, activeProfileKey);
+  const modelOptions =
+    provider === 'ollama'
+      ? discoveredModels[activeProfileKey] || []
+      : hasDiscoveredOllamaModels
+        ? discoveredModels[activeProfileKey] || []
+        : modelPreset.models;
   const modelInputGuidance = getModelInputGuidance(provider, customProtocol);
 
   const currentConfigSet = useMemo(
@@ -956,10 +961,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
   const customModel = currentProfile.customModel;
   const useCustomModel = currentProfile.useCustomModel;
   const shouldShowOllamaManualModelToggle =
-    provider !== 'ollama'
-      || useCustomModel
-      || Boolean(error)
-      || modelOptions.length === 0;
+    provider !== 'ollama' || useCustomModel || Boolean(error) || modelOptions.length === 0;
   const contextWindow = currentProfile.contextWindow;
   const maxTokens = currentProfile.maxTokens;
   const detectedProviderSetup = useMemo(
@@ -1181,7 +1183,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
 
   const changeProtocol = useCallback((newProtocol: CustomProtocolType) => {
     dispatch({ type: 'SET_LAST_CUSTOM_PROTOCOL', payload: newProtocol });
-    dispatch({ type: 'SET_ACTIVE_PROFILE_KEY', payload: profileKeyFromProvider('custom', newProtocol) });
+    dispatch({
+      type: 'SET_ACTIVE_PROFILE_KEY',
+      payload: profileKeyFromProvider('custom', newProtocol),
+    });
   }, []);
 
   const setApiKey = useCallback(
@@ -1354,7 +1359,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
           if (!inPreset) {
             return {
               ...current,
-              model: provider === 'ollama' ? '' : (preset.models[0]?.id || ''),
+              model: provider === 'ollama' ? '' : preset.models[0]?.id || '',
             };
           }
         }
@@ -1430,52 +1435,55 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     showSuccessKey,
   ]);
 
-  const handleDiagnose = useCallback(async (verificationLevel: 'fast' | 'deep' = 'fast') => {
-    if (requiresApiKey && !apiKey.trim()) {
-      showErrorKey('api.testError.missing_key');
-      return;
-    }
+  const handleDiagnose = useCallback(
+    async (verificationLevel: 'fast' | 'deep' = 'fast') => {
+      if (requiresApiKey && !apiKey.trim()) {
+        showErrorKey('api.testError.missing_key');
+        return;
+      }
 
-    clearError();
-    dispatch({ type: 'SET_IS_DIAGNOSING', payload: true });
-    dispatch({ type: 'SET_DIAGNOSTIC_RESULT', payload: null });
-    dispatch({ type: 'SET_TEST_RESULT', payload: null });
-    try {
-      const resolvedBaseUrl =
-        provider === 'custom' || provider === 'ollama'
-          ? baseUrl.trim()
-          : (baseUrl.trim() || currentPreset.baseUrl || '').trim();
+      clearError();
+      dispatch({ type: 'SET_IS_DIAGNOSING', payload: true });
+      dispatch({ type: 'SET_DIAGNOSTIC_RESULT', payload: null });
+      dispatch({ type: 'SET_TEST_RESULT', payload: null });
+      try {
+        const resolvedBaseUrl =
+          provider === 'custom' || provider === 'ollama'
+            ? baseUrl.trim()
+            : (baseUrl.trim() || currentPreset.baseUrl || '').trim();
 
-      const finalModel = useCustomModel ? customModel.trim() : model;
+        const finalModel = useCustomModel ? customModel.trim() : model;
 
-      const result = await window.electronAPI.config.diagnose({
-        provider,
-        apiKey: apiKey.trim(),
-        baseUrl: resolvedBaseUrl || undefined,
-        customProtocol,
-        model: finalModel || undefined,
-        verificationLevel,
-      });
-      dispatch({ type: 'SET_DIAGNOSTIC_RESULT', payload: result });
-    } catch (err) {
-      showErrorText((err as Error).message || 'Diagnosis failed');
-    } finally {
-      dispatch({ type: 'SET_IS_DIAGNOSING', payload: false });
-    }
-  }, [
-    requiresApiKey,
-    apiKey,
-    baseUrl,
-    provider,
-    customProtocol,
-    model,
-    customModel,
-    useCustomModel,
-    currentPreset.baseUrl,
-    clearError,
-    showErrorKey,
-    showErrorText,
-  ]);
+        const result = await window.electronAPI.config.diagnose({
+          provider,
+          apiKey: apiKey.trim(),
+          baseUrl: resolvedBaseUrl || undefined,
+          customProtocol,
+          model: finalModel || undefined,
+          verificationLevel,
+        });
+        dispatch({ type: 'SET_DIAGNOSTIC_RESULT', payload: result });
+      } catch (err) {
+        showErrorText((err as Error).message || 'Diagnosis failed');
+      } finally {
+        dispatch({ type: 'SET_IS_DIAGNOSING', payload: false });
+      }
+    },
+    [
+      requiresApiKey,
+      apiKey,
+      baseUrl,
+      provider,
+      customProtocol,
+      model,
+      customModel,
+      useCustomModel,
+      currentPreset.baseUrl,
+      clearError,
+      showErrorKey,
+      showErrorText,
+    ]
+  );
 
   const handleDeepDiagnose = useCallback(async () => {
     await handleDiagnose('deep');
@@ -1501,10 +1509,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
 
       const latestTarget = latestOllamaTargetRef.current;
       if (
-        requestId !== ollamaRefreshRequestIdRef.current
-        || latestTarget.provider !== 'ollama'
-        || latestTarget.activeProfileKey !== requestedProfileKey
-        || latestTarget.baseUrl !== requestedBaseUrl
+        requestId !== ollamaRefreshRequestIdRef.current ||
+        latestTarget.provider !== 'ollama' ||
+        latestTarget.activeProfileKey !== requestedProfileKey ||
+        latestTarget.baseUrl !== requestedBaseUrl
       ) {
         return models;
       }
@@ -1534,10 +1542,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     } catch (refreshError) {
       const latestTarget = latestOllamaTargetRef.current;
       if (
-        requestId !== ollamaRefreshRequestIdRef.current
-        || latestTarget.provider !== 'ollama'
-        || latestTarget.activeProfileKey !== requestedProfileKey
-        || latestTarget.baseUrl !== requestedBaseUrl
+        requestId !== ollamaRefreshRequestIdRef.current ||
+        latestTarget.provider !== 'ollama' ||
+        latestTarget.activeProfileKey !== requestedProfileKey ||
+        latestTarget.baseUrl !== requestedBaseUrl
       ) {
         return [];
       }
@@ -1553,16 +1561,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
         dispatch({ type: 'SET_IS_REFRESHING_MODELS', payload: false });
       }
     }
-  }, [
-    activeProfileKey,
-    apiKey,
-    baseUrl,
-    presets,
-    provider,
-    clearError,
-    showErrorKey,
-    showErrorText,
-  ]);
+  }, [activeProfileKey, apiKey, baseUrl, provider, clearError, showErrorKey, showErrorText]);
 
   const applyDiscoveredOllamaState = useCallback(
     (
@@ -1622,10 +1621,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
         });
         const latestTarget = latestOllamaTargetRef.current;
         if (
-          requestId !== ollamaDiscoverRequestIdRef.current
-          || latestTarget.provider !== 'ollama'
-          || latestTarget.activeProfileKey !== requestedProfileKey
-          || latestTarget.baseUrl !== requestedBaseUrl
+          requestId !== ollamaDiscoverRequestIdRef.current ||
+          latestTarget.provider !== 'ollama' ||
+          latestTarget.activeProfileKey !== requestedProfileKey ||
+          latestTarget.baseUrl !== requestedBaseUrl
         ) {
           return result;
         }
@@ -1656,10 +1655,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       } catch (discoveryError) {
         const latestTarget = latestOllamaTargetRef.current;
         if (
-          requestId !== ollamaDiscoverRequestIdRef.current
-          || latestTarget.provider !== 'ollama'
-          || latestTarget.activeProfileKey !== requestedProfileKey
-          || latestTarget.baseUrl !== requestedBaseUrl
+          requestId !== ollamaDiscoverRequestIdRef.current ||
+          latestTarget.provider !== 'ollama' ||
+          latestTarget.activeProfileKey !== requestedProfileKey ||
+          latestTarget.baseUrl !== requestedBaseUrl
         ) {
           return null;
         }

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -262,7 +262,8 @@ export const useAppStore = create<AppState>((set) => ({
 
   removeSession: (sessionId) =>
     set((state) => {
-      const { [sessionId]: _, ...restSessionStates } = state.sessionStates;
+      const restSessionStates = { ...state.sessionStates };
+      delete restSessionStates[sessionId];
       return {
         sessions: state.sessions.filter((s) => s.id !== sessionId),
         sessionStates: restSessionStates,

--- a/src/tests/skills/dangling-symlink.test.ts
+++ b/src/tests/skills/dangling-symlink.test.ts
@@ -20,6 +20,24 @@ function isDanglingSymlink(filePath: string): boolean {
   }
 }
 
+function supportsDirectorySymlinks(): boolean {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cowork-symlink-probe-'));
+  const targetPath = path.join(probeDir, 'target');
+  const linkPath = path.join(probeDir, 'link');
+
+  try {
+    fs.mkdirSync(targetPath);
+    fs.symlinkSync(targetPath, linkPath, 'dir');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+}
+
+const itIfDirectorySymlinkSupported = supportsDirectorySymlinks() ? it : it.skip;
+
 describe('isDanglingSymlink', () => {
   let tmpDir: string;
 
@@ -43,7 +61,7 @@ describe('isDanglingSymlink', () => {
     expect(isDanglingSymlink(dirPath)).toBe(false);
   });
 
-  it('returns false for a valid symlink', () => {
+  itIfDirectorySymlinkSupported('returns false for a valid symlink', () => {
     const targetPath = path.join(tmpDir, 'target');
     fs.mkdirSync(targetPath);
     const linkPath = path.join(tmpDir, 'link');
@@ -51,9 +69,9 @@ describe('isDanglingSymlink', () => {
     expect(isDanglingSymlink(linkPath)).toBe(false);
   });
 
-  it('returns true for a dangling symlink', () => {
+  itIfDirectorySymlinkSupported('returns true for a dangling symlink', () => {
     const linkPath = path.join(tmpDir, 'dangling');
-    fs.symlinkSync('/nonexistent/path/that/does/not/exist', linkPath, 'dir');
+    fs.symlinkSync(path.join(tmpDir, 'missing-target'), linkPath, 'dir');
     expect(isDanglingSymlink(linkPath)).toBe(true);
   });
 
@@ -61,21 +79,24 @@ describe('isDanglingSymlink', () => {
     expect(isDanglingSymlink(path.join(tmpDir, 'nope'))).toBe(false);
   });
 
-  it('returns true when symlink target is removed after creation', () => {
-    const targetPath = path.join(tmpDir, 'target-dir');
-    fs.mkdirSync(targetPath);
-    const linkPath = path.join(tmpDir, 'link-to-target');
-    fs.symlinkSync(targetPath, linkPath, 'dir');
+  itIfDirectorySymlinkSupported(
+    'returns true when symlink target is removed after creation',
+    () => {
+      const targetPath = path.join(tmpDir, 'target-dir');
+      fs.mkdirSync(targetPath);
+      const linkPath = path.join(tmpDir, 'link-to-target');
+      fs.symlinkSync(targetPath, linkPath, 'dir');
 
-    // Symlink is valid before removal
-    expect(isDanglingSymlink(linkPath)).toBe(false);
+      // Symlink is valid before removal
+      expect(isDanglingSymlink(linkPath)).toBe(false);
 
-    // Remove the target
-    fs.rmSync(targetPath, { recursive: true });
+      // Remove the target
+      fs.rmSync(targetPath, { recursive: true });
 
-    // Now the symlink is dangling
-    expect(isDanglingSymlink(linkPath)).toBe(true);
-  });
+      // Now the symlink is dangling
+      expect(isDanglingSymlink(linkPath)).toBe(true);
+    }
+  );
 });
 
 describe('dangling symlink cleanup in skill directories', () => {
@@ -89,24 +110,24 @@ describe('dangling symlink cleanup in skill directories', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('fs.existsSync returns false for dangling symlinks', () => {
+  itIfDirectorySymlinkSupported('fs.existsSync returns false for dangling symlinks', () => {
     const linkPath = path.join(tmpDir, 'docx');
-    fs.symlinkSync('/nonexistent/asar/path', linkPath, 'dir');
+    fs.symlinkSync(path.join(tmpDir, 'missing-asar-path'), linkPath, 'dir');
     expect(fs.existsSync(linkPath)).toBe(false);
   });
 
-  it('fs.mkdirSync fails on path with dangling symlink', () => {
+  itIfDirectorySymlinkSupported('fs.mkdirSync fails on path with dangling symlink', () => {
     const linkPath = path.join(tmpDir, 'docx');
-    fs.symlinkSync('/nonexistent/asar/path', linkPath, 'dir');
+    fs.symlinkSync(path.join(tmpDir, 'missing-asar-path'), linkPath, 'dir');
 
     expect(() => {
       fs.mkdirSync(linkPath, { recursive: true });
     }).toThrow();
   });
 
-  it('unlinkSync removes a dangling symlink', () => {
+  itIfDirectorySymlinkSupported('unlinkSync removes a dangling symlink', () => {
     const linkPath = path.join(tmpDir, 'docx');
-    fs.symlinkSync('/nonexistent/asar/path', linkPath, 'dir');
+    fs.symlinkSync(path.join(tmpDir, 'missing-asar-path'), linkPath, 'dir');
 
     // Confirm it's dangling
     expect(isDanglingSymlink(linkPath)).toBe(true);
@@ -123,17 +144,17 @@ describe('dangling symlink cleanup in skill directories', () => {
     expect(fs.statSync(linkPath).isDirectory()).toBe(true);
   });
 
-  it('readdirSync lists dangling symlinks by name', () => {
+  itIfDirectorySymlinkSupported('readdirSync lists dangling symlinks by name', () => {
     const linkPath = path.join(tmpDir, 'docx');
-    fs.symlinkSync('/nonexistent/asar/path', linkPath, 'dir');
+    fs.symlinkSync(path.join(tmpDir, 'missing-asar-path'), linkPath, 'dir');
 
     const entries = fs.readdirSync(tmpDir);
     expect(entries).toContain('docx');
   });
 
-  it('statSync throws ENOENT on dangling symlinks', () => {
+  itIfDirectorySymlinkSupported('statSync throws ENOENT on dangling symlinks', () => {
     const linkPath = path.join(tmpDir, 'docx');
-    fs.symlinkSync('/nonexistent/asar/path', linkPath, 'dir');
+    fs.symlinkSync(path.join(tmpDir, 'missing-asar-path'), linkPath, 'dir');
 
     expect(() => {
       fs.statSync(linkPath);

--- a/tests/credentials-ipc-password-strip.test.ts
+++ b/tests/credentials-ipc-password-strip.test.ts
@@ -14,8 +14,8 @@ describe('credentials IPC password stripping', () => {
       )?.[0] ?? '';
 
     expect(saveBlock).toContain('const saved = credentialsStore.save(credential)');
-    expect(saveBlock).toContain('password: _pw');
-    expect(saveBlock).toContain('return safe');
+    expect(source).toContain('function omitCredentialPassword');
+    expect(saveBlock).toContain('return omitCredentialPassword(saved)');
     // Must NOT return the raw save result directly
     expect(saveBlock).not.toMatch(/return credentialsStore\.save\(/);
   });
@@ -29,8 +29,8 @@ describe('credentials IPC password stripping', () => {
       )?.[0] ?? '';
 
     expect(updateBlock).toContain('const updated = credentialsStore.update(id, updates)');
-    expect(updateBlock).toContain('password: _pw');
-    expect(updateBlock).toContain('return safe');
+    expect(source).toContain('function omitCredentialPassword');
+    expect(updateBlock).toContain('return omitCredentialPassword(updated)');
     // Must NOT return the raw update result directly
     expect(updateBlock).not.toMatch(/return credentialsStore\.update\(/);
   });

--- a/tests/logger-context.test.ts
+++ b/tests/logger-context.test.ts
@@ -60,7 +60,22 @@ async function getLogContent(logger: typeof import('../src/main/utils/logger')):
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
 
-  return fs.readFileSync(logFilePath!, 'utf8');
+  let lastContent = '';
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      const content = fs.readFileSync(logFilePath!, 'utf8');
+      if (content.length > 0 && content === lastContent) {
+        return content;
+      }
+      lastContent = content;
+    } catch {
+      // Retry until the file is readable and content stabilizes.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  return lastContent;
 }
 
 describe('logger context (AsyncLocalStorage)', () => {
@@ -122,12 +137,9 @@ describe('logger context (AsyncLocalStorage)', () => {
   it('runWithLogContext propagates sessionId and traceId to logCtx output', async () => {
     const logger = await import('../src/main/utils/logger');
 
-    logger.runWithLogContext(
-      { sessionId: 'test-session-1234', traceId: 'abc12345' },
-      () => {
-        logger.logCtx('[Test] context aware log');
-      }
-    );
+    logger.runWithLogContext({ sessionId: 'test-session-1234', traceId: 'abc12345' }, () => {
+      logger.logCtx('[Test] context aware log');
+    });
 
     const content = await getLogContent(logger);
     expect(content).toContain('[sid:test-ses]');
@@ -150,19 +162,13 @@ describe('logger context (AsyncLocalStorage)', () => {
   it('nested runWithLogContext overrides parent context', async () => {
     const logger = await import('../src/main/utils/logger');
 
-    logger.runWithLogContext(
-      { sessionId: 'outer-session-id00', traceId: 'outer000' },
-      () => {
-        logger.logCtx('[Test] outer log');
-        logger.runWithLogContext(
-          { sessionId: 'inner-session-id00', traceId: 'inner000' },
-          () => {
-            logger.logCtx('[Test] inner log');
-          }
-        );
-        logger.logCtx('[Test] outer again');
-      }
-    );
+    logger.runWithLogContext({ sessionId: 'outer-session-id00', traceId: 'outer000' }, () => {
+      logger.logCtx('[Test] outer log');
+      logger.runWithLogContext({ sessionId: 'inner-session-id00', traceId: 'inner000' }, () => {
+        logger.logCtx('[Test] inner log');
+      });
+      logger.logCtx('[Test] outer again');
+    });
 
     const content = await getLogContent(logger);
     const lines = content.split('\n');
@@ -183,13 +189,10 @@ describe('logger context (AsyncLocalStorage)', () => {
   it('logCtxWarn and logCtxError include context prefix in file', async () => {
     const logger = await import('../src/main/utils/logger');
 
-    logger.runWithLogContext(
-      { sessionId: 'warn-error-sess', traceId: 'we123456' },
-      () => {
-        logger.logCtxWarn('[Test] warning message');
-        logger.logCtxError('[Test] error message');
-      }
-    );
+    logger.runWithLogContext({ sessionId: 'warn-error-sess', traceId: 'we123456' }, () => {
+      logger.logCtxWarn('[Test] warning message');
+      logger.logCtxError('[Test] error message');
+    });
 
     const content = await getLogContent(logger);
     expect(content).toContain('[WARN]');
@@ -208,12 +211,9 @@ describe('logger context (AsyncLocalStorage)', () => {
 
     const startTime = Date.now() - 42;
 
-    logger.runWithLogContext(
-      { sessionId: 'timing-session0', traceId: 'tim12345' },
-      () => {
-        logger.logTiming('test-operation', startTime);
-      }
-    );
+    logger.runWithLogContext({ sessionId: 'timing-session0', traceId: 'tim12345' }, () => {
+      logger.logTiming('test-operation', startTime);
+    });
 
     const content = await getLogContent(logger);
     expect(content).toContain('[TIMING] test-operation:');
@@ -234,12 +234,9 @@ describe('logger context (AsyncLocalStorage)', () => {
   it('original log/logError still work inside and outside context', async () => {
     const logger = await import('../src/main/utils/logger');
 
-    logger.runWithLogContext(
-      { sessionId: 'compat-session0', traceId: 'compat00' },
-      () => {
-        logger.log('[Test] original log inside context');
-      }
-    );
+    logger.runWithLogContext({ sessionId: 'compat-session0', traceId: 'compat00' }, () => {
+      logger.log('[Test] original log inside context');
+    });
     logger.log('[Test] original log outside context');
 
     const content = await getLogContent(logger);

--- a/tests/path-resolver-containment.test.ts
+++ b/tests/path-resolver-containment.test.ts
@@ -1,4 +1,6 @@
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import type { MountedPath } from '../src/renderer/types';
 import { PathResolver } from '../src/main/sandbox/path-resolver';
 
 describe('PathResolver containment', () => {
@@ -6,7 +8,7 @@ describe('PathResolver containment', () => {
     const resolver = new PathResolver();
     resolver.registerSession('session-1', [
       { virtual: '/mnt/workspace', real: '/tmp/project' },
-    ] as any);
+    ] as MountedPath[]);
 
     expect(resolver.resolve('session-1', '/mnt/workspace-evil/secret.txt')).toBeNull();
   });
@@ -15,7 +17,7 @@ describe('PathResolver containment', () => {
     const resolver = new PathResolver();
     resolver.registerSession('session-1', [
       { virtual: '/mnt/workspace', real: '/tmp/project' },
-    ] as any);
+    ] as MountedPath[]);
 
     expect(resolver.virtualize('session-1', '/tmp/project-evil/secret.txt')).toBeNull();
   });
@@ -24,10 +26,10 @@ describe('PathResolver containment', () => {
     const resolver = new PathResolver();
     resolver.registerSession('session-1', [
       { virtual: '/mnt/workspace', real: '/tmp/project' },
-    ] as any);
+    ] as MountedPath[]);
 
     expect(resolver.resolve('session-1', '/mnt/workspace/notes..final.md')).toBe(
-      '/tmp/project/notes..final.md'
+      path.join('/tmp/project', 'notes..final.md')
     );
   });
 });

--- a/tests/plugin-runtime-service.test.ts
+++ b/tests/plugin-runtime-service.test.ts
@@ -2,8 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import type { PluginCatalogItemV2 } from '../src/renderer/types';
 
 let testRoot = '';
+
+type CatalogServiceStub = {
+  listAnthropicPlugins: () => Promise<PluginCatalogItemV2[]>;
+  downloadPlugin?: ReturnType<typeof vi.fn>;
+};
+
+type CommandRunnerStub = (
+  command: string,
+  args: string[]
+) => Promise<{ stdout: string; stderr: string }>;
 
 vi.mock('electron', () => {
   const electron = {
@@ -72,13 +83,19 @@ function createPluginFixture(root: string, pluginName: string): string {
   return pluginRoot;
 }
 
-async function createRuntimeService(options?: { catalogService?: any; commandRunner?: any }) {
+async function createRuntimeService(options?: {
+  catalogService?: CatalogServiceStub;
+  commandRunner?: CommandRunnerStub;
+}) {
   const { PluginRuntimeService } = await import('../src/main/skills/plugin-runtime-service');
-  const fakeCatalogService = options?.catalogService ?? ({
-    listAnthropicPlugins: vi.fn(),
+  const fakeCatalogService = options?.catalogService ?? {
+    listAnthropicPlugins: vi.fn(async () => [] as PluginCatalogItemV2[]),
     downloadPlugin: vi.fn(),
-  } as any);
-  return new PluginRuntimeService(fakeCatalogService, options?.commandRunner);
+  };
+  return new PluginRuntimeService(
+    fakeCatalogService as ConstructorParameters<typeof PluginRuntimeService>[0],
+    options?.commandRunner
+  );
 }
 
 describe('PluginRuntimeService', () => {
@@ -116,7 +133,7 @@ describe('PluginRuntimeService', () => {
         catalogSource: 'claude-marketplace',
       },
     ]);
-    const catalogService = { listAnthropicPlugins } as any;
+    const catalogService: CatalogServiceStub = { listAnthropicPlugins };
     const commandRunner = vi
       .fn()
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
@@ -135,11 +152,15 @@ describe('PluginRuntimeService', () => {
     const service = await createRuntimeService({ catalogService, commandRunner });
     const result = await service.install('context7');
 
-    expect(commandRunner).toHaveBeenNthCalledWith(1, 'claude', ['plugin', 'install', 'context7@claude-plugins-official']);
+    expect(commandRunner).toHaveBeenNthCalledWith(1, 'claude', [
+      'plugin',
+      'install',
+      'context7@claude-plugins-official',
+    ]);
     expect(commandRunner).toHaveBeenNthCalledWith(2, 'claude', ['plugin', 'list', '--json']);
     expect(result.plugin.name).toBe('context7');
     expect(fs.existsSync(result.plugin.runtimePath)).toBe(true);
-  });
+  }, 15000);
 
   it('installs plugin when claude plugin list --json returns an array payload', async () => {
     const fixturesRoot = path.join(testRoot, 'fixtures');
@@ -161,7 +182,7 @@ describe('PluginRuntimeService', () => {
         catalogSource: 'claude-marketplace',
       },
     ]);
-    const catalogService = { listAnthropicPlugins } as any;
+    const catalogService: CatalogServiceStub = { listAnthropicPlugins };
     const commandRunner = vi
       .fn()
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
@@ -217,7 +238,7 @@ describe('PluginRuntimeService', () => {
         catalogSource: 'claude-marketplace',
       },
     ]);
-    const catalogService = { listAnthropicPlugins } as any;
+    const catalogService: CatalogServiceStub = { listAnthropicPlugins };
     const commandRunner = vi
       .fn()
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
@@ -236,11 +257,11 @@ describe('PluginRuntimeService', () => {
     const service = await createRuntimeService({ catalogService, commandRunner });
     const result = await service.install('agent-sdk-dev@claude-plugins-official');
 
-    expect(commandRunner).toHaveBeenNthCalledWith(
-      1,
-      'claude',
-      ['plugin', 'install', 'agent-sdk-dev@claude-plugins-official']
-    );
+    expect(commandRunner).toHaveBeenNthCalledWith(1, 'claude', [
+      'plugin',
+      'install',
+      'agent-sdk-dev@claude-plugins-official',
+    ]);
     expect(result.plugin.name).toBe('agent-sdk-dev');
   });
 
@@ -277,11 +298,13 @@ describe('PluginRuntimeService', () => {
         catalogSource: 'claude-marketplace',
       },
     ]);
-    const catalogService = { listAnthropicPlugins } as any;
+    const catalogService: CatalogServiceStub = { listAnthropicPlugins };
     const commandRunner = vi.fn();
 
     const service = await createRuntimeService({ catalogService, commandRunner });
-    await expect(service.install('Agent SDK Dev')).rejects.toThrow('Multiple plugins share this name');
+    await expect(service.install('Agent SDK Dev')).rejects.toThrow(
+      'Multiple plugins share this name'
+    );
     expect(commandRunner).not.toHaveBeenCalled();
   });
 
@@ -303,7 +326,7 @@ describe('PluginRuntimeService', () => {
         catalogSource: 'claude-marketplace',
       },
     ]);
-    const catalogService = { listAnthropicPlugins } as any;
+    const catalogService: CatalogServiceStub = { listAnthropicPlugins };
     const commandRunner = vi
       .fn()
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
@@ -332,7 +355,7 @@ describe('PluginRuntimeService', () => {
         catalogSource: 'claude-marketplace',
       },
     ]);
-    const catalogService = { listAnthropicPlugins } as any;
+    const catalogService: CatalogServiceStub = { listAnthropicPlugins };
     const commandRunner = vi.fn(async () => {
       const error = new Error('spawn claude ENOENT') as Error & { code?: string };
       error.code = 'ENOENT';
@@ -375,7 +398,9 @@ describe('PluginRuntimeService', () => {
     await service.setComponentEnabled(installResult.plugin.pluginId, 'hooks', true);
     await service.setComponentEnabled(installResult.plugin.pluginId, 'mcp', true);
 
-    const installed = service.listInstalled().find((plugin) => plugin.pluginId === installResult.plugin.pluginId);
+    const installed = service
+      .listInstalled()
+      .find((plugin) => plugin.pluginId === installResult.plugin.pluginId);
     expect(installed).toBeDefined();
     expect(installed?.componentsEnabled.hooks).toBe(true);
     expect(installed?.componentsEnabled.mcp).toBe(true);

--- a/tests/store-encryption.test.ts
+++ b/tests/store-encryption.test.ts
@@ -16,13 +16,17 @@ function registerStoreMocks(userDataPath: string): void {
   }));
 
   vi.doMock('electron-store', () => {
-    class MockStore<T extends Record<string, unknown>> {
+    class MockStore {
       public path: string;
       private internalStore: Record<string, unknown>;
       private readonly encryptionKey?: string;
       private readonly defaults: Record<string, unknown>;
 
-      constructor(options: { name?: string; defaults?: Record<string, unknown>; encryptionKey?: string }) {
+      constructor(options: {
+        name?: string;
+        defaults?: Record<string, unknown>;
+        encryptionKey?: string;
+      }) {
         const name = options.name || 'config';
         this.path = path.join(userDataPath, `${name}.json`);
         this.defaults = { ...(options.defaults || {}) };
@@ -82,8 +86,8 @@ describe('createEncryptedStoreWithKeyRotation', () => {
   afterEach(() => {
     fs.rmSync(tempDir, { recursive: true, force: true });
     vi.resetModules();
-    vi.unmock('electron');
-    vi.unmock('electron-store');
+    vi.doUnmock('electron');
+    vi.doUnmock('electron-store');
   });
 
   it('backs up unreadable encrypted stores and recreates defaults', async () => {
@@ -101,7 +105,8 @@ describe('createEncryptedStoreWithKeyRotation', () => {
       })
     );
 
-    const { createEncryptedStoreWithKeyRotation } = await import('../src/main/utils/store-encryption');
+    const { createEncryptedStoreWithKeyRotation } =
+      await import('../src/main/utils/store-encryption');
     const store = createEncryptedStoreWithKeyRotation<Record<string, unknown>>({
       stableKey: 'stable-key',
       legacyKeys: ['legacy-key-1', 'legacy-key-2'],
@@ -120,7 +125,9 @@ describe('createEncryptedStoreWithKeyRotation', () => {
       apiKey: '',
     });
 
-    const backups = fs.readdirSync(tempDir).filter((file) => file.startsWith('config.json.unreadable-recovery-'));
+    const backups = fs
+      .readdirSync(tempDir)
+      .filter((file) => file.startsWith('config.json.unreadable-recovery-'));
     expect(backups).toHaveLength(1);
     expect(fs.existsSync(path.join(tempDir, backups[0]))).toBe(true);
     expect(fs.existsSync(storePath)).toBe(false);


### PR DESCRIPTION
## Summary\n- clean the remaining lint warnings in main, renderer, and sandbox modules\n- make credential, path resolver, logger, and plugin runtime tests less brittle across platforms and slower CI runs\n- skip directory symlink-specific assertions when the local Windows environment cannot create symlinks\n\n## Verification\n- npm run lint\n- npm run typecheck\n- npm run test:coverage