### PR TITLE
feat: add official Codex ChatGPT support

### DIFF
--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -28,7 +28,15 @@ import { PathResolver } from '../sandbox/path-resolver';
 import { MCPManager } from '../mcp/mcp-manager';
 import { mcpConfigStore } from '../mcp/mcp-config-store';
 import { credentialsStore, type UserCredential } from '../credentials/credentials-store';
-import { log, logWarn, logError, logCtx, logCtxWarn, logCtxError, logTiming } from '../utils/logger';
+import {
+  log,
+  logWarn,
+  logError,
+  logCtx,
+  logCtxWarn,
+  logCtxError,
+  logTiming,
+} from '../utils/logger';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -65,7 +73,8 @@ const VIRTUAL_WORKSPACE_PATH = '/workspace';
 function estimateCharsPerToken(sampleText: string): number {
   if (!sampleText || sampleText.length === 0) return 4;
   const sample = sampleText.substring(0, 500);
-  const cjkCount = (sample.match(/[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/g) || []).length;
+  const cjkCount = (sample.match(/[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/g) || [])
+    .length;
   const cjkRatio = cjkCount / sample.length;
   return 4 - cjkRatio * 2.5; // Range: 1.5 (pure CJK) ~ 4 (pure English)
 }
@@ -89,9 +98,8 @@ function getBundledNodePaths(): { node: string; npx: string } | null {
   const binDir = platform === 'win32' ? resourcesPath : path.join(resourcesPath, 'bin');
   const nodePath = path.join(binDir, platform === 'win32' ? 'node.exe' : 'node');
   const npxPath = path.join(binDir, platform === 'win32' ? 'npx.cmd' : 'npx');
-  cachedBundledNodePaths = (fs.existsSync(nodePath) && fs.existsSync(npxPath))
-    ? { node: nodePath, npx: npxPath }
-    : null;
+  cachedBundledNodePaths =
+    fs.existsSync(nodePath) && fs.existsSync(npxPath) ? { node: nodePath, npx: npxPath } : null;
   return cachedBundledNodePaths;
 }
 
@@ -180,11 +188,13 @@ async function enrichProcessPathForBuild(): Promise<void> {
   if (platform === 'darwin' || platform === 'linux') {
     try {
       const shell = getDefaultShell();
-      const output = (execFileSync(shell, ['-l', '-c', 'echo $PATH'], {
-        encoding: 'utf-8',
-        timeout: 5000,
-        env: { HOME: os.homedir() },
-      }) as string).trim();
+      const output = (
+        execFileSync(shell, ['-l', '-c', 'echo $PATH'], {
+          encoding: 'utf-8',
+          timeout: 5000,
+          env: { HOME: os.homedir() },
+        }) as string
+      ).trim();
       if (output) {
         shellPaths = output.split(':').filter((p: string) => p.trim());
         log(`[ClaudeAgentRunner] Restored ${shellPaths.length} paths from login shell`);
@@ -195,10 +205,17 @@ async function enrichProcessPathForBuild(): Promise<void> {
     }
   } else if (platform === 'win32') {
     try {
-      const output = (execFileSync('powershell.exe', [
-        '-NoProfile', '-Command',
-        "[Environment]::GetEnvironmentVariable('Path', 'User') + ';' + [Environment]::GetEnvironmentVariable('Path', 'Machine')",
-      ], { encoding: 'utf-8', timeout: 5000 }) as string).trim();
+      const output = (
+        execFileSync(
+          'powershell.exe',
+          [
+            '-NoProfile',
+            '-Command',
+            "[Environment]::GetEnvironmentVariable('Path', 'User') + ';' + [Environment]::GetEnvironmentVariable('Path', 'Machine')",
+          ],
+          { encoding: 'utf-8', timeout: 5000 }
+        ) as string
+      ).trim();
       if (output) {
         shellPaths = output.split(';').filter((p: string) => p.trim());
         log(`[ClaudeAgentRunner] Restored ${shellPaths.length} paths from Windows registry`);
@@ -240,7 +257,9 @@ async function enrichProcessPathForBuild(): Promise<void> {
   }
 
   process.env.PATH = merged.join(delimiter);
-  log(`[ClaudeAgentRunner] Enriched process.env.PATH for build mode: ${bundledDirs.length} bundled + ${shellPaths.length} shell + ${currentPaths.length} process → ${merged.length} total`);
+  log(
+    `[ClaudeAgentRunner] Enriched process.env.PATH for build mode: ${bundledDirs.length} bundled + ${shellPaths.length} shell + ${currentPaths.length} process → ${merged.length} total`
+  );
 }
 
 // Shared pi-ai auth storage — created once, reused across sessions.
@@ -253,7 +272,9 @@ function buildMcpCustomTools(mcpManager: MCPManager): ToolDefinition[] {
   const mcpTools = mcpManager.getTools();
   return mcpTools.map((mcpTool) => {
     // Wrap the raw JSON Schema inputSchema as a TypeBox TSchema
-    const parameters = Type.Unsafe<Record<string, unknown>>(mcpTool.inputSchema as Record<string, unknown>);
+    const parameters = Type.Unsafe<Record<string, unknown>>(
+      mcpTool.inputSchema as Record<string, unknown>
+    );
 
     const toolDef: ToolDefinition<TSchema, unknown> = {
       name: mcpTool.name,
@@ -352,9 +373,7 @@ function toErrorText(error: unknown): string {
   return serialized;
 }
 
-function normalizeTokenUsage(
-  usage: unknown
-): Message['tokenUsage'] | undefined {
+function normalizeTokenUsage(usage: unknown): Message['tokenUsage'] | undefined {
   if (!usage || typeof usage !== 'object') {
     return undefined;
   }
@@ -381,7 +400,12 @@ function normalizeTokenUsage(
 interface AgentRunnerOptions {
   sendToRenderer: (event: ServerEvent) => void;
   saveMessage?: (message: Message) => void;
-  requestSudoPassword?: (sessionId: string, toolUseId: string, command: string) => Promise<string | null>;
+  updateSession?: (sessionId: string, updates: Partial<Session>) => void;
+  requestSudoPassword?: (
+    sessionId: string,
+    toolUseId: string,
+    command: string
+  ) => Promise<string | null>;
 }
 
 interface CachedPiSession {
@@ -394,7 +418,7 @@ interface CachedPiSession {
 
 /**
  * ClaudeAgentRunner - Uses @mariozechner/pi-coding-agent SDK
- * 
+ *
  * Environment variables should be set before running:
  *   ANTHROPIC_BASE_URL=https://openrouter.ai/api
  *   ANTHROPIC_AUTH_TOKEN=your_openrouter_api_key
@@ -403,7 +427,11 @@ interface CachedPiSession {
 export class ClaudeAgentRunner {
   private sendToRenderer: (event: ServerEvent) => void;
   private saveMessage?: (message: Message) => void;
-  private requestSudoPassword?: (sessionId: string, toolUseId: string, command: string) => Promise<string | null>;
+  private requestSudoPassword?: (
+    sessionId: string,
+    toolUseId: string,
+    command: string
+  ) => Promise<string | null>;
   private pathResolver: PathResolver;
   private mcpManager?: MCPManager;
   // @ts-expect-error stored for future plugin support
@@ -423,7 +451,11 @@ export class ClaudeAgentRunner {
   clearSdkSession(sessionId: string): void {
     const cached = this.piSessions.get(sessionId);
     if (cached) {
-      try { cached.session.dispose(); } catch (e) { logWarn('[ClaudeAgentRunner] dispose error:', e); }
+      try {
+        cached.session.dispose();
+      } catch (e) {
+        logWarn('[ClaudeAgentRunner] dispose error:', e);
+      }
       this.piSessions.delete(sessionId);
       log('[ClaudeAgentRunner] Disposed pi session for:', sessionId);
     }
@@ -453,10 +485,10 @@ export class ClaudeAgentRunner {
       }
 
       // Group credentials by type
-      const emailCredentials = credentials.filter(c => c.type === 'email');
-      const websiteCredentials = credentials.filter(c => c.type === 'website');
-      const apiCredentials = credentials.filter(c => c.type === 'api');
-      const otherCredentials = credentials.filter(c => c.type === 'other');
+      const emailCredentials = credentials.filter((c) => c.type === 'email');
+      const websiteCredentials = credentials.filter((c) => c.type === 'website');
+      const apiCredentials = credentials.filter((c) => c.type === 'api');
+      const otherCredentials = credentials.filter((c) => c.type === 'other');
 
       // Format credentials with masked password for system prompt.
       // Credentials should be passed through a secure channel (e.g., MCP tool
@@ -471,18 +503,26 @@ export class ClaudeAgentRunner {
       };
 
       const sections: string[] = [];
-      
+
       if (emailCredentials.length > 0) {
-        sections.push(`**Email Accounts (${emailCredentials.length}):**\n${emailCredentials.map(formatCredential).join('\n\n')}`);
+        sections.push(
+          `**Email Accounts (${emailCredentials.length}):**\n${emailCredentials.map(formatCredential).join('\n\n')}`
+        );
       }
       if (websiteCredentials.length > 0) {
-        sections.push(`**Website Accounts (${websiteCredentials.length}):**\n${websiteCredentials.map(formatCredential).join('\n\n')}`);
+        sections.push(
+          `**Website Accounts (${websiteCredentials.length}):**\n${websiteCredentials.map(formatCredential).join('\n\n')}`
+        );
       }
       if (apiCredentials.length > 0) {
-        sections.push(`**API Keys (${apiCredentials.length}):**\n${apiCredentials.map(formatCredential).join('\n\n')}`);
+        sections.push(
+          `**API Keys (${apiCredentials.length}):**\n${apiCredentials.map(formatCredential).join('\n\n')}`
+        );
       }
       if (otherCredentials.length > 0) {
-        sections.push(`**Other Credentials (${otherCredentials.length}):**\n${otherCredentials.map(formatCredential).join('\n\n')}`);
+        sections.push(
+          `**Other Credentials (${otherCredentials.length}):**\n${otherCredentials.map(formatCredential).join('\n\n')}`
+        );
       }
 
       return `
@@ -557,10 +597,10 @@ ${hints.join('\n')}
     // In development, skills are in the project's .claude/skills directory
     // In production, they're bundled with the app (in app.asar.unpacked for asarUnpack files)
     const appPath = app.getAppPath();
-    
+
     // For asarUnpack files, replace .asar with .asar.unpacked
     const unpackedPath = appPath.replace(/\.asar$/, '.asar.unpacked');
-    
+
     const possiblePaths = [
       // Development: relative to this file
       path.join(__dirname, '..', '..', '..', '.claude', 'skills'),
@@ -571,14 +611,14 @@ ${hints.join('\n')}
       // Alternative: in resources folder
       path.join(process.resourcesPath || '', 'skills'),
     ];
-    
+
     for (const p of possiblePaths) {
       if (fs.existsSync(p)) {
         log('[ClaudeAgentRunner] Found built-in skills at:', p);
         return p;
       }
     }
-    
+
     logWarn('[ClaudeAgentRunner] No built-in skills directory found');
     return '';
   }
@@ -605,9 +645,16 @@ ${hints.join('\n')}
       if (fs.statSync(resolvedPath).isDirectory()) {
         return resolvedPath;
       }
-      logWarn('[ClaudeAgentRunner] Configured skills path is not a directory, fallback to runtime path:', resolvedPath);
+      logWarn(
+        '[ClaudeAgentRunner] Configured skills path is not a directory, fallback to runtime path:',
+        resolvedPath
+      );
     } catch (error) {
-      logWarn('[ClaudeAgentRunner] Configured skills path is unavailable, fallback to runtime path:', resolvedPath, error);
+      logWarn(
+        '[ClaudeAgentRunner] Configured skills path is unavailable, fallback to runtime path:',
+        resolvedPath,
+        error
+      );
     }
 
     return this.getRuntimeSkillsDir();
@@ -715,14 +762,14 @@ ${hints.join('\n')}
     this.mcpManager = mcpManager;
     this._pluginRuntimeService = pluginRuntimeService;
     this._skillsAdapter = skillsAdapter;
-    
+
     log('[ClaudeAgentRunner] Initialized with pi-coding-agent SDK');
     log('[ClaudeAgentRunner] Skills enabled: settingSources=[user, project], Skill tool enabled');
     if (mcpManager) {
       log('[ClaudeAgentRunner] MCP support enabled');
     }
   }
-  
+
   /**
    * Check if a command contains sudo
    */
@@ -763,7 +810,9 @@ ${hints.join('\n')}
             if (!password) {
               log('[ClaudeAgentRunner] Sudo password cancelled by user');
               return {
-                content: [{ type: 'text' as const, text: 'Command cancelled: user denied sudo password.' }],
+                content: [
+                  { type: 'text' as const, text: 'Command cancelled: user denied sudo password.' },
+                ],
                 details: undefined as unknown,
               };
             }
@@ -824,9 +873,8 @@ ${hints.join('\n')}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           ctx: any
         ) => {
-          const effectiveParams = params.timeout != null
-            ? params
-            : { ...params, timeout: DEFAULT_BASH_TIMEOUT_SECONDS };
+          const effectiveParams =
+            params.timeout != null ? params : { ...params, timeout: DEFAULT_BASH_TIMEOUT_SECONDS };
           return originalExecute(toolCallId, effectiveParams, signal, onUpdate, ctx);
         },
       } as ToolDefinition;
@@ -839,11 +887,12 @@ ${hints.join('\n')}
   private getCurrentModelString(preferredModel?: string): string {
     const routeModel = preferredModel?.trim();
     const configuredModel = configStore.get('model')?.trim();
-    const model = routeModel
-      || configuredModel
-      || 'anthropic/claude-sonnet-4';
+    const model = routeModel || configuredModel || 'anthropic/claude-sonnet-4';
     logCtx('[ClaudeAgentRunner] Current model:', model);
-    logCtx('[ClaudeAgentRunner] Model source:', routeModel ? 'runtimeRoute.model' : configuredModel ? 'configStore.model' : 'default');
+    logCtx(
+      '[ClaudeAgentRunner] Model source:',
+      routeModel ? 'runtimeRoute.model' : configuredModel ? 'configStore.model' : 'default'
+    );
     return model;
   }
 
@@ -863,12 +912,15 @@ ${hints.join('\n')}
     // Sandbox isolation state (defined outside try for finally access)
     let sandboxPath: string | null = null;
     let useSandboxIsolation = false;
-    
+
     // Helper to convert real sandbox paths back to virtual workspace paths in output
     const sanitizeOutputPaths = (content: string): string => {
       if (!sandboxPath || !useSandboxIsolation) return content;
       // Replace real sandbox path with virtual workspace path
-      return content.replace(new RegExp(sandboxPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), VIRTUAL_WORKSPACE_PATH);
+      return content.replace(
+        new RegExp(sandboxPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
+        VIRTUAL_WORKSPACE_PATH
+      );
     };
 
     const thinkingStepId = uuidv4();
@@ -900,10 +952,10 @@ ${hints.join('\n')}
 
       if (sandbox.isWSL && sandbox.wslStatus?.distro && workingDir) {
         log('[ClaudeAgentRunner] WSL mode active, initializing sandbox sync...');
-        
+
         // Only show sync UI for new sessions (first message)
         const isNewSession = !SandboxSync.hasSession(session.id);
-        
+
         if (isNewSession) {
           // Notify UI: syncing files (only for new sessions)
           this.sendToRenderer({
@@ -916,7 +968,7 @@ ${hints.join('\n')}
             },
           });
         }
-        
+
         const syncResult = await SandboxSync.initSync(
           workingDir,
           session.id,
@@ -927,21 +979,23 @@ ${hints.join('\n')}
           sandboxPath = syncResult.sandboxPath;
           useSandboxIsolation = true;
           log(`[ClaudeAgentRunner] Sandbox initialized: ${sandboxPath}`);
-          log(`[ClaudeAgentRunner]   Files: ${syncResult.fileCount}, Size: ${syncResult.totalSize} bytes`);
-          
+          log(
+            `[ClaudeAgentRunner]   Files: ${syncResult.fileCount}, Size: ${syncResult.totalSize} bytes`
+          );
+
           if (isNewSession) {
             // Update UI with file count (only for new sessions)
             this.sendToRenderer({
-            type: 'sandbox.sync',
-            payload: {
-              sessionId: session.id,
-              phase: 'syncing_skills',
-              message: 'Configuring skills...',
-              detail: 'Copying built-in skills to sandbox',
-              fileCount: syncResult.fileCount,
-              totalSize: syncResult.totalSize,
-            },
-          });
+              type: 'sandbox.sync',
+              payload: {
+                sessionId: session.id,
+                phase: 'syncing_skills',
+                message: 'Configuring skills...',
+                detail: 'Copying built-in skills to sandbox',
+                fileCount: syncResult.fileCount,
+                totalSize: syncResult.totalSize,
+              },
+            });
           }
 
           // Copy skills to sandbox ~/.claude/skills/
@@ -953,7 +1007,7 @@ ${hints.join('\n')}
             // Create .claude/skills directory in sandbox
             execFileSync('wsl', ['-d', distro, '-e', 'mkdir', '-p', sandboxSkillsPath], {
               encoding: 'utf-8',
-              timeout: 10000
+              timeout: 10000,
             });
 
             if (builtinSkillsPath && fs.existsSync(builtinSkillsPath)) {
@@ -964,7 +1018,7 @@ ${hints.join('\n')}
 
               execFileSync('wsl', ['-d', distro, '-e', 'bash', '-c', rsyncCmd], {
                 encoding: 'utf-8',
-                timeout: 120000  // 2 min timeout for large skill directories
+                timeout: 120000, // 2 min timeout for large skill directories
               });
             }
 
@@ -982,15 +1036,22 @@ ${hints.join('\n')}
 
               execFileSync('wsl', ['-d', distro, '-e', 'bash', '-c', rsyncCmd], {
                 encoding: 'utf-8',
-                timeout: 120000  // 2 min timeout for large skill directories
+                timeout: 120000, // 2 min timeout for large skill directories
               });
             }
 
             // List copied skills for verification
-            const copiedSkills = execFileSync('wsl', ['-d', distro, '-e', 'ls', sandboxSkillsPath], {
-              encoding: 'utf-8',
-              timeout: 10000
-            }).trim().split(/\r?\n/).filter(Boolean);
+            const copiedSkills = execFileSync(
+              'wsl',
+              ['-d', distro, '-e', 'ls', sandboxSkillsPath],
+              {
+                encoding: 'utf-8',
+                timeout: 10000,
+              }
+            )
+              .trim()
+              .split(/\r?\n/)
+              .filter(Boolean);
 
             log(`[ClaudeAgentRunner] Skills copied to sandbox: ${sandboxSkillsPath}`);
             log(`[ClaudeAgentRunner]   Skills: ${copiedSkills.join(', ')}`);
@@ -1001,32 +1062,32 @@ ${hints.join('\n')}
           if (isNewSession) {
             // Notify UI: sync complete (only for new sessions)
             this.sendToRenderer({
-            type: 'sandbox.sync',
-            payload: {
-              sessionId: session.id,
-              phase: 'ready',
-              message: 'Sandbox ready',
-              detail: `Synced ${syncResult.fileCount} files`,
-              fileCount: syncResult.fileCount,
-              totalSize: syncResult.totalSize,
-            },
-          });
+              type: 'sandbox.sync',
+              payload: {
+                sessionId: session.id,
+                phase: 'ready',
+                message: 'Sandbox ready',
+                detail: `Synced ${syncResult.fileCount} files`,
+                fileCount: syncResult.fileCount,
+                totalSize: syncResult.totalSize,
+              },
+            });
           }
         } else {
           logError('[ClaudeAgentRunner] Sandbox sync failed:', syncResult.error);
           log('[ClaudeAgentRunner] Falling back to /mnt/ access (less secure)');
-          
+
           if (isNewSession) {
             // Notify UI: error (only for new sessions)
             this.sendToRenderer({
-            type: 'sandbox.sync',
-            payload: {
-              sessionId: session.id,
-              phase: 'error',
-              message: 'Sandbox file sync failed, falling back to direct access mode',
-              detail: 'Falling back to direct access mode (less secure)',
-            },
-          });
+              type: 'sandbox.sync',
+              payload: {
+                sessionId: session.id,
+                phase: 'error',
+                message: 'Sandbox file sync failed, falling back to direct access mode',
+                detail: 'Falling back to direct access mode (less secure)',
+              },
+            });
           }
         }
       }
@@ -1034,12 +1095,12 @@ ${hints.join('\n')}
       // Initialize sandbox sync if Lima mode is active
       if (sandbox.isLima && sandbox.limaStatus?.instanceRunning && workingDir) {
         log('[ClaudeAgentRunner] Lima mode active, initializing sandbox sync...');
-        
+
         const { LimaSync } = await import('../sandbox/lima-sync');
-        
+
         // Only show sync UI for new sessions (first message)
         const isNewLimaSession = !LimaSync.hasSession(session.id);
-        
+
         if (isNewLimaSession) {
           // Notify UI: syncing files (only for new sessions)
           this.sendToRenderer({
@@ -1052,31 +1113,30 @@ ${hints.join('\n')}
             },
           });
         }
-        
-        const syncResult = await LimaSync.initSync(
-          workingDir,
-          session.id
-        );
+
+        const syncResult = await LimaSync.initSync(workingDir, session.id);
 
         if (syncResult.success) {
           sandboxPath = syncResult.sandboxPath;
           useSandboxIsolation = true;
           log(`[ClaudeAgentRunner] Sandbox initialized: ${sandboxPath}`);
-          log(`[ClaudeAgentRunner]   Files: ${syncResult.fileCount}, Size: ${syncResult.totalSize} bytes`);
-          
+          log(
+            `[ClaudeAgentRunner]   Files: ${syncResult.fileCount}, Size: ${syncResult.totalSize} bytes`
+          );
+
           if (isNewLimaSession) {
             // Update UI with file count (only for new sessions)
             this.sendToRenderer({
-            type: 'sandbox.sync',
-            payload: {
-              sessionId: session.id,
-              phase: 'syncing_skills',
-              message: 'Configuring skills...',
-              detail: 'Copying built-in skills to sandbox',
-              fileCount: syncResult.fileCount,
-              totalSize: syncResult.totalSize,
-            },
-          });
+              type: 'sandbox.sync',
+              payload: {
+                sessionId: session.id,
+                phase: 'syncing_skills',
+                message: 'Configuring skills...',
+                detail: 'Copying built-in skills to sandbox',
+                fileCount: syncResult.fileCount,
+                totalSize: syncResult.totalSize,
+              },
+            });
           }
 
           // Copy skills to sandbox ~/.claude/skills/
@@ -1085,10 +1145,14 @@ ${hints.join('\n')}
             const sandboxSkillsPath = `${sandboxPath}/.claude/skills`;
 
             // Create .claude/skills directory in sandbox
-            execFileSync('limactl', ['shell', 'claude-sandbox', '--', 'mkdir', '-p', sandboxSkillsPath], {
-              encoding: 'utf-8',
-              timeout: 10000
-            });
+            execFileSync(
+              'limactl',
+              ['shell', 'claude-sandbox', '--', 'mkdir', '-p', sandboxSkillsPath],
+              {
+                encoding: 'utf-8',
+                timeout: 10000,
+              }
+            );
 
             if (builtinSkillsPath && fs.existsSync(builtinSkillsPath)) {
               // Use rsync to recursively copy all skills (much faster and handles subdirectories)
@@ -1098,7 +1162,7 @@ ${hints.join('\n')}
 
               execFileSync('limactl', ['shell', 'claude-sandbox', '--', 'bash', '-c', rsyncCmd], {
                 encoding: 'utf-8',
-                timeout: 120000  // 2 min timeout for large skill directories
+                timeout: 120000, // 2 min timeout for large skill directories
               });
             }
 
@@ -1115,15 +1179,22 @@ ${hints.join('\n')}
 
               execFileSync('limactl', ['shell', 'claude-sandbox', '--', 'bash', '-c', rsyncCmd], {
                 encoding: 'utf-8',
-                timeout: 120000  // 2 min timeout for large skill directories
+                timeout: 120000, // 2 min timeout for large skill directories
               });
             }
 
             // List copied skills for verification
-            const copiedSkills = execFileSync('limactl', ['shell', 'claude-sandbox', '--', 'ls', sandboxSkillsPath], {
-              encoding: 'utf-8',
-              timeout: 10000
-            }).trim().split(/\r?\n/).filter(Boolean);
+            const copiedSkills = execFileSync(
+              'limactl',
+              ['shell', 'claude-sandbox', '--', 'ls', sandboxSkillsPath],
+              {
+                encoding: 'utf-8',
+                timeout: 10000,
+              }
+            )
+              .trim()
+              .split(/\r?\n/)
+              .filter(Boolean);
 
             log(`[ClaudeAgentRunner] Skills copied to sandbox: ${sandboxSkillsPath}`);
             log(`[ClaudeAgentRunner]   Skills: ${copiedSkills.join(', ')}`);
@@ -1134,44 +1205,44 @@ ${hints.join('\n')}
           if (isNewLimaSession) {
             // Notify UI: sync complete (only for new sessions)
             this.sendToRenderer({
-            type: 'sandbox.sync',
-            payload: {
-              sessionId: session.id,
-              phase: 'ready',
-              message: 'Sandbox ready',
-              detail: `Synced ${syncResult.fileCount} files`,
-              fileCount: syncResult.fileCount,
-              totalSize: syncResult.totalSize,
-            },
-          });
+              type: 'sandbox.sync',
+              payload: {
+                sessionId: session.id,
+                phase: 'ready',
+                message: 'Sandbox ready',
+                detail: `Synced ${syncResult.fileCount} files`,
+                fileCount: syncResult.fileCount,
+                totalSize: syncResult.totalSize,
+              },
+            });
           }
         } else {
           logError('[ClaudeAgentRunner] Sandbox sync failed:', syncResult.error);
           log('[ClaudeAgentRunner] Falling back to direct access (less secure)');
-          
+
           if (isNewLimaSession) {
             // Notify UI: error (only for new sessions)
             this.sendToRenderer({
-            type: 'sandbox.sync',
-            payload: {
-              sessionId: session.id,
-              phase: 'error',
-              message: 'Sandbox file sync failed, falling back to direct access mode',
-              detail: 'Falling back to direct access mode (less secure)',
-            },
-          });
+              type: 'sandbox.sync',
+              payload: {
+                sessionId: session.id,
+                phase: 'error',
+                message: 'Sandbox file sync failed, falling back to direct access mode',
+                detail: 'Falling back to direct access mode (less secure)',
+              },
+            });
           }
         }
       }
 
       // Check if current user message includes images
-      const lastUserMessage = existingMessages.length > 0
-        ? existingMessages[existingMessages.length - 1]
-        : null;
+      const lastUserMessage =
+        existingMessages.length > 0 ? existingMessages[existingMessages.length - 1] : null;
 
       logCtx('[ClaudeAgentRunner] Total messages:', existingMessages.length);
 
-      const hasImages = lastUserMessage?.content.some((c) => (c as { type?: string }).type === 'image') || false;
+      const hasImages =
+        lastUserMessage?.content.some((c) => (c as { type?: string }).type === 'image') || false;
       if (hasImages) {
         log('[ClaudeAgentRunner] User message contains images');
       }
@@ -1183,7 +1254,7 @@ ${hints.join('\n')}
       const modelString = this.getCurrentModelString(runtimeConfig.model);
       const configProtocol = resolvePiRouteProtocol(
         runtimeConfig.provider,
-        runtimeConfig.customProtocol,
+        runtimeConfig.customProtocol
       );
       let usedSyntheticModel = false;
       let piModel = resolvePiRegistryModel(modelString, {
@@ -1211,7 +1282,7 @@ ${hints.join('\n')}
           undefined,
           undefined,
           runtimeConfig.contextWindow,
-          runtimeConfig.maxTokens,
+          runtimeConfig.maxTokens
         );
         // Apply the same runtime overrides (developer role compat, base URL, API downgrade)
         // that resolvePiRegistryModel applies to registry models
@@ -1221,7 +1292,12 @@ ${hints.join('\n')}
           rawProvider: runtimeConfig.provider,
           customProtocol: runtimeConfig.customProtocol,
         });
-        logCtxWarn('[ClaudeAgentRunner] Model not in pi-ai registry, using synthetic model:', modelString, '→', piModel.api);
+        logCtxWarn(
+          '[ClaudeAgentRunner] Model not in pi-ai registry, using synthetic model:',
+          modelString,
+          '→',
+          piModel.api
+        );
       }
       logCtx('[ClaudeAgentRunner] Resolved pi-ai model:', piModel.provider, piModel.id);
 
@@ -1241,7 +1317,7 @@ ${hints.join('\n')}
             ollamaInfo.contextWindow,
             '(was:',
             piModel.contextWindow,
-            ')',
+            ')'
           );
           piModel = { ...piModel, contextWindow: ollamaInfo.contextWindow };
         }
@@ -1261,9 +1337,8 @@ ${hints.join('\n')}
       const apiKey = runtimeConfig.apiKey?.trim();
       if (apiKey) {
         // Map our config provider to pi-ai provider name
-        const piProvider = provider === 'custom'
-          ? (runtimeConfig.customProtocol || 'anthropic')
-          : provider;
+        const piProvider =
+          provider === 'custom' ? runtimeConfig.customProtocol || 'anthropic' : provider;
         authStorage.setRuntimeApiKey(piProvider, apiKey);
         // Also set the key for the model's native provider (e.g., when using
         // google/gemini via openrouter, pi-ai looks up "google" not "openrouter")
@@ -1274,12 +1349,15 @@ ${hints.join('\n')}
         log('[ClaudeAgentRunner] Set runtime API key for config provider:', piProvider);
       } else {
         if (provider === 'ollama') {
-          log('[ClaudeAgentRunner] Ollama configured without explicit API key; relying on OpenAI-compatible placeholder/env auth path', safeStringify({
-            provider,
-            modelProvider: piModel.provider,
-            modelId: piModel.id,
-            baseUrl: piModel.baseUrl || runtimeConfig.baseUrl || '',
-          }));
+          log(
+            '[ClaudeAgentRunner] Ollama configured without explicit API key; relying on OpenAI-compatible placeholder/env auth path',
+            safeStringify({
+              provider,
+              modelProvider: piModel.provider,
+              modelId: piModel.id,
+              baseUrl: piModel.baseUrl || runtimeConfig.baseUrl || '',
+            })
+          );
         } else {
           logWarn('[ClaudeAgentRunner] No API key configured for provider:', provider);
         }
@@ -1292,7 +1370,8 @@ ${hints.join('\n')}
 
       // pi-coding-agent handles path sandboxing via its own tools
       const imageCapable = true; // pi-ai models generally support images; let the model handle unsupported cases
-      const effectiveCwd = (useSandboxIsolation && sandboxPath) ? sandboxPath : (workingDir || process.cwd());
+      const effectiveCwd =
+        useSandboxIsolation && sandboxPath ? sandboxPath : workingDir || process.cwd();
 
       // Use app-specific Claude config directory to avoid conflicts with user settings
       // SDK uses CLAUDE_CONFIG_DIR to locate skills
@@ -1330,7 +1409,10 @@ ${hints.join('\n')}
                 log(`[ClaudeAgentRunner] Linked built-in skill: ${skillName}`);
               } catch (err) {
                 // If symlink fails (e.g., on Windows without permissions), copy the directory
-                logWarn(`[ClaudeAgentRunner] Failed to symlink ${skillName}, copying instead:`, err);
+                logWarn(
+                  `[ClaudeAgentRunner] Failed to symlink ${skillName}, copying instead:`,
+                  err
+                );
                 this.copyDirectorySync(builtinSkillPath, userSkillPath);
               }
             }
@@ -1387,37 +1469,30 @@ ${hints.join('\n')}
       let contextualPrompt = prompt;
       if (!cachedSession) {
         // Cold start: inject recent history into prompt if available
-        const conversationMessages = existingMessages
-          .filter(msg => msg.role === 'user' || msg.role === 'assistant');
-        const historyMessages = (
-          conversationMessages.length > 0
-            && conversationMessages[conversationMessages.length - 1]?.role === 'user'
-        )
-          ? conversationMessages.slice(0, -1)
-          : conversationMessages;
+        const conversationMessages = existingMessages.filter(
+          (msg) => msg.role === 'user' || msg.role === 'assistant'
+        );
+        const historyMessages =
+          conversationMessages.length > 0 &&
+          conversationMessages[conversationMessages.length - 1]?.role === 'user'
+            ? conversationMessages.slice(0, -1)
+            : conversationMessages;
 
         if (historyMessages.length > 0 && !hasImages) {
           // Content-aware chars-per-token estimation (CJK text uses ~1.5 chars/token vs ~4 for English)
           const contextWindow = piModel.contextWindow || 128000;
-          const historyBudgetRatio =
-            provider === 'ollama' && contextWindow < 16384 ? 0.15 : 0.3;
-          const historyTokenBudget = Math.floor(
-            contextWindow * historyBudgetRatio,
-          );
+          const historyBudgetRatio = provider === 'ollama' && contextWindow < 16384 ? 0.15 : 0.3;
+          const historyTokenBudget = Math.floor(contextWindow * historyBudgetRatio);
 
           // Sample recent messages to estimate chars-per-token ratio
           const sampleText = historyMessages
             .slice(-3)
             .flatMap((m) =>
-              m.content
-                .filter((c) => c.type === 'text')
-                .map((c) => (c as { text: string }).text),
+              m.content.filter((c) => c.type === 'text').map((c) => (c as { text: string }).text)
             )
             .join('');
           const charsPerToken = estimateCharsPerToken(sampleText);
-          const historyCharBudget = Math.floor(
-            historyTokenBudget * charsPerToken,
-          );
+          const historyCharBudget = Math.floor(historyTokenBudget * charsPerToken);
 
           const historyItems: string[] = [];
           let charCount = 0;
@@ -1438,9 +1513,7 @@ ${hints.join('\n')}
           if (historyItems.length > 0) {
             const trimmedCount = historyMessages.length - historyItems.length;
             const historyNote =
-              trimmedCount > 0
-                ? `[${trimmedCount} older messages omitted]\n`
-                : '';
+              trimmedCount > 0 ? `[${trimmedCount} older messages omitted]\n` : '';
             const preamble = `<conversation_history>\n${historyNote}${historyItems.join('\n')}\n</conversation_history>`;
             contextualPrompt = `${preamble}\n\n${prompt}`;
             log(
@@ -1454,7 +1527,7 @@ ${hints.join('\n')}
               charCount,
               ', charsPerToken:',
               charsPerToken.toFixed(2),
-              ')',
+              ')'
             );
           }
         }
@@ -1477,7 +1550,10 @@ ${hints.join('\n')}
         let allConfigs: ReturnType<typeof mcpConfigStore.getEnabledServers> = [];
         try {
           allConfigs = mcpConfigStore.getEnabledServers();
-          log('[ClaudeAgentRunner] Enabled MCP configs:', allConfigs.map((c) => c.name));
+          log(
+            '[ClaudeAgentRunner] Enabled MCP configs:',
+            allConfigs.map((c) => c.name)
+          );
         } catch (error) {
           logWarn(
             '[ClaudeAgentRunner] Failed to read enabled MCP configs; MCP tools will be unavailable this query',
@@ -1505,9 +1581,12 @@ ${hints.join('\n')}
 
               if (config.type === 'stdio') {
                 // 当命令是 npx 或 node 时优先使用内置路径
-                const command = (config.command === 'npx' && bundledNpx)
-                  ? bundledNpx
-                  : (config.command === 'node' && bundledNodePaths ? bundledNodePaths.node : config.command);
+                const command =
+                  config.command === 'npx' && bundledNpx
+                    ? bundledNpx
+                    : config.command === 'node' && bundledNodePaths
+                      ? bundledNodePaths.node
+                      : config.command;
 
                 // 使用内置 npx/node 时，将内置 node bin 注入 PATH
                 const serverEnv = { ...config.env };
@@ -1527,15 +1606,19 @@ ${hints.join('\n')}
                 let resolvedArgs = config.args || [];
 
                 // Check if any args contain placeholders that need resolving
-                const hasPlaceholders = resolvedArgs.some((arg) =>
-                  arg.includes('{SOFTWARE_DEV_SERVER_PATH}') ||
-                  arg.includes('{GUI_OPERATE_SERVER_PATH}')
+                const hasPlaceholders = resolvedArgs.some(
+                  (arg) =>
+                    arg.includes('{SOFTWARE_DEV_SERVER_PATH}') ||
+                    arg.includes('{GUI_OPERATE_SERVER_PATH}')
                 );
 
                 if (hasPlaceholders) {
                   // Get the appropriate preset based on config name
                   let presetKey: string | null = null;
-                  if (config.name === 'Software_Development' || config.name === 'Software Development') {
+                  if (
+                    config.name === 'Software_Development' ||
+                    config.name === 'Software Development'
+                  ) {
                     presetKey = 'software-development';
                   } else if (config.name === 'GUI_Operate' || config.name === 'GUI Operate') {
                     presetKey = 'gui-operate';
@@ -1601,16 +1684,18 @@ ${hints.join('\n')}
       }
       logTiming('after building MCP servers config', runStartTime);
 
-      const workspaceInfoPrompt = useSandboxIsolation && sandboxPath
-        ? `<workspace_info>
+      const workspaceInfoPrompt =
+        useSandboxIsolation && sandboxPath
+          ? `<workspace_info>
 Your current workspace is located at: ${VIRTUAL_WORKSPACE_PATH}
 This is an isolated sandbox environment. Use ${VIRTUAL_WORKSPACE_PATH} as the root path for file operations.
 </workspace_info>`
-        : workingDir
-          ? `<workspace_info>Your current workspace is: ${workingDir}</workspace_info>`
-          : '';
+          : workingDir
+            ? `<workspace_info>Your current workspace is: ${workingDir}</workspace_info>`
+            : '';
 
-      const includeCredentialsPrompt = /login|sign[\s-]?in|credential|password|gmail|邮箱|登录|账号|密码/i.test(prompt);
+      const includeCredentialsPrompt =
+        /login|sign[\s-]?in|credential|password|gmail|邮箱|登录|账号|密码/i.test(prompt);
       // Cowork-specific rules appended to pi's native system prompt.
       // Skills and tool descriptions are handled by pi's DefaultResourceLoader.
       const coworkAppendPrompt = [
@@ -1632,7 +1717,9 @@ Tool routing:
 </tool_behavior>`,
         includeCredentialsPrompt ? this.getCredentialsPrompt() : '',
         this.getBundledPathHints(),
-      ].filter((section): section is string => Boolean(section && section.trim())).join('\n\n');
+      ]
+        .filter((section): section is string => Boolean(section && section.trim()))
+        .join('\n\n');
 
       logTiming('before pi-coding-agent session creation', runStartTime);
 
@@ -1650,7 +1737,10 @@ Tool routing:
       // Re-read every query so newly added/removed MCP servers take effect immediately.
       const mcpCustomTools = this.mcpManager ? buildMcpCustomTools(this.mcpManager) : [];
       if (mcpCustomTools.length > 0) {
-        log(`[ClaudeAgentRunner] Registered ${mcpCustomTools.length} MCP tools as customTools:`, mcpCustomTools.map(t => t.name).join(', '));
+        log(
+          `[ClaudeAgentRunner] Registered ${mcpCustomTools.length} MCP tools as customTools:`,
+          mcpCustomTools.map((t) => t.name).join(', ')
+        );
       }
 
       // Enrich process.env.PATH for build mode — ensures Skill commands (python3, node)
@@ -1660,7 +1750,9 @@ Tool routing:
       const codingTools = createCodingTools(effectiveCwd);
 
       // Inject a default 120s timeout for bash commands when the model omits one
-      const withTimeout = ClaudeAgentRunner.wrapBashToolWithDefaultTimeout(codingTools as ToolDefinition[]);
+      const withTimeout = ClaudeAgentRunner.wrapBashToolWithDefaultTimeout(
+        codingTools as ToolDefinition[]
+      );
 
       // Wrap the bash tool to intercept sudo commands and request passwords
       // Note: wrapBashToolForSudo returns ToolDefinition[] (5-param execute) but
@@ -1671,8 +1763,12 @@ Tool routing:
       // Diagnostic: log tools being passed to SDK (helps debug Ollama tool use)
       logCtx(`[ClaudeAgentRunner] Session reuse check: cached=${!!cachedSession}`);
       logCtx(`[ClaudeAgentRunner] Model=${piModel.id}, thinkingLevel=${thinkingLevel}`);
-      log(`[ClaudeAgentRunner] Built-in tools (${wrappedTools.length}): ${wrappedTools.map((t: { name?: string; type?: string }) => t.name || t.type).join(', ')}`);
-      log(`[ClaudeAgentRunner] Custom MCP tools (${mcpCustomTools.length}): ${mcpCustomTools.map(t => t.name).join(', ')}`);
+      log(
+        `[ClaudeAgentRunner] Built-in tools (${wrappedTools.length}): ${wrappedTools.map((t: { name?: string; type?: string }) => t.name || t.type).join(', ')}`
+      );
+      log(
+        `[ClaudeAgentRunner] Custom MCP tools (${mcpCustomTools.length}): ${mcpCustomTools.map((t) => t.name).join(', ')}`
+      );
 
       let piSession: PiAgentSession;
       if (cachedSession) {
@@ -1681,21 +1777,30 @@ Tool routing:
 
         // Hot-swap model/thinking if changed — SDK supports this natively
         if (cachedSession.modelId !== piModel.id) {
-          logCtx('[ClaudeAgentRunner] Model changed, hot-swapping:', cachedSession.modelId, '→', piModel.id);
+          logCtx(
+            '[ClaudeAgentRunner] Model changed, hot-swapping:',
+            cachedSession.modelId,
+            '→',
+            piModel.id
+          );
           await piSession.setModel(piModel);
           cachedSession.modelId = piModel.id;
           // Update Ollama num_ctx ref if present
           if (cachedSession.ollamaNumCtx) {
-            cachedSession.ollamaNumCtx.value =
-              piModel.contextWindow || 128000;
+            cachedSession.ollamaNumCtx.value = piModel.contextWindow || 128000;
             log(
               '[ClaudeAgentRunner] Updated Ollama num_ctx on hot-swap:',
-              cachedSession.ollamaNumCtx.value,
+              cachedSession.ollamaNumCtx.value
             );
           }
         }
         if (cachedSession.thinkingLevel !== thinkingLevel) {
-          logCtx('[ClaudeAgentRunner] Thinking level changed, hot-swapping:', cachedSession.thinkingLevel, '→', thinkingLevel);
+          logCtx(
+            '[ClaudeAgentRunner] Thinking level changed, hot-swapping:',
+            cachedSession.thinkingLevel,
+            '→',
+            thinkingLevel
+          );
           piSession.setThinkingLevel(thinkingLevel);
           cachedSession.thinkingLevel = thinkingLevel;
         }
@@ -1728,7 +1833,7 @@ Tool routing:
           log(
             '[ClaudeAgentRunner] Ollama small context model, disabling auto-compaction (contextWindow:',
             contextWindow,
-            ')',
+            ')'
           );
         } else if (provider === 'ollama' && contextWindow < 65536) {
           // Medium context: scale reserves proportionally
@@ -1739,7 +1844,7 @@ Tool routing:
           };
           log(
             '[ClaudeAgentRunner] Ollama medium context, scaled compaction:',
-            JSON.stringify(compactionSettings),
+            JSON.stringify(compactionSettings)
           );
         } else {
           compactionSettings = { enabled: true };
@@ -1775,7 +1880,10 @@ Tool routing:
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const agent = piSession.agent as any;
           const originalOnPayload = agent._onPayload as
-            | ((payload: Record<string, unknown>, modelArg: unknown) => Promise<Record<string, unknown>>)
+            | ((
+                payload: Record<string, unknown>,
+                modelArg: unknown
+              ) => Promise<Record<string, unknown>>)
             | undefined;
           const ollamaNumCtx = {
             value: piModel.contextWindow || 128000,
@@ -1790,7 +1898,7 @@ Tool routing:
           this.piSessions.get(session.id)!.ollamaNumCtx = ollamaNumCtx;
           log(
             '[ClaudeAgentRunner] Ollama _onPayload wrapper installed, num_ctx:',
-            ollamaNumCtx.value,
+            ollamaNumCtx.value
           );
         }
 
@@ -1836,14 +1944,17 @@ Tool routing:
           title: 'Processing request...',
         });
         if (provider === 'ollama') {
-          log('[ClaudeAgentRunner] Ollama first stream event received', safeStringify({
-            sessionId: session.id,
-            eventType,
-            modelId: piModel.id,
-            modelProvider: piModel.provider,
-            baseUrl: piModel.baseUrl || runtimeConfig.baseUrl || '',
-            latencyMs: firstStreamEventAt - promptStartedAt,
-          }));
+          log(
+            '[ClaudeAgentRunner] Ollama first stream event received',
+            safeStringify({
+              sessionId: session.id,
+              eventType,
+              modelId: piModel.id,
+              modelProvider: piModel.provider,
+              baseUrl: piModel.baseUrl || runtimeConfig.baseUrl || '',
+              latencyMs: firstStreamEventAt - promptStartedAt,
+            })
+          );
         }
       };
 
@@ -1865,302 +1976,322 @@ Tool routing:
 
       const getStreamEventSummary = () =>
         Object.fromEntries(
-          Array.from(streamEventCounts.entries()).sort(([left], [right]) => left.localeCompare(right))
+          Array.from(streamEventCounts.entries()).sort(([left], [right]) =>
+            left.localeCompare(right)
+          )
         );
 
       const unsubscribe = piSession.subscribe((event) => {
         try {
-        if (controller.signal.aborted) return;
+          if (controller.signal.aborted) return;
 
-        // Reset activity timeout on meaningful events
-        resetActivityTimeout();
+          // Reset activity timeout on meaningful events
+          resetActivityTimeout();
 
-        if (event.type === 'message_update') {
-          const updateType = event.assistantMessageEvent.type;
-          recordStreamEvent(updateType);
-          if (updateType !== 'text_delta' && updateType !== 'thinking_delta') {
-            log(`[ClaudeAgentRunner] Event: ${event.type} → ${updateType}`);
+          if (event.type === 'message_update') {
+            const updateType = event.assistantMessageEvent.type;
+            recordStreamEvent(updateType);
+            if (updateType !== 'text_delta' && updateType !== 'thinking_delta') {
+              log(`[ClaudeAgentRunner] Event: ${event.type} → ${updateType}`);
+            }
+          } else if (event.type === 'message_start') {
+            log(
+              '[ClaudeAgentRunner] Event: message_start',
+              safeStringify(summarizeMessageForLog(event.message), 2)
+            );
+          } else if (event.type === 'message_end') {
+            log(
+              '[ClaudeAgentRunner] Event: message_end',
+              safeStringify(
+                {
+                  message: summarizeMessageForLog(event.message),
+                  messageUpdateCounts: getStreamEventSummary(),
+                },
+                2
+              )
+            );
+          } else if (event.type === 'turn_end') {
+            log(`[ClaudeAgentRunner] Event: ${event.type}`);
+          } else {
+            log(`[ClaudeAgentRunner] Event: ${event.type}`);
           }
-        } else if (event.type === 'message_start') {
-          log('[ClaudeAgentRunner] Event: message_start', safeStringify(summarizeMessageForLog(event.message), 2));
-        } else if (event.type === 'message_end') {
-          log(
-            '[ClaudeAgentRunner] Event: message_end',
-            safeStringify(
-              {
-                message: summarizeMessageForLog(event.message),
-                messageUpdateCounts: getStreamEventSummary(),
-              },
-              2
-            )
-          );
-        } else if (event.type === 'turn_end') {
-          log(`[ClaudeAgentRunner] Event: ${event.type}`);
-        } else {
-          log(`[ClaudeAgentRunner] Event: ${event.type}`);
-        }
 
-        switch (event.type) {
-          case 'message_update': {
-            if (controller.signal.aborted) break;
-            const ame = event.assistantMessageEvent;
-            if (ame.type === 'text_delta') {
-              markFirstStreamEvent(ame.type);
-              const parsed = thinkParser.push(ame.delta);
-              if (parsed.thinking) {
+          switch (event.type) {
+            case 'message_update': {
+              if (controller.signal.aborted) break;
+              const ame = event.assistantMessageEvent;
+              if (ame.type === 'text_delta') {
+                markFirstStreamEvent(ame.type);
+                const parsed = thinkParser.push(ame.delta);
+                if (parsed.thinking) {
+                  this.sendToRenderer({
+                    type: 'stream.thinking',
+                    payload: { sessionId: session.id, delta: parsed.thinking },
+                  });
+                }
+                if (parsed.text) {
+                  streamedText += parsed.text;
+                  this.sendPartial(session.id, parsed.text);
+                }
+              } else if (ame.type === 'thinking_delta') {
+                markFirstStreamEvent(ame.type);
+                // Forward thinking delta to renderer for real-time display
                 this.sendToRenderer({
                   type: 'stream.thinking',
-                  payload: { sessionId: session.id, delta: parsed.thinking },
+                  payload: { sessionId: session.id, delta: ame.delta },
+                });
+              } else if (ame.type === 'toolcall_start') {
+                markFirstStreamEvent(ame.type);
+                const partial = ame.partial;
+                const toolContent = partial?.content?.[ame.contentIndex];
+                const toolName = toolContent?.type === 'toolCall' ? toolContent.name : 'unknown';
+                const toolCallId = toolContent?.type === 'toolCall' ? toolContent.id : uuidv4();
+                this.sendTraceStep(session.id, {
+                  id: toolCallId,
+                  type: 'tool_call',
+                  status: 'running',
+                  title: toolName,
+                  toolName,
+                  toolInput:
+                    toolContent?.type === 'toolCall'
+                      ? (toolContent.arguments as Record<string, unknown>) || {}
+                      : undefined,
+                  timestamp: Date.now(),
+                });
+              } else if (ame.type === 'done') {
+                // Some providers emit 'done' via message_update — we handle it
+                // in message_end below as a unified path for all providers.
+                log('[ClaudeAgentRunner] message_update done event (handled in message_end)');
+              } else if (ame.type === 'error') {
+                const errorDetail = JSON.stringify(ame.error?.content || 'no content');
+                logCtxError('[ClaudeAgentRunner] pi-ai stream error:', ame.reason, errorDetail);
+              }
+              break;
+            }
+
+            case 'message_end': {
+              // Unified handler: send the final assistant message to the renderer.
+              // Works for all providers (some emit 'done' via message_update, others don't).
+              if (controller.signal.aborted) break;
+
+              // Flush any buffered content from the think-tag parser
+              const flushed = thinkParser.flush();
+              if (flushed.thinking) {
+                this.sendToRenderer({
+                  type: 'stream.thinking',
+                  payload: { sessionId: session.id, delta: flushed.thinking },
                 });
               }
-              if (parsed.text) {
-                streamedText += parsed.text;
-                this.sendPartial(session.id, parsed.text);
+              if (flushed.text) {
+                streamedText += flushed.text;
+                this.sendPartial(session.id, flushed.text);
               }
-            } else if (ame.type === 'thinking_delta') {
-              markFirstStreamEvent(ame.type);
-              // Forward thinking delta to renderer for real-time display
-              this.sendToRenderer({
-                type: 'stream.thinking',
-                payload: { sessionId: session.id, delta: ame.delta },
+
+              const msg = event.message;
+              if (process.env.COWORK_LOG_SDK_MESSAGES_FULL === '1') {
+                log('[ClaudeAgentRunner] message_end raw message:', safeStringify(msg, 2));
+              }
+              const resolvedPayload = resolveMessageEndPayload({
+                message: msg as Parameters<typeof resolveMessageEndPayload>[0]['message'],
+                streamedText,
               });
-            } else if (ame.type === 'toolcall_start') {
-              markFirstStreamEvent(ame.type);
-              const partial = ame.partial;
-              const toolContent = partial?.content?.[ame.contentIndex];
-              const toolName = toolContent?.type === 'toolCall' ? toolContent.name : 'unknown';
-              const toolCallId = toolContent?.type === 'toolCall' ? toolContent.id : uuidv4();
+              streamedText = resolvedPayload.nextStreamedText;
+              if (provider === 'ollama') {
+                log(
+                  '[ClaudeAgentRunner] Ollama message_end diagnostics',
+                  safeStringify({
+                    sessionId: session.id,
+                    modelId: piModel.id,
+                    modelProvider: piModel.provider,
+                    usedSyntheticModel,
+                    receivedFirstStreamEvent,
+                    firstStreamLatencyMs: firstStreamEventAt
+                      ? firstStreamEventAt - promptStartedAt
+                      : null,
+                    stopReason: (msg as { stopReason?: unknown })?.stopReason ?? null,
+                    contentBlocks: Array.isArray((msg as { content?: unknown[] })?.content)
+                      ? ((msg as { content?: unknown[] }).content?.length ?? 0)
+                      : 0,
+                    emittedError: Boolean(resolvedPayload.errorText),
+                  })
+                );
+              }
+              if (resolvedPayload.errorText) {
+                terminalErrorText = resolvedPayload.errorText;
+                if (!hasEmittedError) {
+                  hasEmittedError = true;
+                  this.sendMessage(session.id, {
+                    id: uuidv4(),
+                    sessionId: session.id,
+                    role: 'assistant',
+                    content: [
+                      {
+                        type: 'text',
+                        text: `**Error**: ${resolvedPayload.errorText}\n\n${
+                          /\b4\d{2}\b/.test(resolvedPayload.errorText)
+                            ? '_请检查配置后重试。_'
+                            : '_Agent 正在自动重试，请稍候..._'
+                        }`,
+                      },
+                    ],
+                    timestamp: Date.now(),
+                  });
+                }
+                break;
+              }
+              if (resolvedPayload.shouldEmitMessage) {
+                const contentBlocks: ContentBlock[] = [];
+                for (const block of resolvedPayload.effectiveContent) {
+                  if (block.type === 'text') {
+                    const { cleanText, artifacts } = extractArtifactsFromText(block.text);
+                    if (cleanText) {
+                      contentBlocks.push({ type: 'text', text: sanitizeOutputPaths(cleanText) });
+                    }
+                    if (artifacts.length > 0) {
+                      for (const step of buildArtifactTraceSteps(artifacts)) {
+                        this.sendTraceStep(session.id, step);
+                      }
+                    }
+                  } else if (block.type === 'toolCall') {
+                    contentBlocks.push({
+                      type: 'tool_use',
+                      id: block.id,
+                      name: block.name,
+                      input: block.arguments,
+                    });
+                  } else if (block.type === 'thinking') {
+                    // Include thinking blocks in the final message for UI display
+                    contentBlocks.push({
+                      type: 'thinking',
+                      thinking: block.thinking,
+                    });
+                  } else {
+                    // Unknown block type — pass through as text so content isn't silently lost
+                    const unknownBlock = block as { type?: string; text?: string };
+                    log(`[ClaudeAgentRunner] Unknown content block type: ${unknownBlock.type}`);
+                    const text = unknownBlock.text || JSON.stringify(block);
+                    if (text) contentBlocks.push({ type: 'text', text });
+                  }
+                }
+                // Always clear partial text; send message even if only artifacts were extracted
+                this.sendToRenderer({
+                  type: 'stream.partial',
+                  payload: { sessionId: session.id, delta: '' },
+                });
+                if (contentBlocks.length > 0) {
+                  const msgWithUsage = msg as { usage?: unknown };
+                  const tokenUsage = normalizeTokenUsage(msgWithUsage.usage);
+                  if (msgWithUsage.usage) {
+                    log(
+                      '[ClaudeAgentRunner] normalized usage:',
+                      safeStringify(
+                        {
+                          raw: msgWithUsage.usage,
+                          normalized: tokenUsage,
+                        },
+                        2
+                      )
+                    );
+                  }
+                  const assistantMsg: Message = {
+                    id: uuidv4(),
+                    sessionId: session.id,
+                    role: 'assistant',
+                    content: contentBlocks,
+                    timestamp: Date.now(),
+                    tokenUsage,
+                  };
+                  this.sendMessage(session.id, assistantMsg);
+                }
+              }
+              break;
+            }
+
+            case 'tool_execution_start': {
+              logCtx(`[ClaudeAgentRunner] Tool execution start: ${event.toolName}`);
+              break;
+            }
+
+            case 'tool_execution_end': {
+              if (controller.signal.aborted) break;
+              const toolCallId = event.toolCallId;
+              const isError = event.isError;
+              const outputText =
+                typeof event.result === 'string'
+                  ? event.result
+                  : JSON.stringify(event.result || '');
+              this.sendTraceUpdate(session.id, toolCallId, {
+                status: isError ? 'error' : 'completed',
+                toolName: event.toolName,
+                toolOutput: sanitizeOutputPaths(outputText).slice(0, 800),
+              });
+
+              // Send tool result message
+              const toolResultMsg: Message = {
+                id: uuidv4(),
+                sessionId: session.id,
+                role: 'assistant',
+                content: [
+                  {
+                    type: 'tool_result',
+                    toolUseId: toolCallId,
+                    content: sanitizeOutputPaths(outputText),
+                    isError,
+                  },
+                ],
+                timestamp: Date.now(),
+              };
+              this.sendMessage(session.id, toolResultMsg);
+              break;
+            }
+
+            case 'agent_end': {
+              logCtx('[ClaudeAgentRunner] Agent finished');
+              break;
+            }
+
+            case 'auto_compaction_start': {
+              log('[ClaudeAgentRunner] Auto-compaction started, reason:', event.reason);
+              compactionStepId = `compaction-${Date.now()}`;
               this.sendTraceStep(session.id, {
-                id: toolCallId,
-                type: 'tool_call',
+                id: compactionStepId,
+                type: 'thinking',
                 status: 'running',
-                title: toolName,
-                toolName,
-                toolInput: toolContent?.type === 'toolCall' ? (toolContent.arguments as Record<string, unknown> || {}) : undefined,
+                title: `Compacting context (${event.reason})...`,
                 timestamp: Date.now(),
               });
-            } else if (ame.type === 'done') {
-              // Some providers emit 'done' via message_update — we handle it
-              // in message_end below as a unified path for all providers.
-              log('[ClaudeAgentRunner] message_update done event (handled in message_end)');
-            } else if (ame.type === 'error') {
-              const errorDetail = JSON.stringify(ame.error?.content || 'no content');
-              logCtxError('[ClaudeAgentRunner] pi-ai stream error:', ame.reason, errorDetail);
-            }
-            break;
-          }
-
-          case 'message_end': {
-            // Unified handler: send the final assistant message to the renderer.
-            // Works for all providers (some emit 'done' via message_update, others don't).
-            if (controller.signal.aborted) break;
-
-            // Flush any buffered content from the think-tag parser
-            const flushed = thinkParser.flush();
-            if (flushed.thinking) {
-              this.sendToRenderer({
-                type: 'stream.thinking',
-                payload: { sessionId: session.id, delta: flushed.thinking },
-              });
-            }
-            if (flushed.text) {
-              streamedText += flushed.text;
-              this.sendPartial(session.id, flushed.text);
+              break;
             }
 
-            const msg = event.message;
-            if (process.env.COWORK_LOG_SDK_MESSAGES_FULL === '1') {
+            case 'auto_compaction_end': {
+              const status = event.aborted ? 'error' : event.errorMessage ? 'error' : 'completed';
+              const title = event.aborted
+                ? 'Context compaction aborted'
+                : event.errorMessage
+                  ? `Context compaction failed: ${event.errorMessage}`
+                  : 'Context compaction completed';
               log(
-                '[ClaudeAgentRunner] message_end raw message:',
-                safeStringify(msg, 2)
+                '[ClaudeAgentRunner] Auto-compaction ended:',
+                title,
+                'willRetry:',
+                event.willRetry
               );
-            }
-            const resolvedPayload = resolveMessageEndPayload({
-              message: msg as Parameters<typeof resolveMessageEndPayload>[0]['message'],
-              streamedText,
-            });
-            streamedText = resolvedPayload.nextStreamedText;
-            if (provider === 'ollama') {
-              log('[ClaudeAgentRunner] Ollama message_end diagnostics', safeStringify({
-                sessionId: session.id,
-                modelId: piModel.id,
-                modelProvider: piModel.provider,
-                usedSyntheticModel,
-                receivedFirstStreamEvent,
-                firstStreamLatencyMs: firstStreamEventAt ? firstStreamEventAt - promptStartedAt : null,
-                stopReason: (msg as { stopReason?: unknown })?.stopReason ?? null,
-                contentBlocks: Array.isArray((msg as { content?: unknown[] })?.content)
-                  ? ((msg as { content?: unknown[] }).content?.length ?? 0)
-                  : 0,
-                emittedError: Boolean(resolvedPayload.errorText),
-              }));
-            }
-            if (resolvedPayload.errorText) {
-              terminalErrorText = resolvedPayload.errorText;
-              if (!hasEmittedError) {
-                hasEmittedError = true;
-                this.sendMessage(session.id, {
-                  id: uuidv4(),
-                  sessionId: session.id,
-                  role: 'assistant',
-                  content: [{
-                    type: 'text',
-                    text: `**Error**: ${resolvedPayload.errorText}\n\n${
-                      /\b4\d{2}\b/.test(resolvedPayload.errorText)
-                        ? '_请检查配置后重试。_'
-                        : '_Agent 正在自动重试，请稍候..._'
-                    }`,
-                  }],
+              if (compactionStepId) {
+                this.sendTraceUpdate(session.id, compactionStepId, { status, title });
+                compactionStepId = undefined;
+              } else {
+                // Fallback: no matching start event, send as new step
+                this.sendTraceStep(session.id, {
+                  id: `compaction-end-${Date.now()}`,
+                  type: 'thinking',
+                  status,
+                  title,
                   timestamp: Date.now(),
                 });
               }
               break;
             }
-            if (resolvedPayload.shouldEmitMessage) {
-              const contentBlocks: ContentBlock[] = [];
-              for (const block of resolvedPayload.effectiveContent) {
-                if (block.type === 'text') {
-                  const { cleanText, artifacts } = extractArtifactsFromText(block.text);
-                  if (cleanText) {
-                    contentBlocks.push({ type: 'text', text: sanitizeOutputPaths(cleanText) });
-                  }
-                  if (artifacts.length > 0) {
-                    for (const step of buildArtifactTraceSteps(artifacts)) {
-                      this.sendTraceStep(session.id, step);
-                    }
-                  }
-                } else if (block.type === 'toolCall') {
-                  contentBlocks.push({
-                    type: 'tool_use',
-                    id: block.id,
-                    name: block.name,
-                    input: block.arguments,
-                  });
-                } else if (block.type === 'thinking') {
-                  // Include thinking blocks in the final message for UI display
-                  contentBlocks.push({
-                    type: 'thinking',
-                    thinking: block.thinking,
-                  });
-                } else {
-                  // Unknown block type — pass through as text so content isn't silently lost
-                  const unknownBlock = block as { type?: string; text?: string };
-                  log(`[ClaudeAgentRunner] Unknown content block type: ${unknownBlock.type}`);
-                  const text = unknownBlock.text || JSON.stringify(block);
-                  if (text) contentBlocks.push({ type: 'text', text });
-                }
-              }
-              // Always clear partial text; send message even if only artifacts were extracted
-              this.sendToRenderer({
-                type: 'stream.partial',
-                payload: { sessionId: session.id, delta: '' },
-              });
-              if (contentBlocks.length > 0) {
-                const msgWithUsage = msg as { usage?: unknown };
-                const tokenUsage = normalizeTokenUsage(msgWithUsage.usage);
-                if (msgWithUsage.usage) {
-                  log(
-                    '[ClaudeAgentRunner] normalized usage:',
-                    safeStringify(
-                      {
-                        raw: msgWithUsage.usage,
-                        normalized: tokenUsage,
-                      },
-                      2
-                    )
-                  );
-                }
-                const assistantMsg: Message = {
-                  id: uuidv4(),
-                  sessionId: session.id,
-                  role: 'assistant',
-                  content: contentBlocks,
-                  timestamp: Date.now(),
-                  tokenUsage,
-                };
-                this.sendMessage(session.id, assistantMsg);
-              }
-            }
-            break;
           }
-
-          case 'tool_execution_start': {
-            logCtx(`[ClaudeAgentRunner] Tool execution start: ${event.toolName}`);
-            break;
-          }
-
-          case 'tool_execution_end': {
-            if (controller.signal.aborted) break;
-            const toolCallId = event.toolCallId;
-            const isError = event.isError;
-            const outputText = typeof event.result === 'string'
-              ? event.result
-              : JSON.stringify(event.result || '');
-            this.sendTraceUpdate(session.id, toolCallId, {
-              status: isError ? 'error' : 'completed',
-              toolName: event.toolName,
-              toolOutput: sanitizeOutputPaths(outputText).slice(0, 800),
-            });
-
-            // Send tool result message
-            const toolResultMsg: Message = {
-              id: uuidv4(),
-              sessionId: session.id,
-              role: 'assistant',
-              content: [{
-                type: 'tool_result',
-                toolUseId: toolCallId,
-                content: sanitizeOutputPaths(outputText),
-                isError,
-              }],
-              timestamp: Date.now(),
-            };
-            this.sendMessage(session.id, toolResultMsg);
-            break;
-          }
-
-          case 'agent_end': {
-            logCtx('[ClaudeAgentRunner] Agent finished');
-            break;
-          }
-
-          case 'auto_compaction_start': {
-            log('[ClaudeAgentRunner] Auto-compaction started, reason:', event.reason);
-            compactionStepId = `compaction-${Date.now()}`;
-            this.sendTraceStep(session.id, {
-              id: compactionStepId,
-              type: 'thinking',
-              status: 'running',
-              title: `Compacting context (${event.reason})...`,
-              timestamp: Date.now(),
-            });
-            break;
-          }
-
-          case 'auto_compaction_end': {
-            const status = event.aborted ? 'error' : (event.errorMessage ? 'error' : 'completed');
-            const title = event.aborted
-              ? 'Context compaction aborted'
-              : event.errorMessage
-                ? `Context compaction failed: ${event.errorMessage}`
-                : 'Context compaction completed';
-            log('[ClaudeAgentRunner] Auto-compaction ended:', title, 'willRetry:', event.willRetry);
-            if (compactionStepId) {
-              this.sendTraceUpdate(session.id, compactionStepId, { status, title });
-              compactionStepId = undefined;
-            } else {
-              // Fallback: no matching start event, send as new step
-              this.sendTraceStep(session.id, {
-                id: `compaction-end-${Date.now()}`,
-                type: 'thinking',
-                status,
-                title,
-                timestamp: Date.now(),
-              });
-            }
-            break;
-          }
-        }
         } catch (subscribeErr) {
           logError('[ClaudeAgentRunner] Error in subscribe callback:', subscribeErr);
           if (compactionStepId) {
@@ -2188,25 +2319,35 @@ Tool routing:
       try {
         resetActivityTimeout();
         if (provider === 'ollama') {
-          log('[ClaudeAgentRunner] Starting Ollama prompt', safeStringify({
-            sessionId: session.id,
-            modelId: piModel.id,
-            modelProvider: piModel.provider,
-            baseUrl: piModel.baseUrl || runtimeConfig.baseUrl || '',
-            usedSyntheticModel,
-            hasExplicitApiKey: Boolean(apiKey),
-            thinkingLevel,
-          }));
+          log(
+            '[ClaudeAgentRunner] Starting Ollama prompt',
+            safeStringify({
+              sessionId: session.id,
+              modelId: piModel.id,
+              modelProvider: piModel.provider,
+              baseUrl: piModel.baseUrl || runtimeConfig.baseUrl || '',
+              usedSyntheticModel,
+              hasExplicitApiKey: Boolean(apiKey),
+              thinkingLevel,
+            })
+          );
         }
         try {
           const promptResult = await piSession.prompt(contextualPrompt);
-          log('[ClaudeAgentRunner] prompt() returned:', JSON.stringify(promptResult ?? 'void').substring(0, 1000));
+          log(
+            '[ClaudeAgentRunner] prompt() returned:',
+            JSON.stringify(promptResult ?? 'void').substring(0, 1000)
+          );
         } finally {
           if (activityTimeoutId) clearTimeout(activityTimeoutId);
           if (ollamaColdStartTimerId) clearTimeout(ollamaColdStartTimerId);
         }
       } finally {
-        try { unsubscribe(); } catch (e) { logWarn('[ClaudeAgentRunner] unsubscribe error:', e); }
+        try {
+          unsubscribe();
+        } catch (e) {
+          logWarn('[ClaudeAgentRunner] unsubscribe error:', e);
+        }
       }
 
       logTiming('pi-coding-agent prompt completed', runStartTime);
@@ -2233,7 +2374,6 @@ Tool routing:
           title: terminalErrorText ? 'Request failed' : 'Task completed',
         });
       }
-
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
         if (abortedByTimeout) {
@@ -2316,14 +2456,18 @@ Tool routing:
             id: uuidv4(),
             sessionId: session.id,
             role: 'assistant',
-            content: [{ type: 'text', text: `**Warning**: Sandbox sync failed: ${syncErr instanceof Error ? syncErr.message : String(syncErr)}` }],
+            content: [
+              {
+                type: 'text',
+                text: `**Warning**: Sandbox sync failed: ${syncErr instanceof Error ? syncErr.message : String(syncErr)}`,
+              },
+            ],
             timestamp: Date.now(),
           });
         }
       }
     }
   }
-
 
   cancel(sessionId: string): void {
     const controller = this.activeControllers.get(sessionId);
@@ -2352,5 +2496,4 @@ Tool routing:
   private sendPartial(sessionId: string, delta: string): void {
     this.sendToRenderer({ type: 'stream.partial', payload: { sessionId, delta } });
   }
-
 }

--- a/src/main/claude/claude-sdk-one-shot.ts
+++ b/src/main/claude/claude-sdk-one-shot.ts
@@ -22,8 +22,10 @@ import {
   resolveSyntheticPiModelFallback,
 } from './pi-model-resolution';
 
-const NETWORK_ERROR_RE = /enotfound|econnrefused|etimedout|eai_again|enetunreach|timed?\s*out|timeout|abort|network\s*error/i;
-const AUTH_ERROR_RE = /authentication[_\s-]?failed|unauthorized|invalid[_\s-]?api[_\s-]?key|forbidden|401|403/i;
+const NETWORK_ERROR_RE =
+  /enotfound|econnrefused|etimedout|eai_again|enetunreach|timed?\s*out|timeout|abort|network\s*error/i;
+const AUTH_ERROR_RE =
+  /authentication[_\s-]?failed|unauthorized|invalid[_\s-]?api[_\s-]?key|forbidden|401|403/i;
 const RATE_LIMIT_RE = /rate[_\s-]?limit|too\s+many\s+requests|429/i;
 const SERVER_ERROR_RE = /server[_\s-]?error|internal\s+server\s+error|5\d\d/i;
 const PROBE_ACK = 'sdk_probe_ok';
@@ -44,7 +46,7 @@ function resolveProbeApiKey(
   resolvedCustomProtocol: CustomProtocolType,
   effectiveBaseUrl: string | undefined,
   explicitApiKey: string | undefined,
-  config: AppConfig,
+  config: AppConfig
 ): string {
   const candidateApiKey = explicitApiKey ?? config.apiKey?.trim() ?? '';
   if (candidateApiKey) {
@@ -52,21 +54,29 @@ function resolveProbeApiKey(
   }
 
   if (input.provider === 'ollama') {
-    return resolveOllamaCredentials({
-      provider: input.provider,
-      customProtocol: resolvedCustomProtocol,
-      apiKey: '',
-      baseUrl: effectiveBaseUrl,
-    })?.apiKey || '';
+    return (
+      resolveOllamaCredentials({
+        provider: input.provider,
+        customProtocol: resolvedCustomProtocol,
+        apiKey: '',
+        baseUrl: effectiveBaseUrl,
+      })?.apiKey || ''
+    );
   }
 
-  if (input.provider === 'openai' || input.provider === 'openrouter' || (input.provider === 'custom' && resolvedCustomProtocol === 'openai')) {
-    return resolveOpenAICredentials({
-      provider: input.provider,
-      customProtocol: resolvedCustomProtocol,
-      apiKey: '',
-      baseUrl: effectiveBaseUrl,
-    })?.apiKey || '';
+  if (
+    input.provider === 'openai' ||
+    input.provider === 'openrouter' ||
+    (input.provider === 'custom' && resolvedCustomProtocol === 'openai')
+  ) {
+    return (
+      resolveOpenAICredentials({
+        provider: input.provider,
+        customProtocol: resolvedCustomProtocol,
+        apiKey: '',
+        baseUrl: effectiveBaseUrl,
+      })?.apiKey || ''
+    );
   }
 
   if (
@@ -95,21 +105,23 @@ function resolveProbeApiKey(
 function buildProbeConfig(input: ApiTestInput, config: AppConfig): AppConfig {
   const resolvedBaseUrl = resolveProbeBaseUrl(input);
   const normalizedInputApiKey = typeof input.apiKey === 'string' ? input.apiKey.trim() : undefined;
-  const resolvedCustomProtocol = resolvePiRouteProtocol(input.provider, input.customProtocol) as CustomProtocolType;
+  const resolvedCustomProtocol = resolvePiRouteProtocol(
+    input.provider,
+    input.customProtocol
+  ) as CustomProtocolType;
   const effectiveRawBaseUrl = resolvedBaseUrl || '';
-  const effectiveBaseUrl = input.provider === 'ollama'
-    ? (normalizeOllamaBaseUrl(effectiveRawBaseUrl) || effectiveRawBaseUrl)
-    : (
-      resolvedCustomProtocol === 'openai' || resolvedCustomProtocol === 'gemini'
+  const effectiveBaseUrl =
+    input.provider === 'ollama'
+      ? normalizeOllamaBaseUrl(effectiveRawBaseUrl) || effectiveRawBaseUrl
+      : resolvedCustomProtocol === 'openai' || resolvedCustomProtocol === 'gemini'
         ? effectiveRawBaseUrl
-        : normalizeAnthropicBaseUrl(effectiveRawBaseUrl)
-    );
+        : normalizeAnthropicBaseUrl(effectiveRawBaseUrl);
   const effectiveApiKey = resolveProbeApiKey(
     input,
     resolvedCustomProtocol,
     effectiveBaseUrl,
     normalizedInputApiKey,
-    config,
+    config
   );
   return {
     ...config,
@@ -121,11 +133,7 @@ function buildProbeConfig(input: ApiTestInput, config: AppConfig): AppConfig {
   };
 }
 
-function mapPiAiError(
-  errorText: string,
-  durationMs: number,
-  provider?: string,
-): ApiTestResult {
+function mapPiAiError(errorText: string, durationMs: number, provider?: string): ApiTestResult {
   const details = errorText.trim();
   const lowered = details.toLowerCase();
 
@@ -153,12 +161,12 @@ function mapPiAiError(
 async function runPiAiOneShot(
   prompt: string,
   systemPrompt: string,
-  config: AppConfig,
+  config: AppConfig
 ): Promise<{ text: string; hasThinking: boolean; durationMs: number }> {
   const modelString = resolvePiModelString(config);
   const keyProvider = config.customProtocol || config.provider || 'anthropic';
   const parts = modelString.split('/');
-  const provider = parts.length >= 2 ? parts[0] : (keyProvider || 'anthropic');
+  const provider = parts.length >= 2 ? parts[0] : keyProvider || 'anthropic';
   let piModel = resolvePiRegistryModel(modelString, {
     configProvider: keyProvider,
     customBaseUrl: config.baseUrl?.trim() || undefined,
@@ -168,7 +176,10 @@ async function runPiAiOneShot(
 
   if (!piModel) {
     // Synthetic fallback for unknown/custom models
-    const effectiveProtocol = resolvePiRouteProtocol(config.provider, config.customProtocol) as CustomProtocolType;
+    const effectiveProtocol = resolvePiRouteProtocol(
+      config.provider,
+      config.customProtocol
+    ) as CustomProtocolType;
     const api = config.baseUrl?.trim() ? inferPiApi(effectiveProtocol) : undefined;
     const synthetic = resolveSyntheticPiModelFallback({
       rawModel: config.model,
@@ -182,7 +193,7 @@ async function runPiAiOneShot(
       synthetic.provider,
       effectiveProtocol,
       config.baseUrl?.trim() || '',
-      api,
+      api
     );
     piModel = applyPiModelRuntimeOverrides(piModel, {
       configProvider: keyProvider,
@@ -213,30 +224,61 @@ async function runPiAiOneShot(
   // Use pi-ai's completeSimple for a one-shot call
   // Pass apiKey directly in options — completeSimple uses options.apiKey || env var
   const userMsg: PiUserMessage = { role: 'user', content: prompt, timestamp: Date.now() };
-  log('[OneShot] Calling completeSimple:', resolvedModel.provider, resolvedModel.id, 'baseUrl:', resolvedModel.baseUrl, 'api:', resolvedModel.api);
-  const response = await completeSimple(resolvedModel, {
-    systemPrompt,
-    messages: [userMsg],
-  }, { apiKey: apiKey || undefined });
+  log(
+    '[OneShot] Calling completeSimple:',
+    resolvedModel.provider,
+    resolvedModel.id,
+    'baseUrl:',
+    resolvedModel.baseUrl,
+    'api:',
+    resolvedModel.api
+  );
+  const response = await completeSimple(
+    resolvedModel,
+    {
+      systemPrompt,
+      messages: [userMsg],
+    },
+    { apiKey: apiKey || undefined }
+  );
 
   // Extract text and thinking content from response
-  const textBlocks = response.content.filter(b => b.type === 'text');
-  const thinkingBlocks = response.content.filter(b => b.type === 'thinking');
-  const text = textBlocks.map(b => (b as { text: string }).text).join('').trim();
+  const textBlocks = response.content.filter((b) => b.type === 'text');
+  const thinkingBlocks = response.content.filter((b) => b.type === 'thinking');
+  const text = textBlocks
+    .map((b) => (b as { text: string }).text)
+    .join('')
+    .trim();
   const hasThinking = thinkingBlocks.some(
-    b => (b as { thinking: string }).thinking?.trim().length > 0
+    (b) => (b as { thinking: string }).thinking?.trim().length > 0
   );
-  log('[OneShot] Response:', text ? text.substring(0, 200) : '(empty)', 'blocks:', response.content.length, 'textBlocks:', textBlocks.length, 'thinkingBlocks:', thinkingBlocks.length);
+  log(
+    '[OneShot] Response:',
+    text ? text.substring(0, 200) : '(empty)',
+    'blocks:',
+    response.content.length,
+    'textBlocks:',
+    textBlocks.length,
+    'thinkingBlocks:',
+    thinkingBlocks.length
+  );
   return { text, hasThinking, durationMs: Date.now() - start };
 }
 
 function normalizeProbeAck(raw: string): string {
   // Strip markdown formatting and quotes around/between words, but preserve
   // underscores inside words (PROBE_ACK = 'sdk_probe_ok' contains underscores).
-  return raw.replace(/(?<!\w)[*_~`"']+|[*_~`"']+(?!\w)/g, '').replace(/[.,!?;:]+$/g, '').trim().toLowerCase();
+  return raw
+    .replace(/(?<!\w)[*_~`"']+|[*_~`"']+(?!\w)/g, '')
+    .replace(/[.,!?;:]+$/g, '')
+    .trim()
+    .toLowerCase();
 }
 
-export async function probeWithClaudeSdk(input: ApiTestInput, config: AppConfig): Promise<ApiTestResult> {
+export async function probeWithClaudeSdk(
+  input: ApiTestInput,
+  config: AppConfig
+): Promise<ApiTestResult> {
   const probeConfig = buildProbeConfig(input, config);
 
   if (input.provider === 'custom' && !probeConfig.baseUrl?.trim()) {
@@ -255,7 +297,7 @@ export async function probeWithClaudeSdk(input: ApiTestInput, config: AppConfig)
     const result = await runPiAiOneShot(
       `Please reply with exactly: ${PROBE_ACK}`,
       `You are a connectivity probe. Do not use tools. Reply with exactly: ${PROBE_ACK}`,
-      probeConfig,
+      probeConfig
     );
 
     if (!result.text && !result.hasThinking) {
@@ -269,7 +311,9 @@ export async function probeWithClaudeSdk(input: ApiTestInput, config: AppConfig)
     // Thinking models may respond only with reasoning content and no text —
     // treat as successful probe since the model is reachable and responding.
     if (!result.text && result.hasThinking) {
-      log('[Probe] Thinking-only response — treating as ok (model reachable, cannot validate ack text)');
+      log(
+        '[Probe] Thinking-only response — treating as ok (model reachable, cannot validate ack text)'
+      );
       return { ok: true, latencyMs: result.durationMs };
     }
     if (!normalizeProbeAck(result.text).includes(PROBE_ACK)) {
@@ -290,13 +334,17 @@ export async function probeWithClaudeSdk(input: ApiTestInput, config: AppConfig)
 export async function generateTitleWithClaudeSdk(
   titlePrompt: string,
   config: AppConfig,
-  _cwdOverride?: string,
+  _cwdOverride?: string
 ): Promise<string | null> {
+  if (config.provider === 'codex_chatgpt') {
+    return null;
+  }
+
   try {
     const result = await runPiAiOneShot(
       titlePrompt,
       'Generate a concise title. Reply with only the title text and no extra markup.',
-      config,
+      config
     );
     const title = normalizeGeneratedTitle(result.text);
     if (!title && result.hasThinking) {

--- a/src/main/codex/codex-agent-runner.ts
+++ b/src/main/codex/codex-agent-runner.ts
@@ -1,0 +1,513 @@
+import { v4 as uuidv4 } from 'uuid';
+import { type ChildProcessWithoutNullStreams } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as readline from 'readline';
+import { configStore } from '../config/config-store';
+import { spawnCodexExecProcess } from './codex-cli';
+import type {
+  Session,
+  Message,
+  ServerEvent,
+  TraceStep,
+  ImageContent,
+  TokenUsage,
+} from '../../renderer/types';
+
+interface CodexAgentRunnerOptions {
+  sendToRenderer: (event: ServerEvent) => void;
+  saveMessage?: (message: Message) => void;
+  updateSession?: (sessionId: string, updates: Partial<Session>) => void;
+}
+
+interface CodexThreadStartedEvent {
+  type: 'thread.started';
+  thread_id: string;
+}
+
+interface CodexTurnCompletedEvent {
+  type: 'turn.completed';
+  usage: {
+    input_tokens: number;
+    cached_input_tokens: number;
+    output_tokens: number;
+  };
+}
+
+interface CodexTurnFailedEvent {
+  type: 'turn.failed';
+  error: { message: string };
+}
+
+interface CodexThreadErrorEvent {
+  type: 'error';
+  message: string;
+}
+
+interface CodexItemEvent {
+  type: 'item.started' | 'item.updated' | 'item.completed';
+  item: {
+    id: string;
+    type: string;
+    text?: string;
+    command?: string;
+    aggregated_output?: string;
+    exit_code?: number;
+    status?: string;
+    server?: string;
+    tool?: string;
+    arguments?: unknown;
+    result?: { content?: unknown[]; structured_content?: unknown };
+    error?: { message?: string };
+    query?: string;
+    changes?: Array<{ path: string; kind: string }>;
+    items?: Array<{ text: string; completed: boolean }>;
+  };
+}
+
+type CodexEvent =
+  | CodexThreadStartedEvent
+  | CodexTurnCompletedEvent
+  | CodexTurnFailedEvent
+  | CodexThreadErrorEvent
+  | CodexItemEvent
+  | { type: 'turn.started' };
+
+function toErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function mediaTypeToExtension(mediaType: string): string {
+  switch (mediaType) {
+    case 'image/jpeg':
+      return '.jpg';
+    case 'image/png':
+      return '.png';
+    case 'image/gif':
+      return '.gif';
+    case 'image/webp':
+      return '.webp';
+    default:
+      return '.img';
+  }
+}
+
+function toTokenUsage(event: CodexTurnCompletedEvent | null): TokenUsage | undefined {
+  if (!event) {
+    return undefined;
+  }
+  return {
+    input: event.usage.input_tokens + event.usage.cached_input_tokens,
+    output: event.usage.output_tokens,
+  };
+}
+
+function buildHistoryPreamble(existingMessages: Message[]): string {
+  const conversationMessages = existingMessages.filter(
+    (message) => message.role === 'user' || message.role === 'assistant'
+  );
+  const historyMessages = conversationMessages.length > 0 ? conversationMessages.slice(0, -1) : [];
+
+  const historyItems = historyMessages
+    .map((message) => {
+      const text = message.content
+        .filter((block) => block.type === 'text')
+        .map((block) => (block as { text: string }).text)
+        .join('\n')
+        .trim();
+      if (!text) {
+        return null;
+      }
+      return `<turn role="${message.role}">${text}</turn>`;
+    })
+    .filter((item): item is string => Boolean(item))
+    .slice(-12);
+
+  if (historyItems.length === 0) {
+    return '';
+  }
+
+  return `<conversation_history>\n${historyItems.join('\n')}\n</conversation_history>`;
+}
+
+function formatTodoList(items: Array<{ text: string; completed: boolean }> | undefined): string {
+  return (items || []).map((item) => `${item.completed ? '[x]' : '[ ]'} ${item.text}`).join('\n');
+}
+
+export class CodexAgentRunner {
+  private sendToRenderer: (event: ServerEvent) => void;
+  private saveMessage?: (message: Message) => void;
+  private updateSession?: (sessionId: string, updates: Partial<Session>) => void;
+  private activeControllers = new Map<string, AbortController>();
+  private activeProcesses = new Map<string, ChildProcessWithoutNullStreams>();
+
+  constructor(options: CodexAgentRunnerOptions) {
+    this.sendToRenderer = options.sendToRenderer;
+    this.saveMessage = options.saveMessage;
+    this.updateSession = options.updateSession;
+  }
+
+  clearSdkSession(_sessionId: string): void {
+    // No-op: Codex thread state is persisted by the CLI itself.
+  }
+
+  cancel(sessionId: string): void {
+    this.activeControllers.get(sessionId)?.abort();
+    this.activeProcesses.get(sessionId)?.kill();
+  }
+
+  async run(session: Session, prompt: string, existingMessages: Message[]): Promise<void> {
+    const controller = new AbortController();
+    this.activeControllers.set(session.id, controller);
+
+    const thinkingStepId = uuidv4();
+    let usageEvent: CodexTurnCompletedEvent | null = null;
+    const partialTextByItem = new Map<string, string>();
+    const imagePaths: string[] = [];
+
+    this.sendTraceStep(session.id, {
+      id: thinkingStepId,
+      type: 'thinking',
+      status: 'running',
+      title: 'Processing request...',
+      timestamp: Date.now(),
+    });
+
+    try {
+      const config = configStore.getAll();
+      const lastUserMessage = existingMessages[existingMessages.length - 1];
+      const workingDirectory = session.cwd || process.cwd();
+      const reasoningEffort = config.enableThinking ? 'medium' : undefined;
+      const historyPreamble = session.openaiThreadId ? '' : buildHistoryPreamble(existingMessages);
+      const input = historyPreamble ? `${historyPreamble}\n\n${prompt}` : prompt;
+
+      for (const block of lastUserMessage?.content || []) {
+        if (block.type !== 'image') {
+          continue;
+        }
+        imagePaths.push(this.writeTempImage(block));
+      }
+
+      const child = spawnCodexExecProcess({
+        codexPath: config.codexPath,
+        input,
+        threadId: session.openaiThreadId,
+        model: config.model || 'gpt-5-codex',
+        workingDirectory,
+        additionalDirectories: session.mountedPaths.map((mountedPath) => mountedPath.real),
+        imagePaths,
+        reasoningEffort,
+        signal: controller.signal,
+      });
+      this.activeProcesses.set(session.id, child);
+
+      const stderrChunks: Buffer[] = [];
+      child.stderr.on('data', (chunk) => stderrChunks.push(Buffer.from(chunk)));
+
+      const rl = readline.createInterface({ input: child.stdout, crlfDelay: Infinity });
+      try {
+        for await (const line of rl) {
+          if (!line.trim()) {
+            continue;
+          }
+          const event = JSON.parse(line) as CodexEvent;
+          if (event.type === 'thread.started') {
+            if (event.thread_id && event.thread_id !== session.openaiThreadId) {
+              session.openaiThreadId = event.thread_id;
+              this.updateSession?.(session.id, { openaiThreadId: event.thread_id });
+            }
+            continue;
+          }
+          if (event.type === 'turn.completed') {
+            usageEvent = event;
+            continue;
+          }
+          if (event.type === 'turn.failed') {
+            throw new Error(event.error.message);
+          }
+          if (event.type === 'error') {
+            throw new Error(event.message);
+          }
+          if (event.type === 'turn.started') {
+            continue;
+          }
+          this.handleItemEvent(session.id, event, partialTextByItem, () =>
+            toTokenUsage(usageEvent)
+          );
+        }
+      } finally {
+        rl.close();
+      }
+
+      const exitCode = await new Promise<number | null>((resolve, reject) => {
+        child.once('error', reject);
+        child.once('close', resolve);
+      });
+      if (exitCode !== 0 && !controller.signal.aborted) {
+        const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+        throw new Error(stderr || `Codex exited with code ${exitCode}`);
+      }
+
+      this.sendTraceUpdate(session.id, thinkingStepId, {
+        status: controller.signal.aborted ? 'completed' : 'completed',
+        title: controller.signal.aborted ? 'Cancelled' : 'Task completed',
+      });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        this.sendTraceUpdate(session.id, thinkingStepId, {
+          status: 'completed',
+          title: 'Cancelled',
+        });
+        return;
+      }
+
+      const finalErrorText = toErrorText(error);
+      this.sendMessage(session.id, {
+        id: uuidv4(),
+        sessionId: session.id,
+        role: 'assistant',
+        content: [{ type: 'text', text: `**Error**: ${finalErrorText}` }],
+        timestamp: Date.now(),
+      });
+      this.sendTraceUpdate(session.id, thinkingStepId, {
+        status: 'error',
+        title: 'Request failed',
+      });
+
+      if (error instanceof Error) {
+        (error as Error & { alreadyReportedToUser?: boolean }).alreadyReportedToUser = true;
+      }
+      throw error;
+    } finally {
+      for (const imagePath of imagePaths) {
+        try {
+          fs.unlinkSync(imagePath);
+        } catch {
+          // Ignore temp cleanup errors.
+        }
+      }
+      this.activeControllers.delete(session.id);
+      this.activeProcesses.delete(session.id);
+    }
+  }
+
+  private writeTempImage(block: ImageContent): string {
+    const filePath = path.join(
+      os.tmpdir(),
+      `open-cowork-codex-${Date.now()}-${Math.random().toString(36).slice(2)}${mediaTypeToExtension(block.source.media_type)}`
+    );
+    fs.writeFileSync(filePath, Buffer.from(block.source.data, 'base64'));
+    return filePath;
+  }
+
+  private handleItemEvent(
+    sessionId: string,
+    event: CodexItemEvent,
+    partialTextByItem: Map<string, string>,
+    getTokenUsage: () => TokenUsage | undefined
+  ): void {
+    const item = event.item;
+    switch (item.type) {
+      case 'agent_message': {
+        const nextText = item.text || '';
+        const previousText = partialTextByItem.get(item.id) || '';
+        if (nextText.startsWith(previousText) && nextText.length > previousText.length) {
+          this.sendPartial(sessionId, nextText.slice(previousText.length));
+        }
+        partialTextByItem.set(item.id, nextText);
+        if (event.type === 'item.completed' && nextText.trim()) {
+          this.sendPartial(sessionId, '');
+          this.sendMessage(sessionId, {
+            id: uuidv4(),
+            sessionId,
+            role: 'assistant',
+            content: [{ type: 'text', text: nextText }],
+            timestamp: Date.now(),
+            tokenUsage: getTokenUsage(),
+          });
+        }
+        break;
+      }
+      case 'reasoning': {
+        if (event.type === 'item.started') {
+          this.sendTraceStep(sessionId, {
+            id: item.id,
+            type: 'thinking',
+            status: 'running',
+            title: 'Reasoning',
+            content: item.text || '',
+            timestamp: Date.now(),
+          });
+        } else {
+          this.sendTraceUpdate(sessionId, item.id, {
+            status: event.type === 'item.completed' ? 'completed' : 'running',
+            content: item.text || '',
+          });
+        }
+        break;
+      }
+      case 'command_execution': {
+        const toolName = 'bash';
+        if (event.type === 'item.started') {
+          this.sendTraceStep(sessionId, {
+            id: item.id,
+            type: 'tool_call',
+            status: 'running',
+            title: item.command || 'Command execution',
+            toolName,
+            toolInput: item.command ? { command: item.command } : undefined,
+            timestamp: Date.now(),
+          });
+        } else {
+          this.sendTraceUpdate(sessionId, item.id, {
+            status:
+              event.type === 'item.completed'
+                ? item.status === 'failed'
+                  ? 'error'
+                  : 'completed'
+                : 'running',
+            toolOutput: item.aggregated_output?.slice(0, 800) || '',
+          });
+          if (event.type === 'item.completed') {
+            this.sendMessage(sessionId, {
+              id: uuidv4(),
+              sessionId,
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool_result',
+                  toolUseId: item.id,
+                  content: item.aggregated_output || '',
+                  isError: item.status === 'failed',
+                },
+              ],
+              timestamp: Date.now(),
+            });
+          }
+        }
+        break;
+      }
+      case 'mcp_tool_call': {
+        const title = `${item.server || 'MCP'} -> ${item.tool || 'tool'}`;
+        if (event.type === 'item.started') {
+          this.sendTraceStep(sessionId, {
+            id: item.id,
+            type: 'tool_call',
+            status: 'running',
+            title,
+            toolName: item.tool || 'mcp',
+            toolInput: item.arguments as Record<string, unknown> | undefined,
+            timestamp: Date.now(),
+          });
+        } else {
+          this.sendTraceUpdate(sessionId, item.id, {
+            status:
+              event.type === 'item.completed'
+                ? item.status === 'failed'
+                  ? 'error'
+                  : 'completed'
+                : 'running',
+            toolOutput: item.error?.message || '',
+          });
+        }
+        break;
+      }
+      case 'todo_list': {
+        const content = formatTodoList(item.items);
+        if (event.type === 'item.started') {
+          this.sendTraceStep(sessionId, {
+            id: item.id,
+            type: 'thinking',
+            status: 'running',
+            title: 'Plan',
+            content,
+            timestamp: Date.now(),
+          });
+        } else {
+          this.sendTraceUpdate(sessionId, item.id, {
+            status: event.type === 'item.completed' ? 'completed' : 'running',
+            content,
+          });
+        }
+        break;
+      }
+      case 'web_search': {
+        if (event.type === 'item.started') {
+          this.sendTraceStep(sessionId, {
+            id: item.id,
+            type: 'tool_call',
+            status: 'running',
+            title: item.query || 'Web search',
+            toolName: 'web_search',
+            timestamp: Date.now(),
+          });
+        } else {
+          this.sendTraceUpdate(sessionId, item.id, {
+            status: event.type === 'item.completed' ? 'completed' : 'running',
+          });
+        }
+        break;
+      }
+      case 'file_change': {
+        const summary = (item.changes || [])
+          .map((change) => `${change.kind}: ${change.path}`)
+          .join('\n');
+        if (event.type === 'item.started') {
+          this.sendTraceStep(sessionId, {
+            id: item.id,
+            type: 'text',
+            status: 'running',
+            title: 'Applying file changes',
+            content: summary,
+            timestamp: Date.now(),
+          });
+        } else {
+          this.sendTraceUpdate(sessionId, item.id, {
+            status:
+              event.type === 'item.completed'
+                ? item.status === 'failed'
+                  ? 'error'
+                  : 'completed'
+                : 'running',
+            content: summary,
+          });
+        }
+        break;
+      }
+      case 'error': {
+        this.sendTraceStep(sessionId, {
+          id: item.id,
+          type: 'thinking',
+          status: 'error',
+          title: 'Error occurred',
+          content: item.text || item.error?.message || '',
+          timestamp: Date.now(),
+        });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  private sendTraceStep(sessionId: string, step: TraceStep): void {
+    this.sendToRenderer({ type: 'trace.step', payload: { sessionId, step } });
+  }
+
+  private sendTraceUpdate(sessionId: string, stepId: string, updates: Partial<TraceStep>): void {
+    this.sendToRenderer({ type: 'trace.update', payload: { sessionId, stepId, updates } });
+  }
+
+  private sendMessage(sessionId: string, message: Message): void {
+    this.saveMessage?.(message);
+    this.sendToRenderer({ type: 'stream.message', payload: { sessionId, message } });
+  }
+
+  private sendPartial(sessionId: string, delta: string): void {
+    this.sendToRenderer({ type: 'stream.partial', payload: { sessionId, delta } });
+  }
+}

--- a/src/main/codex/codex-cli.ts
+++ b/src/main/codex/codex-cli.ts
@@ -1,0 +1,322 @@
+import { existsSync } from 'fs';
+import { homedir } from 'os';
+import { join, delimiter } from 'path';
+import { spawn, type ChildProcessWithoutNullStreams, type SpawnOptions } from 'child_process';
+
+const CODEX_INTERNAL_ORIGINATOR_OVERRIDE = 'CODEX_INTERNAL_ORIGINATOR_OVERRIDE';
+const OPEN_COWORK_ORIGINATOR = 'open_cowork';
+
+export interface CodexCommandResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  cliFound: boolean;
+}
+
+export interface CodexAuthStatus {
+  ok: boolean;
+  loggedIn: boolean;
+  cliFound: boolean;
+  message: string;
+  stdout?: string;
+  stderr?: string;
+}
+
+export interface CodexAuthActionResult {
+  ok: boolean;
+  cliFound: boolean;
+  message: string;
+  stdout?: string;
+  stderr?: string;
+}
+
+function buildCodexAuthActionMessage(
+  action: 'login' | 'device-login' | 'logout',
+  result: CodexCommandResult
+): string {
+  const combined = `${result.stdout}\n${result.stderr}`.trim();
+  if (combined) {
+    if (action === 'login' && /Timed out after/i.test(combined)) {
+      return `${combined} Browser login runs \`codex login\`. If the localhost callback does not complete on Windows, try \`codex login --device-auth\` instead and check \`codex-login.log\` for details.`;
+    }
+    return combined;
+  }
+
+  if (action === 'login') {
+    return 'Codex browser login finished. Manual terminal command: `codex login`. If the browser callback fails, use `codex login --device-auth` instead.';
+  }
+  if (action === 'device-login') {
+    return 'Codex device login finished. Manual terminal command: `codex login --device-auth`.';
+  }
+  return 'Codex logout finished. Manual terminal command: `codex logout`.';
+}
+
+export interface SpawnCodexExecOptions {
+  codexPath?: string;
+  input: string;
+  threadId?: string;
+  model?: string;
+  workingDirectory?: string;
+  additionalDirectories?: string[];
+  imagePaths?: string[];
+  reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+  signal?: AbortSignal;
+}
+
+function getDefaultCodexCandidates(): string[] {
+  const candidates = new Set<string>();
+  const appData = process.env.APPDATA?.trim();
+  const home = homedir();
+
+  if (process.platform === 'win32') {
+    if (appData) {
+      candidates.add(join(appData, 'npm', 'codex.cmd'));
+      candidates.add(join(appData, 'npm', 'codex'));
+    }
+    if (home) {
+      candidates.add(join(home, 'AppData', 'Roaming', 'npm', 'codex.cmd'));
+      candidates.add(join(home, 'AppData', 'Roaming', 'npm', 'codex'));
+    }
+  }
+
+  return Array.from(candidates);
+}
+
+function resolveCodexPath(codexPath?: string): string {
+  const explicitPath = codexPath?.trim();
+  if (explicitPath) {
+    return explicitPath;
+  }
+
+  for (const candidate of getDefaultCodexCandidates()) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return 'codex';
+}
+
+function buildCodexEnv(): NodeJS.ProcessEnv {
+  const pathEntries = new Set((process.env.PATH || '').split(delimiter).filter(Boolean));
+  for (const candidate of getDefaultCodexCandidates()) {
+    const lastSlash = Math.max(candidate.lastIndexOf('\\'), candidate.lastIndexOf('/'));
+    if (lastSlash > 0) {
+      pathEntries.add(candidate.slice(0, lastSlash));
+    }
+  }
+
+  return {
+    ...process.env,
+    PATH: Array.from(pathEntries).join(delimiter),
+    [CODEX_INTERNAL_ORIGINATOR_OVERRIDE]: OPEN_COWORK_ORIGINATOR,
+  };
+}
+
+function quoteForPowerShell(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function shouldUsePowerShellWrapper(commandPath: string): boolean {
+  return process.platform === 'win32' && /\.(cmd|bat)$/i.test(commandPath);
+}
+
+function spawnCodexChild(
+  commandPath: string,
+  args: string[],
+  options: SpawnOptions
+): ChildProcessWithoutNullStreams {
+  if (shouldUsePowerShellWrapper(commandPath)) {
+    const command = `& ${quoteForPowerShell(commandPath)}${args.length ? ` ${args.map(quoteForPowerShell).join(' ')}` : ''}`;
+    return spawn(
+      'powershell.exe',
+      ['-NoProfile', '-Command', command],
+      options
+    ) as ChildProcessWithoutNullStreams;
+  }
+
+  return spawn(commandPath, args, options) as ChildProcessWithoutNullStreams;
+}
+
+export function spawnCodexExecProcess(
+  options: SpawnCodexExecOptions
+): ChildProcessWithoutNullStreams {
+  const commandPath = resolveCodexPath(options.codexPath);
+  const args = ['exec', '--experimental-json'];
+
+  if (options.model?.trim()) {
+    args.push('--model', options.model.trim());
+  }
+  args.push('--sandbox', 'workspace-write');
+  args.push('--skip-git-repo-check');
+  args.push('--config', 'approval_policy="never"');
+  args.push('--config', 'sandbox_workspace_write.network_access=true');
+
+  if (options.reasoningEffort) {
+    args.push('--config', `model_reasoning_effort="${options.reasoningEffort}"`);
+  }
+  if (options.workingDirectory?.trim()) {
+    args.push('--cd', options.workingDirectory.trim());
+  }
+  for (const dir of options.additionalDirectories || []) {
+    if (dir.trim()) {
+      args.push('--add-dir', dir);
+    }
+  }
+  if (options.threadId?.trim()) {
+    args.push('resume', options.threadId.trim());
+  }
+  for (const imagePath of options.imagePaths || []) {
+    if (imagePath.trim()) {
+      args.push('--image', imagePath);
+    }
+  }
+
+  const child = spawnCodexChild(commandPath, args, {
+    cwd: options.workingDirectory?.trim() || process.cwd(),
+    env: buildCodexEnv(),
+    signal: options.signal,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  child.stdin.write(options.input);
+  child.stdin.end();
+  return child;
+}
+
+async function runCodexCommand(
+  args: string[],
+  options: { codexPath?: string; cwd?: string; timeoutMs?: number } = {}
+): Promise<CodexCommandResult> {
+  return new Promise((resolve) => {
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let settled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const commandPath = resolveCodexPath(options.codexPath);
+
+    const child = spawnCodexChild(commandPath, args, {
+      cwd: options.cwd || process.cwd(),
+      env: buildCodexEnv(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const finish = (result: CodexCommandResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      resolve(result);
+    };
+
+    child.stdout.on('data', (chunk) => stdoutChunks.push(Buffer.from(chunk)));
+    child.stderr.on('data', (chunk) => stderrChunks.push(Buffer.from(chunk)));
+
+    child.once('error', (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      finish({
+        code: null,
+        stdout: Buffer.concat(stdoutChunks).toString('utf8').trim(),
+        stderr: message,
+        cliFound: !/ENOENT/i.test(message),
+      });
+    });
+
+    child.once('close', (code) => {
+      finish({
+        code,
+        stdout: Buffer.concat(stdoutChunks).toString('utf8').trim(),
+        stderr: Buffer.concat(stderrChunks).toString('utf8').trim(),
+        cliFound: true,
+      });
+    });
+
+    const timeoutMs = options.timeoutMs ?? 15_000;
+    timeoutId = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        // Ignore kill errors on timeout.
+      }
+      finish({
+        code: null,
+        stdout: Buffer.concat(stdoutChunks).toString('utf8').trim(),
+        stderr: `Timed out after ${timeoutMs}ms`,
+        cliFound: true,
+      });
+    }, timeoutMs);
+  });
+}
+
+export async function getCodexAuthStatus(codexPath?: string): Promise<CodexAuthStatus> {
+  const result = await runCodexCommand(['login', 'status'], { codexPath, timeoutMs: 10_000 });
+
+  if (!result.cliFound) {
+    return {
+      ok: false,
+      loggedIn: false,
+      cliFound: false,
+      message: 'Codex CLI was not found. Install `@openai/codex` or set a Codex CLI path first.',
+      stderr: result.stderr,
+    };
+  }
+
+  if (result.code === 0) {
+    return {
+      ok: true,
+      loggedIn: true,
+      cliFound: true,
+      message: result.stdout || 'Codex CLI is signed in.',
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  }
+
+  const combined = `${result.stdout}\n${result.stderr}`.trim();
+  const apiKeyHint = /api key|api-key/i.test(combined)
+    ? ' If this Codex install is still in API-key mode, run `codex logout` and sign in again with ChatGPT.'
+    : '';
+
+  return {
+    ok: false,
+    loggedIn: false,
+    cliFound: true,
+    message: (combined || 'Codex CLI is not signed in.') + apiKeyHint,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+export async function runCodexAuthAction(
+  action: 'login' | 'device-login' | 'logout',
+  codexPath?: string
+): Promise<CodexAuthActionResult> {
+  const args =
+    action === 'logout'
+      ? ['logout']
+      : action === 'device-login'
+        ? ['login', '--device-auth']
+        : ['login'];
+  const timeoutMs = action === 'logout' ? 30_000 : 5 * 60_000;
+  const result = await runCodexCommand(args, { codexPath, timeoutMs });
+
+  if (!result.cliFound) {
+    return {
+      ok: false,
+      cliFound: false,
+      message: 'Codex CLI was not found. Install `@openai/codex` or set a Codex CLI path first.',
+      stderr: result.stderr,
+    };
+  }
+
+  return {
+    ok: result.code === 0,
+    cliFound: true,
+    message: buildCodexAuthActionMessage(action, result),
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}

--- a/src/main/codex/codex-models.ts
+++ b/src/main/codex/codex-models.ts
@@ -1,0 +1,128 @@
+import type { ProviderModelInfo } from '../../renderer/types';
+
+const CODEX_MODELS_DOCS_URL = 'https://developers.openai.com/codex/models';
+const CODEX_MODELS_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+const FALLBACK_CODEX_MODELS: ProviderModelInfo[] = [
+  { id: 'gpt-5.4', name: 'gpt-5.4' },
+  { id: 'gpt-5.4-mini', name: 'gpt-5.4-mini' },
+  { id: 'gpt-5.3-codex', name: 'gpt-5.3-codex' },
+  { id: 'gpt-5.3-codex-spark', name: 'gpt-5.3-codex-spark' },
+  { id: 'gpt-5.2-codex', name: 'gpt-5.2-codex' },
+  { id: 'gpt-5.2', name: 'gpt-5.2' },
+  { id: 'gpt-5.1-codex-max', name: 'gpt-5.1-codex-max' },
+  { id: 'gpt-5.1', name: 'gpt-5.1' },
+  { id: 'gpt-5.1-codex', name: 'gpt-5.1-codex' },
+  { id: 'gpt-5-codex', name: 'gpt-5-codex' },
+  { id: 'gpt-5-codex-mini', name: 'gpt-5-codex-mini' },
+  { id: 'gpt-5', name: 'gpt-5' },
+];
+
+const FALLBACK_CODEX_MODEL_IDS = FALLBACK_CODEX_MODELS.map((item) => item.id);
+
+let cachedCodexModels: ProviderModelInfo[] | null = null;
+let cachedCodexModelsAt = 0;
+
+function createTimeoutSignal(timeoutMs: number): AbortSignal {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  controller.signal.addEventListener('abort', () => clearTimeout(timeoutId), { once: true });
+  return controller.signal;
+}
+
+export function getFallbackCodexModels(): ProviderModelInfo[] {
+  return FALLBACK_CODEX_MODELS.map((item) => ({ ...item }));
+}
+
+export function extractCodexModelIds(source: string): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  const commandPattern = /codex\s+-m\s+(gpt-[a-z0-9.-]+)/gi;
+  const textPattern = /\b(gpt-(?:[a-z0-9]+(?:\.[a-z0-9]+)?(?:-[a-z0-9]+)*))\b/gi;
+
+  const addId = (candidate: string) => {
+    const normalized = candidate.trim().toLowerCase();
+    if (!normalized.startsWith('gpt-') || seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    ids.push(normalized);
+  };
+
+  for (const match of source.matchAll(commandPattern)) {
+    addId(match[1] || '');
+  }
+
+  if (ids.length < 4) {
+    for (const match of source.matchAll(textPattern)) {
+      addId(match[1] || '');
+    }
+  }
+
+  return ids;
+}
+
+function sortCodexModelIds(modelIds: string[]): string[] {
+  const fallbackOrder = new Map(FALLBACK_CODEX_MODEL_IDS.map((id, index) => [id, index]));
+  return [...modelIds].sort((left, right) => {
+    const leftIndex = fallbackOrder.get(left);
+    const rightIndex = fallbackOrder.get(right);
+
+    if (leftIndex !== undefined && rightIndex !== undefined) {
+      return leftIndex - rightIndex;
+    }
+    if (leftIndex !== undefined) {
+      return -1;
+    }
+    if (rightIndex !== undefined) {
+      return 1;
+    }
+    return left.localeCompare(right);
+  });
+}
+
+async function fetchOfficialCodexModels(timeoutMs: number): Promise<ProviderModelInfo[]> {
+  const response = await fetch(CODEX_MODELS_DOCS_URL, {
+    headers: { Accept: 'text/html, text/plain;q=0.9, */*;q=0.8' },
+    signal: createTimeoutSignal(timeoutMs),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Codex models docs request failed with status ${response.status}`);
+  }
+
+  const body = await response.text();
+  const extractedIds = sortCodexModelIds(extractCodexModelIds(body));
+  if (extractedIds.length < 4) {
+    throw new Error('Could not extract enough Codex model IDs from official docs');
+  }
+
+  return extractedIds.map((id) => ({ id, name: id }));
+}
+
+export async function listOfficialCodexModels(options?: {
+  forceRefresh?: boolean;
+  timeoutMs?: number;
+}): Promise<ProviderModelInfo[]> {
+  const forceRefresh = Boolean(options?.forceRefresh);
+  const timeoutMs = options?.timeoutMs ?? 12_000;
+  const now = Date.now();
+
+  if (!forceRefresh && cachedCodexModels && now - cachedCodexModelsAt < CODEX_MODELS_CACHE_TTL_MS) {
+    return cachedCodexModels.map((item) => ({ ...item }));
+  }
+
+  try {
+    const models = await fetchOfficialCodexModels(timeoutMs);
+    cachedCodexModels = models;
+    cachedCodexModelsAt = now;
+    return models.map((item) => ({ ...item }));
+  } catch {
+    const fallback = getFallbackCodexModels();
+    if (!cachedCodexModels) {
+      cachedCodexModels = fallback;
+      cachedCodexModelsAt = now;
+    }
+    return (cachedCodexModels || fallback).map((item) => ({ ...item }));
+  }
+}

--- a/src/main/config/config-store.ts
+++ b/src/main/config/config-store.ts
@@ -30,11 +30,19 @@ import {
   shouldUseAnthropicAuthToken,
 } from './auth-utils';
 import { API_PROVIDER_PRESETS, PI_AI_CURATED_PRESETS } from '../../shared/api-model-presets';
+import { listOfficialCodexModels } from '../codex/codex-models';
 
 /**
  * Application configuration schema
  */
-export type ProviderType = 'openrouter' | 'anthropic' | 'custom' | 'openai' | 'gemini' | 'ollama';
+export type ProviderType =
+  | 'openrouter'
+  | 'anthropic'
+  | 'custom'
+  | 'openai'
+  | 'gemini'
+  | 'ollama'
+  | 'codex_chatgpt';
 export type CustomProtocolType = 'anthropic' | 'openai' | 'gemini';
 export type AppTheme = 'dark' | 'light' | 'system';
 export type ProviderProfileKey =
@@ -43,6 +51,7 @@ export type ProviderProfileKey =
   | 'openai'
   | 'gemini'
   | 'ollama'
+  | 'codex_chatgpt'
   | 'custom:anthropic'
   | 'custom:openai'
   | 'custom:gemini';
@@ -100,6 +109,9 @@ export interface AppConfig {
   // Optional: Claude Code CLI path override
   claudeCodePath?: string;
 
+  // Optional: Codex CLI path override
+  codexPath?: string;
+
   // Optional: Default working directory
   defaultWorkdir?: string;
 
@@ -134,6 +146,7 @@ const DIRECT_READ_KEYS = new Set<keyof AppConfig>([
   'activeProfileKey',
   'activeConfigSetId',
   'claudeCodePath',
+  'codexPath',
   'defaultWorkdir',
   'globalSkillsPath',
   'enableDevLogs',
@@ -163,6 +176,11 @@ const defaultProfiles: Record<ProviderProfileKey, ProviderProfile> = {
     apiKey: '',
     baseUrl: 'http://localhost:11434/v1',
     model: '',
+  },
+  codex_chatgpt: {
+    apiKey: '',
+    baseUrl: '',
+    model: 'gpt-5.4',
   },
   gemini: {
     apiKey: '',
@@ -209,6 +227,7 @@ const defaultConfig: AppConfig = {
   activeConfigSetId: DEFAULT_CONFIG_SET_ID,
   configSets: [defaultConfigSet],
   claudeCodePath: '',
+  codexPath: '',
   defaultWorkdir: '',
   globalSkillsPath: '',
   enableDevLogs: true,
@@ -233,9 +252,14 @@ export async function getPiAiModelPresets(): Promise<typeof PROVIDER_PRESETS> {
   if (cachedDynamicPresets) return cachedDynamicPresets;
 
   try {
-    const { getModels } = await import('@mariozechner/pi-ai') as { getModels: (provider: string) => Array<{ id: string; name: string }> | undefined };
+    const { getModels } = (await import('@mariozechner/pi-ai')) as {
+      getModels: (provider: string) => Array<{ id: string; name: string }> | undefined;
+    };
 
-    const result = { ...PROVIDER_PRESETS } as Record<string, typeof PROVIDER_PRESETS[keyof typeof PROVIDER_PRESETS]>;
+    const result = { ...PROVIDER_PRESETS } as Record<
+      string,
+      (typeof PROVIDER_PRESETS)[keyof typeof PROVIDER_PRESETS]
+    >;
 
     for (const [providerKey, curated] of Object.entries(PI_AI_CURATED)) {
       const preset = PROVIDER_PRESETS[providerKey as keyof typeof PROVIDER_PRESETS];
@@ -244,11 +268,11 @@ export async function getPiAiModelPresets(): Promise<typeof PROVIDER_PRESETS> {
       const registryModels = getModels(curated.piProvider);
       if (!registryModels || registryModels.length === 0) continue;
 
-      const registryIds = new Set(registryModels.map(m => m.id));
+      const registryIds = new Set(registryModels.map((m) => m.id));
       const picked = curated.pick
-        .filter(id => registryIds.has(id))
-        .map(id => {
-          const reg = registryModels.find(m => m.id === id);
+        .filter((id) => registryIds.has(id))
+        .map((id) => {
+          const reg = registryModels.find((m) => m.id === id);
           return { id, name: reg?.name || id };
         });
 
@@ -256,6 +280,11 @@ export async function getPiAiModelPresets(): Promise<typeof PROVIDER_PRESETS> {
         result[providerKey] = { ...preset, models: picked };
       }
     }
+
+    result.codex_chatgpt = {
+      ...PROVIDER_PRESETS.codex_chatgpt,
+      models: await listOfficialCodexModels(),
+    };
 
     cachedDynamicPresets = result as unknown as typeof PROVIDER_PRESETS;
     return cachedDynamicPresets;
@@ -271,6 +300,7 @@ const PROFILE_KEYS: ProviderProfileKey[] = [
   'openai',
   'gemini',
   'ollama',
+  'codex_chatgpt',
   'custom:anthropic',
   'custom:openai',
   'custom:gemini',
@@ -278,7 +308,15 @@ const PROFILE_KEYS: ProviderProfileKey[] = [
 const VALID_THEMES: AppTheme[] = ['dark', 'light', 'system'];
 
 function isProviderType(value: unknown): value is ProviderType {
-  return value === 'openrouter' || value === 'anthropic' || value === 'custom' || value === 'openai' || value === 'gemini' || value === 'ollama';
+  return (
+    value === 'openrouter' ||
+    value === 'anthropic' ||
+    value === 'custom' ||
+    value === 'openai' ||
+    value === 'gemini' ||
+    value === 'ollama' ||
+    value === 'codex_chatgpt'
+  );
 }
 
 function isCustomProtocol(value: unknown): value is CustomProtocolType {
@@ -293,7 +331,10 @@ function isAppTheme(value: unknown): value is AppTheme {
   return typeof value === 'string' && VALID_THEMES.includes(value as AppTheme);
 }
 
-function profileKeyFromProvider(provider: ProviderType, customProtocol: CustomProtocolType = 'anthropic'): ProviderProfileKey {
+function profileKeyFromProvider(
+  provider: ProviderType,
+  customProtocol: CustomProtocolType = 'anthropic'
+): ProviderProfileKey {
   if (provider !== 'custom') {
     return provider;
   }
@@ -306,7 +347,10 @@ function profileKeyFromProvider(provider: ProviderType, customProtocol: CustomPr
   return 'custom:anthropic';
 }
 
-function profileKeyToProvider(profileKey: ProviderProfileKey): { provider: ProviderType; customProtocol: CustomProtocolType } {
+function profileKeyToProvider(profileKey: ProviderProfileKey): {
+  provider: ProviderType;
+  customProtocol: CustomProtocolType;
+} {
   if (profileKey === 'custom:openai') {
     return { provider: 'custom', customProtocol: 'openai' };
   }
@@ -324,6 +368,9 @@ function profileKeyToProvider(profileKey: ProviderProfileKey): { provider: Provi
   }
   if (profileKey === 'ollama') {
     return { provider: 'ollama', customProtocol: 'openai' };
+  }
+  if (profileKey === 'codex_chatgpt') {
+    return { provider: 'codex_chatgpt', customProtocol: 'openai' };
   }
   return { provider: profileKey, customProtocol: 'anthropic' };
 }
@@ -344,7 +391,10 @@ function nowISO(): string {
   return new Date().toISOString();
 }
 
-function normalizeCustomProtocol(value: CustomProtocolType | undefined, fallback: CustomProtocolType = 'anthropic'): CustomProtocolType {
+function normalizeCustomProtocol(
+  value: CustomProtocolType | undefined,
+  fallback: CustomProtocolType = 'anthropic'
+): CustomProtocolType {
   if (value === 'openai' || value === 'gemini') {
     return value;
   }
@@ -352,7 +402,7 @@ function normalizeCustomProtocol(value: CustomProtocolType | undefined, fallback
 }
 
 function defaultProtocolForProvider(provider: ProviderType): CustomProtocolType {
-  if (provider === 'openai' || provider === 'ollama') {
+  if (provider === 'openai' || provider === 'ollama' || provider === 'codex_chatgpt') {
     return 'openai';
   }
   if (provider === 'gemini') {
@@ -422,7 +472,7 @@ export class ConfigStore {
     if (orProfile?.model) {
       orProfile.model = orProfile.model.replace(
         /^(anthropic\/claude-(?:sonnet|opus|haiku)-\d+)-(\d+)/,
-        '$1.$2',
+        '$1.$2'
       );
     }
     // Also fix the flat model field (legacy compat)
@@ -444,17 +494,21 @@ export class ConfigStore {
     };
   }
 
-  private normalizeProfile(profileKey: ProviderProfileKey, profile: Partial<ProviderProfile> | undefined): ProviderProfile {
+  private normalizeProfile(
+    profileKey: ProviderProfileKey,
+    profile: Partial<ProviderProfile> | undefined
+  ): ProviderProfile {
     const fallback = this.getDefaultProfile(profileKey);
-    const model = typeof profile?.model === 'string' && profile.model.trim()
-      ? profile.model.trim()
-      : fallback.model;
-    const rawBaseUrl = typeof profile?.baseUrl === 'string' && profile.baseUrl.trim()
-      ? profile.baseUrl.trim()
-      : fallback.baseUrl;
-    const baseUrl = profileKey === 'ollama'
-      ? (normalizeOllamaBaseUrl(rawBaseUrl) || fallback.baseUrl)
-      : rawBaseUrl;
+    const model =
+      typeof profile?.model === 'string' && profile.model.trim()
+        ? profile.model.trim()
+        : fallback.model;
+    const rawBaseUrl =
+      typeof profile?.baseUrl === 'string' && profile.baseUrl.trim()
+        ? profile.baseUrl.trim()
+        : fallback.baseUrl;
+    const baseUrl =
+      profileKey === 'ollama' ? normalizeOllamaBaseUrl(rawBaseUrl) || fallback.baseUrl : rawBaseUrl;
     return {
       apiKey: typeof profile?.apiKey === 'string' ? profile.apiKey : '',
       baseUrl,
@@ -495,10 +549,18 @@ export class ConfigStore {
       if (typeof rawProfile.apiKey === 'string' && rawProfile.apiKey.trim()) {
         return true;
       }
-      if (typeof rawProfile.baseUrl === 'string' && rawProfile.baseUrl.trim() && rawProfile.baseUrl.trim() !== fallback.baseUrl) {
+      if (
+        typeof rawProfile.baseUrl === 'string' &&
+        rawProfile.baseUrl.trim() &&
+        rawProfile.baseUrl.trim() !== fallback.baseUrl
+      ) {
         return true;
       }
-      if (typeof rawProfile.model === 'string' && rawProfile.model.trim() && rawProfile.model.trim() !== fallback.model) {
+      if (
+        typeof rawProfile.model === 'string' &&
+        rawProfile.model.trim() &&
+        rawProfile.model.trim() !== fallback.model
+      ) {
         return true;
       }
       return false;
@@ -507,7 +569,9 @@ export class ConfigStore {
 
     let activeProfileKey: ProviderProfileKey = shouldUseLegacyProjection
       ? derivedProfileKey
-      : (isProfileKey(raw.activeProfileKey) ? raw.activeProfileKey : derivedProfileKey);
+      : isProfileKey(raw.activeProfileKey)
+        ? raw.activeProfileKey
+        : derivedProfileKey;
 
     const profiles = this.cloneProfiles(raw.profiles);
     const hasLegacyProjection =
@@ -525,8 +589,8 @@ export class ConfigStore {
     }
 
     if (
-      activeProfileKey === 'custom:openai'
-      && isOllamaLegacyCustomOpenAIConfig({
+      activeProfileKey === 'custom:openai' &&
+      isOllamaLegacyCustomOpenAIConfig({
         provider,
         customProtocol,
         baseUrl: profiles['custom:openai']?.baseUrl,
@@ -795,9 +859,15 @@ export class ConfigStore {
       profiles: projected.profiles,
       activeConfigSetId,
       configSets,
-      claudeCodePath: typeof raw.claudeCodePath === 'string' ? raw.claudeCodePath : defaultConfig.claudeCodePath,
-      defaultWorkdir: typeof raw.defaultWorkdir === 'string' ? raw.defaultWorkdir : defaultConfig.defaultWorkdir,
-      globalSkillsPath: typeof raw.globalSkillsPath === 'string' ? raw.globalSkillsPath : defaultConfig.globalSkillsPath,
+      claudeCodePath:
+        typeof raw.claudeCodePath === 'string' ? raw.claudeCodePath : defaultConfig.claudeCodePath,
+      codexPath: typeof raw.codexPath === 'string' ? raw.codexPath : defaultConfig.codexPath,
+      defaultWorkdir:
+        typeof raw.defaultWorkdir === 'string' ? raw.defaultWorkdir : defaultConfig.defaultWorkdir,
+      globalSkillsPath:
+        typeof raw.globalSkillsPath === 'string'
+          ? raw.globalSkillsPath
+          : defaultConfig.globalSkillsPath,
       enableDevLogs: toBoolean(raw.enableDevLogs, defaultConfig.enableDevLogs),
       theme: isAppTheme(raw.theme) ? raw.theme : defaultConfig.theme,
       sandboxEnabled: toBoolean(raw.sandboxEnabled, defaultConfig.sandboxEnabled),
@@ -824,7 +894,8 @@ export class ConfigStore {
     nextConfigSets: ApiConfigSet[],
     requestedActiveConfigSetId: string
   ): AppConfig {
-    const activeConfigSet = nextConfigSets.find((set) => set.id === requestedActiveConfigSetId) || nextConfigSets[0];
+    const activeConfigSet =
+      nextConfigSets.find((set) => set.id === requestedActiveConfigSetId) || nextConfigSets[0];
     const projected = this.projectFromConfigSet(activeConfigSet);
     return {
       ...base,
@@ -841,16 +912,18 @@ export class ConfigStore {
     };
   }
 
-  private buildUniqueConfigSetName(name: string, existingSets: ApiConfigSet[], excludeId?: string): string {
+  private buildUniqueConfigSetName(
+    name: string,
+    existingSets: ApiConfigSet[],
+    excludeId?: string
+  ): string {
     const trimmed = name.trim();
     if (!trimmed) {
       throw new Error('Config set name is required');
     }
 
     const usedNames = new Set(
-      existingSets
-        .filter((set) => set.id !== excludeId)
-        .map((set) => set.name)
+      existingSets.filter((set) => set.id !== excludeId).map((set) => set.name)
     );
 
     if (!usedNames.has(trimmed)) {
@@ -950,7 +1023,9 @@ export class ConfigStore {
     let newSet: ApiConfigSet;
 
     if (mode === 'blank') {
-      const activeSet = current.configSets.find((set) => set.id === current.activeConfigSetId) || current.configSets[0];
+      const activeSet =
+        current.configSets.find((set) => set.id === current.activeConfigSetId) ||
+        current.configSets[0];
       const seedProvider = activeSet?.provider || current.provider;
       const seedProtocol: CustomProtocolType = normalizeCustomProtocol(
         activeSet?.customProtocol,
@@ -963,9 +1038,10 @@ export class ConfigStore {
         customProtocol: seedProtocol,
       });
     } else {
-      const source = current.configSets.find((set) => set.id === payload.fromSetId)
-        || current.configSets.find((set) => set.id === current.activeConfigSetId)
-        || current.configSets[0];
+      const source =
+        current.configSets.find((set) => set.id === payload.fromSetId) ||
+        current.configSets.find((set) => set.id === current.activeConfigSetId) ||
+        current.configSets[0];
 
       if (!source) {
         throw new Error('Config set clone source not found');
@@ -1030,9 +1106,8 @@ export class ConfigStore {
       .map((set) => this.cloneConfigSet(set));
 
     const fallbackActive = nextSets.find((set) => set.isSystem)?.id || nextSets[0]?.id;
-    const nextActiveConfigSetId = current.activeConfigSetId === payload.id
-      ? fallbackActive
-      : current.activeConfigSetId;
+    const nextActiveConfigSetId =
+      current.activeConfigSetId === payload.id ? fallbackActive : current.activeConfigSetId;
 
     this.saveConfig(this.composeProjectedConfig(current, nextSets, nextActiveConfigSetId));
 
@@ -1060,7 +1135,10 @@ export class ConfigStore {
     if (Array.isArray(updates.configSets) && updates.configSets.length > 0) {
       const normalizedSets = this.normalizeConfigSets(updates.configSets, {
         provider: current.provider,
-        customProtocol: normalizeCustomProtocol(current.customProtocol, defaultProtocolForProvider(current.provider)),
+        customProtocol: normalizeCustomProtocol(
+          current.customProtocol,
+          defaultProtocolForProvider(current.provider)
+        ),
         activeProfileKey: current.activeProfileKey,
         profiles: this.cloneProfiles(current.profiles),
         enableThinking: current.enableThinking,
@@ -1068,15 +1146,17 @@ export class ConfigStore {
       nextConfigSets = normalizedSets;
     }
 
-    const requestedActiveConfigSetId = toNonEmptyString(updates.activeConfigSetId) || current.activeConfigSetId;
+    const requestedActiveConfigSetId =
+      toNonEmptyString(updates.activeConfigSetId) || current.activeConfigSetId;
     const activeConfigSetId = nextConfigSets.some((set) => set.id === requestedActiveConfigSetId)
       ? requestedActiveConfigSetId
       : nextConfigSets[0].id;
 
     const targetIndex = nextConfigSets.findIndex((set) => set.id === activeConfigSetId);
-    const targetSet = targetIndex >= 0
-      ? this.cloneConfigSet(nextConfigSets[targetIndex])
-      : this.cloneConfigSet(nextConfigSets[0]);
+    const targetSet =
+      targetIndex >= 0
+        ? this.cloneConfigSet(nextConfigSets[targetIndex])
+        : this.cloneConfigSet(nextConfigSets[0]);
 
     const nextProfiles = this.cloneProfiles(targetSet.profiles);
     let nextActiveProfileKey = targetSet.activeProfileKey;
@@ -1113,10 +1193,15 @@ export class ConfigStore {
       }
 
       if (updates.provider || updates.customProtocol) {
-        const requestedProvider = isProviderType(updates.provider) ? updates.provider : nextProvider;
-        const requestedProtocol = requestedProvider === 'custom'
-          ? (isCustomProtocol(updates.customProtocol) ? updates.customProtocol : nextCustomProtocol)
-          : defaultProtocolForProvider(requestedProvider);
+        const requestedProvider = isProviderType(updates.provider)
+          ? updates.provider
+          : nextProvider;
+        const requestedProtocol =
+          requestedProvider === 'custom'
+            ? isCustomProtocol(updates.customProtocol)
+              ? updates.customProtocol
+              : nextCustomProtocol
+            : defaultProtocolForProvider(requestedProvider);
         nextActiveProfileKey = profileKeyFromProvider(requestedProvider, requestedProtocol);
         const fromProfile = profileKeyToProvider(nextActiveProfileKey);
         nextProvider = fromProfile.provider;
@@ -1137,7 +1222,10 @@ export class ConfigStore {
         const model = updates.model?.trim();
         nextActiveProfile.model = model || this.getDefaultProfile(nextActiveProfileKey).model;
       }
-      nextProfiles[nextActiveProfileKey] = this.normalizeProfile(nextActiveProfileKey, nextActiveProfile);
+      nextProfiles[nextActiveProfileKey] = this.normalizeProfile(
+        nextActiveProfileKey,
+        nextActiveProfile
+      );
 
       const updatedSet: ApiConfigSet = {
         ...targetSet,
@@ -1145,7 +1233,8 @@ export class ConfigStore {
         customProtocol: nextCustomProtocol,
         activeProfileKey: nextActiveProfileKey,
         profiles: nextProfiles,
-        enableThinking: updates.enableThinking !== undefined ? updates.enableThinking : targetSet.enableThinking,
+        enableThinking:
+          updates.enableThinking !== undefined ? updates.enableThinking : targetSet.enableThinking,
         updatedAt: nowISO(),
       };
 
@@ -1157,13 +1246,22 @@ export class ConfigStore {
     const projectedConfig = this.composeProjectedConfig(current, nextConfigSets, activeConfigSetId);
     this.saveConfig({
       ...projectedConfig,
-      claudeCodePath: updates.claudeCodePath !== undefined ? updates.claudeCodePath : current.claudeCodePath,
-      defaultWorkdir: updates.defaultWorkdir !== undefined ? updates.defaultWorkdir : current.defaultWorkdir,
-      globalSkillsPath: updates.globalSkillsPath !== undefined ? updates.globalSkillsPath : current.globalSkillsPath,
-      enableDevLogs: updates.enableDevLogs !== undefined ? updates.enableDevLogs : current.enableDevLogs,
+      claudeCodePath:
+        updates.claudeCodePath !== undefined ? updates.claudeCodePath : current.claudeCodePath,
+      codexPath: updates.codexPath !== undefined ? updates.codexPath : current.codexPath,
+      defaultWorkdir:
+        updates.defaultWorkdir !== undefined ? updates.defaultWorkdir : current.defaultWorkdir,
+      globalSkillsPath:
+        updates.globalSkillsPath !== undefined
+          ? updates.globalSkillsPath
+          : current.globalSkillsPath,
+      enableDevLogs:
+        updates.enableDevLogs !== undefined ? updates.enableDevLogs : current.enableDevLogs,
       theme: updates.theme !== undefined ? updates.theme : current.theme,
-      sandboxEnabled: updates.sandboxEnabled !== undefined ? updates.sandboxEnabled : current.sandboxEnabled,
-      isConfigured: updates.isConfigured !== undefined ? updates.isConfigured : current.isConfigured,
+      sandboxEnabled:
+        updates.sandboxEnabled !== undefined ? updates.sandboxEnabled : current.sandboxEnabled,
+      isConfigured:
+        updates.isConfigured !== undefined ? updates.isConfigured : current.isConfigured,
     });
   }
 
@@ -1181,32 +1279,41 @@ export class ConfigStore {
     baseUrl?: string;
     model?: string;
   }): boolean {
-    if (projection.provider === 'ollama' && !(projection.model?.trim())) {
+    if (projection.provider === 'ollama' && !projection.model?.trim()) {
       return false;
+    }
+    if (projection.provider === 'codex_chatgpt') {
+      return Boolean(projection.model?.trim());
     }
     const apiKey = projection.apiKey?.trim();
     if (apiKey) {
       return true;
     }
-    if (shouldAllowEmptyAnthropicApiKey({
-      provider: projection.provider,
-      customProtocol: projection.customProtocol,
-      baseUrl: projection.baseUrl,
-    })) {
+    if (
+      shouldAllowEmptyAnthropicApiKey({
+        provider: projection.provider,
+        customProtocol: projection.customProtocol,
+        baseUrl: projection.baseUrl,
+      })
+    ) {
       return true;
     }
-    if (shouldAllowEmptyGeminiApiKey({
-      provider: projection.provider,
-      customProtocol: projection.customProtocol,
-      baseUrl: projection.baseUrl,
-    })) {
+    if (
+      shouldAllowEmptyGeminiApiKey({
+        provider: projection.provider,
+        customProtocol: projection.customProtocol,
+        baseUrl: projection.baseUrl,
+      })
+    ) {
       return true;
     }
-    if (shouldAllowEmptyOllamaApiKey({
-      provider: projection.provider,
-      customProtocol: projection.customProtocol,
-      baseUrl: projection.baseUrl,
-    })) {
+    if (
+      shouldAllowEmptyOllamaApiKey({
+        provider: projection.provider,
+        customProtocol: projection.customProtocol,
+        baseUrl: projection.baseUrl,
+      })
+    ) {
       return true;
     }
     const protocol: CustomProtocolType = normalizeCustomProtocol(
@@ -1302,6 +1409,26 @@ export class ConfigStore {
     delete process.env.CLAUDE_CODE_PATH;
     delete process.env.COWORK_WORKDIR;
 
+    if (projectedConfig.provider === 'codex_chatgpt') {
+      if (projectedConfig.defaultWorkdir) {
+        process.env.COWORK_WORKDIR = projectedConfig.defaultWorkdir;
+      }
+
+      log('[Config] Applied env vars for provider:', projectedConfig.provider, {
+        ANTHROPIC_API_KEY: '(unset)',
+        ANTHROPIC_AUTH_TOKEN: '(unset)',
+        ANTHROPIC_BASE_URL: '(unset)',
+        OPENAI_API_KEY: '(unset)',
+        OPENAI_BASE_URL: '(unset)',
+        OPENAI_MODEL: '(unset)',
+        OPENAI_API_MODE: '(unset)',
+        OPENAI_ACCOUNT_ID: '(unset)',
+        GEMINI_API_KEY: '(unset)',
+        GEMINI_BASE_URL: '(unset)',
+      });
+      return;
+    }
+
     const useOpenAI =
       projectedConfig.provider === 'openai' ||
       projectedConfig.provider === 'ollama' ||
@@ -1311,9 +1438,10 @@ export class ConfigStore {
       (projectedConfig.provider === 'custom' && projectedConfig.customProtocol === 'gemini');
 
     if (useOpenAI) {
-      const resolvedOpenAI = projectedConfig.provider === 'ollama'
-        ? resolveOllamaCredentials(projectedConfig)
-        : resolveOpenAICredentials(projectedConfig);
+      const resolvedOpenAI =
+        projectedConfig.provider === 'ollama'
+          ? resolveOllamaCredentials(projectedConfig)
+          : resolveOpenAICredentials(projectedConfig);
       if (resolvedOpenAI?.apiKey) {
         process.env.OPENAI_API_KEY = resolvedOpenAI.apiKey;
       }
@@ -1340,13 +1468,17 @@ export class ConfigStore {
         process.env.CLAUDE_MODEL = projectedConfig.model;
       }
     } else {
-      const effectiveAnthropicApiKey = projectedConfig.apiKey?.trim() || (
-        shouldAllowEmptyAnthropicApiKey(projectedConfig)
-          ? LOCAL_ANTHROPIC_PLACEHOLDER_KEY
-          : ''
-      );
-      if (projectedConfig.provider === 'anthropic' || (projectedConfig.provider === 'custom' && projectedConfig.customProtocol !== 'openai')) {
-        const useAuthToken = shouldUseAnthropicAuthToken({ ...projectedConfig, apiKey: effectiveAnthropicApiKey });
+      const effectiveAnthropicApiKey =
+        projectedConfig.apiKey?.trim() ||
+        (shouldAllowEmptyAnthropicApiKey(projectedConfig) ? LOCAL_ANTHROPIC_PLACEHOLDER_KEY : '');
+      if (
+        projectedConfig.provider === 'anthropic' ||
+        (projectedConfig.provider === 'custom' && projectedConfig.customProtocol !== 'openai')
+      ) {
+        const useAuthToken = shouldUseAnthropicAuthToken({
+          ...projectedConfig,
+          apiKey: effectiveAnthropicApiKey,
+        });
         if (effectiveAnthropicApiKey) {
           if (useAuthToken) {
             process.env.ANTHROPIC_AUTH_TOKEN = effectiveAnthropicApiKey;

--- a/src/main/config/config-test-routing.ts
+++ b/src/main/config/config-test-routing.ts
@@ -1,10 +1,22 @@
 import type { ApiTestInput, ApiTestResult } from '../../renderer/types';
 import type { AppConfig } from './config-store';
 import { probeWithClaudeSdk } from '../claude/claude-sdk-one-shot';
+import { getCodexAuthStatus } from '../codex/codex-cli';
 
 export async function runConfigApiTest(
   payload: ApiTestInput,
-  config: AppConfig,
+  config: AppConfig
 ): Promise<ApiTestResult> {
+  if (payload.provider === 'codex_chatgpt') {
+    const startedAt = Date.now();
+    const status = await getCodexAuthStatus(payload.codexPath || config.codexPath);
+    return {
+      ok: status.ok && status.loggedIn,
+      latencyMs: Date.now() - startedAt,
+      errorType: status.ok && status.loggedIn ? undefined : 'unknown',
+      details: status.message,
+    };
+  }
+
   return probeWithClaudeSdk(payload, config);
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,8 @@ import {
 } from './config/config-store';
 import { runConfigApiTest } from './config/config-test-routing';
 import { listOllamaModels } from './config/ollama-api';
+import { getCodexAuthStatus, runCodexAuthAction } from './codex/codex-cli';
+import { listOfficialCodexModels } from './codex/codex-models';
 import { mcpConfigStore } from './mcp/mcp-config-store';
 import { credentialsStore, type UserCredential } from './credentials/credentials-store';
 import { getSandboxAdapter, shutdownSandbox } from './sandbox/sandbox-adapter';
@@ -231,7 +233,8 @@ function buildMacMenu() {
         {
           label: 'Preferences…',
           accelerator: 'CmdOrCtrl+,',
-          click: () => mainWindow?.webContents.send('server-event', { type: 'navigate', payload: 'settings' }),
+          click: () =>
+            mainWindow?.webContents.send('server-event', { type: 'navigate', payload: 'settings' }),
         },
         { type: 'separator' },
         { role: 'services' },
@@ -267,12 +270,7 @@ function buildMacMenu() {
     },
     {
       label: 'Window',
-      submenu: [
-        { role: 'minimize' },
-        { role: 'close' },
-        { type: 'separator' },
-        { role: 'front' },
-      ],
+      submenu: [{ role: 'minimize' }, { role: 'close' }, { type: 'separator' }, { role: 'front' }],
     },
   ];
 
@@ -382,17 +380,18 @@ function createWindow() {
   const savedTheme = getSavedThemePreference();
   applyNativeThemePreference(savedTheme);
   const effectiveTheme = resolveEffectiveTheme(savedTheme);
-  const THEME = effectiveTheme === 'dark'
-    ? {
-        background: DARK_BG,
-        titleBar: DARK_BG,
-        titleBarSymbol: '#f1ece4',
-      }
-    : {
-        background: LIGHT_BG,
-        titleBar: LIGHT_BG,
-        titleBarSymbol: '#1a1a1a',
-      };
+  const THEME =
+    effectiveTheme === 'dark'
+      ? {
+          background: DARK_BG,
+          titleBar: DARK_BG,
+          titleBarSymbol: '#f1ece4',
+        }
+      : {
+          background: LIGHT_BG,
+          titleBar: LIGHT_BG,
+          titleBarSymbol: '#1a1a1a',
+        };
 
   // Platform-specific window configuration
   const isMac = process.platform === 'darwin';
@@ -677,7 +676,10 @@ async function startSandboxBootstrap(): Promise<void> {
 
 // 发送事件到渲染进程（含远程会话拦截）
 function sendToRenderer(event: ServerEvent) {
-  const payload = 'payload' in event ? (event.payload as { sessionId?: string; [key: string]: unknown }) : undefined;
+  const payload =
+    'payload' in event
+      ? (event.payload as { sessionId?: string; [key: string]: unknown })
+      : undefined;
   const sessionId = payload?.sessionId;
 
   // 判断是否远程会话
@@ -848,7 +850,8 @@ app
         },
         {
           label: 'Settings',
-          click: () => mainWindow?.webContents.send('server-event', { type: 'navigate', payload: 'settings' }),
+          click: () =>
+            mainWindow?.webContents.send('server-event', { type: 'navigate', payload: 'settings' }),
         },
       ]);
       app.dock?.setMenu(dockMenu);
@@ -870,26 +873,22 @@ app
         type: 'native-theme.changed',
         payload: { shouldUseDarkColors: nativeTheme.shouldUseDarkColors },
       });
-      if (
-        getSavedThemePreference() === 'system'
-        && mainWindow
-        && !mainWindow.isDestroyed()
-      ) {
-        mainWindow.setBackgroundColor(
-          nativeTheme.shouldUseDarkColors ? DARK_BG : LIGHT_BG
-        );
+      if (getSavedThemePreference() === 'system' && mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.setBackgroundColor(nativeTheme.shouldUseDarkColors ? DARK_BG : LIGHT_BG);
       }
     });
 
     // Auto-updater: check for updates in production
     if (!isDev) {
-      import('electron-updater').then(({ autoUpdater }) => {
-        autoUpdater.checkForUpdatesAndNotify().catch((err: unknown) => {
-          log('[AutoUpdater] Update check failed:', err);
+      import('electron-updater')
+        .then(({ autoUpdater }) => {
+          autoUpdater.checkForUpdatesAndNotify().catch((err: unknown) => {
+            log('[AutoUpdater] Update check failed:', err);
+          });
+        })
+        .catch((err: unknown) => {
+          log('[AutoUpdater] Failed to load electron-updater:', err);
         });
-      }).catch((err: unknown) => {
-        log('[AutoUpdater] Failed to load electron-updater:', err);
-      });
     }
 
     startNavServer(() => mainWindow);
@@ -996,7 +995,10 @@ let isCleaningUp = false;
 function withTimeout<T>(operation: Promise<T>, timeoutMs: number, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+      timeoutMs
+    );
   });
 
   return Promise.race([operation, timeoutPromise]).finally(() => {
@@ -1102,7 +1104,11 @@ app.on('before-quit', async (event) => {
     // In dev mode, exit quickly — no need for async sandbox cleanup
     if (process.env.VITE_DEV_SERVER_URL) {
       stopNavServer();
-      try { closeDatabase(); } catch { /* best-effort */ }
+      try {
+        closeDatabase();
+      } catch {
+        /* best-effort */
+      }
       closeLogFile();
       tray?.destroy();
       tray = null;
@@ -1491,16 +1497,45 @@ ipcMain.handle('config.test', async (_event, payload: ApiTestInput): Promise<Api
   }
 });
 
+ipcMain.handle('config.codexAuthStatus', async (_event, payload?: { codexPath?: string }) => {
+  try {
+    return await getCodexAuthStatus(payload?.codexPath || configStore.get('codexPath'));
+  } catch (error) {
+    logError('[Config] Codex auth status failed:', error);
+    return {
+      ok: false,
+      loggedIn: false,
+      cliFound: true,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+});
+
+ipcMain.handle('config.codexLogin', async (_event, payload?: { codexPath?: string }) => {
+  return runCodexAuthAction('login', payload?.codexPath || configStore.get('codexPath'));
+});
+
+ipcMain.handle('config.codexDeviceLogin', async (_event, payload?: { codexPath?: string }) => {
+  return runCodexAuthAction('device-login', payload?.codexPath || configStore.get('codexPath'));
+});
+
+ipcMain.handle('config.codexLogout', async (_event, payload?: { codexPath?: string }) => {
+  return runCodexAuthAction('logout', payload?.codexPath || configStore.get('codexPath'));
+});
+
 ipcMain.handle(
   'config.listModels',
   async (
     _event,
     payload: { provider: AppConfig['provider']; apiKey: string; baseUrl?: string }
   ): Promise<ProviderModelInfo[]> => {
-    if (payload.provider !== 'ollama') {
-      return [];
+    if (payload.provider === 'ollama') {
+      return listOllamaModels(payload);
     }
-    return listOllamaModels(payload);
+    if (payload.provider === 'codex_chatgpt') {
+      return listOfficialCodexModels({ forceRefresh: true });
+    }
+    return [];
   }
 );
 
@@ -1523,7 +1558,6 @@ ipcMain.handle('config.discover-local', async (_event, payload?: { baseUrl?: str
     return [];
   }
 });
-
 
 // MCP Server IPC handlers
 ipcMain.handle('mcp.getServers', () => {
@@ -1639,7 +1673,7 @@ ipcMain.handle('credentials.getByType', (_event, type: UserCredential['type']) =
   try {
     const creds = credentialsStore.getByType(type);
     // Strip password field before sending to renderer
-    return creds.map(c => ({ ...c, password: undefined }));
+    return creds.map((c) => ({ ...c, password: undefined }));
   } catch (error) {
     logError('[Credentials] Error getting credentials by type:', error);
     return [];
@@ -1650,7 +1684,7 @@ ipcMain.handle('credentials.getByService', (_event, service: string) => {
   try {
     const creds = credentialsStore.getByService(service);
     // Strip password field before sending to renderer
-    return creds.map(c => ({ ...c, password: undefined }));
+    return creds.map((c) => ({ ...c, password: undefined }));
   } catch (error) {
     logError('[Credentials] Error getting credentials by service:', error);
     return [];
@@ -1891,7 +1925,6 @@ ipcMain.handle('plugins.uninstall', async (_event, pluginId: string) => {
   }
 });
 
-
 // Window control IPC handlers
 ipcMain.on('window.minimize', () => {
   try {
@@ -1993,7 +2026,6 @@ ipcMain.handle('sandbox.installPythonInWSL', async (_event, distro: string) => {
   }
 });
 
-
 // Lima IPC handlers (macOS)
 ipcMain.handle('sandbox.checkLima', async () => {
   try {
@@ -2048,7 +2080,6 @@ ipcMain.handle('sandbox.installPythonInLima', async () => {
     return false;
   }
 });
-
 
 // Logs IPC handlers
 ipcMain.handle('logs.getPath', () => {
@@ -2688,18 +2719,16 @@ async function handleClientEvent(event: ClientEvent): Promise<unknown> {
 
     case 'settings.update':
       if (
-        event.payload.theme === 'dark'
-        || event.payload.theme === 'light'
-        || event.payload.theme === 'system'
+        event.payload.theme === 'dark' ||
+        event.payload.theme === 'light' ||
+        event.payload.theme === 'system'
       ) {
         const nextTheme = event.payload.theme as AppTheme;
         configStore.update({ theme: nextTheme });
         applyNativeThemePreference(nextTheme);
         if (mainWindow && !mainWindow.isDestroyed()) {
           const effectiveTheme = resolveEffectiveTheme(nextTheme);
-          mainWindow.setBackgroundColor(
-            effectiveTheme === 'dark' ? DARK_BG : LIGHT_BG
-          );
+          mainWindow.setBackgroundColor(effectiveTheme === 'dark' ? DARK_BG : LIGHT_BG);
         }
         sendToRenderer({
           type: 'config.status',

--- a/src/main/session/session-manager.ts
+++ b/src/main/session/session-manager.ts
@@ -14,17 +14,40 @@
 import { v4 as uuidv4 } from 'uuid';
 import * as fs from 'fs';
 import * as path from 'path';
-import type { Session, Message, ServerEvent, PermissionResult, ContentBlock, TextContent, TraceStep, FileAttachmentContent } from '../../renderer/types';
+import type {
+  Session,
+  Message,
+  ServerEvent,
+  PermissionResult,
+  ContentBlock,
+  TextContent,
+  TraceStep,
+  FileAttachmentContent,
+} from '../../renderer/types';
 import type { DatabaseInstance, TraceStepRow } from '../db/database';
 import { PathResolver } from '../sandbox/path-resolver';
-import { SandboxAdapter, getSandboxAdapter, initializeSandbox, reinitializeSandbox } from '../sandbox/sandbox-adapter';
+import {
+  SandboxAdapter,
+  getSandboxAdapter,
+  initializeSandbox,
+  reinitializeSandbox,
+} from '../sandbox/sandbox-adapter';
 import { SandboxSync } from '../sandbox/sandbox-sync';
 import { ClaudeAgentRunner } from '../claude/agent-runner';
+import { CodexAgentRunner } from '../codex/codex-agent-runner';
 import { configStore } from '../config/config-store';
 import { MCPManager } from '../mcp/mcp-manager';
 import { mcpConfigStore } from '../mcp/mcp-config-store';
 import { PluginRuntimeService } from '../skills/plugin-runtime-service';
-import { log, logError, logWarn, logCtx, logCtxError, runWithLogContext, generateTraceId } from '../utils/logger';
+import {
+  log,
+  logError,
+  logWarn,
+  logCtx,
+  logCtxError,
+  runWithLogContext,
+  generateTraceId,
+} from '../utils/logger';
 import { maybeGenerateSessionTitle } from './session-title-flow';
 import {
   buildTitlePrompt,
@@ -49,12 +72,17 @@ export class SessionManager {
   private pathResolver: PathResolver;
   private sandboxAdapter: SandboxAdapter;
   private agentRunner!: AgentRunner;
+  private codexRunner!: AgentRunner;
   private mcpManager: MCPManager;
   private pluginRuntimeService?: PluginRuntimeService;
   private activeSessions: Map<string, AbortController> = new Map();
-  private promptQueues: Map<string, Array<{ prompt: string; content?: ContentBlock[] }>> = new Map();
+  private promptQueues: Map<string, Array<{ prompt: string; content?: ContentBlock[] }>> =
+    new Map();
   private pendingPermissions: Map<string, (result: PermissionResult) => void> = new Map();
-  private pendingSudoPasswords: Map<string, { sessionId: string; resolve: (password: string | null) => void }> = new Map();
+  private pendingSudoPasswords: Map<
+    string,
+    { sessionId: string; resolve: (password: string | null) => void }
+  > = new Map();
   private sandboxInitPromises: Map<string, Promise<void>> = new Map();
   private sessionTitleAttempts: Set<string> = new Set();
   private titleGenerationTokens: Map<string, symbol> = new Map();
@@ -96,6 +124,7 @@ export class SessionManager {
    */
   private createAgentRunner(): void {
     this.agentRunner = this.createClaudeAgentRunner();
+    this.codexRunner = this.createCodexAgentRunner();
     log('[SessionManager] Using pi-coding-agent runner');
   }
 
@@ -104,6 +133,8 @@ export class SessionManager {
       {
         sendToRenderer: this.sendToRenderer,
         saveMessage: (message: Message) => this.saveMessage(message),
+        updateSession: (sessionId: string, updates: Partial<Session>) =>
+          this.updateSession(sessionId, updates),
         requestSudoPassword: (sessionId: string, toolUseId: string, command: string) =>
           this.requestSudoPassword(sessionId, toolUseId, command),
       },
@@ -111,6 +142,19 @@ export class SessionManager {
       this.mcpManager,
       this.pluginRuntimeService
     );
+  }
+
+  private createCodexAgentRunner(): CodexAgentRunner {
+    return new CodexAgentRunner({
+      sendToRenderer: this.sendToRenderer,
+      saveMessage: (message: Message) => this.saveMessage(message),
+      updateSession: (sessionId: string, updates: Partial<Session>) =>
+        this.updateSession(sessionId, updates),
+    });
+  }
+
+  private getActiveRunner(): AgentRunner {
+    return configStore.get('provider') === 'codex_chatgpt' ? this.codexRunner : this.agentRunner;
   }
 
   /**
@@ -183,7 +227,9 @@ export class SessionManager {
       logError('[SessionManager] Failed to initialize MCP servers:', error);
       this.sendToRenderer({
         type: 'error',
-        payload: { message: `Failed to initialize MCP servers: ${error instanceof Error ? error.message : String(error)}` },
+        payload: {
+          message: `Failed to initialize MCP servers: ${error instanceof Error ? error.message : String(error)}`,
+        },
       });
     }
   }
@@ -356,7 +402,11 @@ export class SessionManager {
   }
 
   // Continue an existing session
-  async continueSession(sessionId: string, prompt: string, content?: ContentBlock[]): Promise<void> {
+  async continueSession(
+    sessionId: string,
+    prompt: string,
+    content?: ContentBlock[]
+  ): Promise<void> {
     log('[SessionManager] Continuing session:', sessionId);
 
     const session = this.loadSession(sessionId);
@@ -412,7 +462,9 @@ export class SessionManager {
     const initPromise = initializeSandbox({
       workspacePath: session.cwd,
       mainWindow: null, // Will show dialogs globally
-    }).then(() => { /* void */ });
+    }).then(() => {
+      /* void */
+    });
 
     this.sandboxInitPromises.set(session.cwd, initPromise);
 
@@ -424,7 +476,9 @@ export class SessionManager {
       logError('[SessionManager] Failed to initialize sandbox:', error);
       this.sendToRenderer({
         type: 'error',
-        payload: { message: `Failed to initialize sandbox: ${error instanceof Error ? error.message : String(error)}` },
+        payload: {
+          message: `Failed to initialize sandbox: ${error instanceof Error ? error.message : String(error)}`,
+        },
       });
       // Continue anyway - sandbox adapter will fallback to native
     } finally {
@@ -433,7 +487,10 @@ export class SessionManager {
   }
 
   // Helper: Copy files to session's .tmp directory and sync to sandbox if needed
-  private async processFileAttachments(session: Session, content: ContentBlock[]): Promise<ContentBlock[]> {
+  private async processFileAttachments(
+    session: Session,
+    content: ContentBlock[]
+  ): Promise<ContentBlock[]> {
     const processedContent: ContentBlock[] = [];
 
     for (const block of content) {
@@ -464,14 +521,23 @@ export class SessionManager {
             const stats = fs.statSync(destPath);
             actualSize = stats.size;
 
-            log('[SessionManager] Copied file:', sourcePath, '->', destPath, `(${actualSize} bytes)`);
+            log(
+              '[SessionManager] Copied file:',
+              sourcePath,
+              '->',
+              destPath,
+              `(${actualSize} bytes)`
+            );
           } else if (fileBlock.inlineDataBase64) {
             const buffer = Buffer.from(fileBlock.inlineDataBase64, 'base64');
             fs.writeFileSync(destPath, buffer);
             actualSize = buffer.length;
             log('[SessionManager] Wrote file from inline data:', destPath, `(${actualSize} bytes)`);
           } else {
-            logError('[SessionManager] Source file not found and inline data missing:', sourcePath || '(empty path)');
+            logError(
+              '[SessionManager] Source file not found and inline data missing:',
+              sourcePath || '(empty path)'
+            );
             // Skip this file attachment
             continue;
           }
@@ -482,7 +548,11 @@ export class SessionManager {
           if (sandboxPath) {
             const sandboxRelativePath = `.tmp/${destFilename}`;
             log('[SessionManager] Syncing attached file to sandbox:', sandboxRelativePath);
-            const syncResult = await SandboxSync.syncFileToSandbox(session.id, destPath, sandboxRelativePath);
+            const syncResult = await SandboxSync.syncFileToSandbox(
+              session.id,
+              destPath,
+              sandboxRelativePath
+            );
             if (syncResult.success) {
               log('[SessionManager] File synced to sandbox:', syncResult.sandboxPath);
             } else {
@@ -496,7 +566,11 @@ export class SessionManager {
             if (limaSandboxPath) {
               const sandboxRelativePath = `.tmp/${destFilename}`;
               log('[SessionManager] Syncing attached file to Lima sandbox:', sandboxRelativePath);
-              const syncResult = await LimaSync.syncFileToSandbox(session.id, destPath, sandboxRelativePath);
+              const syncResult = await LimaSync.syncFileToSandbox(
+                session.id,
+                destPath,
+                sandboxRelativePath
+              );
               if (syncResult.success) {
                 log('[SessionManager] File synced to Lima sandbox:', syncResult.sandboxPath);
               } else {
@@ -519,7 +593,9 @@ export class SessionManager {
           logError('[SessionManager] Error copying file:', error);
           this.sendToRenderer({
             type: 'error',
-            payload: { message: `Failed to process file attachment: ${error instanceof Error ? error.message : String(error)}` },
+            payload: {
+              message: `Failed to process file attachment: ${error instanceof Error ? error.message : String(error)}`,
+            },
           });
           // Skip this file attachment
         }
@@ -533,98 +609,132 @@ export class SessionManager {
   }
 
   // Process a prompt using ClaudeAgentRunner
-  private async processPrompt(session: Session, prompt: string, content?: ContentBlock[]): Promise<void> {
+  private async processPrompt(
+    session: Session,
+    prompt: string,
+    content?: ContentBlock[]
+  ): Promise<void> {
     const traceId = generateTraceId();
     return runWithLogContext({ sessionId: session.id, traceId }, async () => {
-    logCtx('[SessionManager] Processing prompt for session:', session.id, 'traceId:', traceId);
-    logCtx('[SessionManager] Received content:', content ? JSON.stringify(content.map((c) => ({ type: c.type, hasData: !!(c as { source?: { data?: unknown } }).source?.data }))) : 'none');
-
-    // Ensure sandbox is initialized for this workspace
-    await this.ensureSandboxInitialized(session);
-
-    try {
-      // Use provided content blocks or fall back to simple text
-      let messageContent: ContentBlock[] = content && content.length > 0
-        ? content
-        : [{ type: 'text', text: prompt } as TextContent];
-
-      // Process file attachments - copy to .tmp directory
-      messageContent = await this.processFileAttachments(session, messageContent);
-
-      logCtx('[SessionManager] Final message content types:', messageContent.map((c) => c.type));
-
-      // Build enhanced prompt with file information
-      let enhancedPrompt = prompt;
-      const fileAttachments = messageContent.filter(c => c.type === 'file_attachment') as FileAttachmentContent[];
-      if (fileAttachments.length > 0) {
-        const fileInfo = fileAttachments.map(f =>
-          `- ${f.filename} (${(f.size / 1024).toFixed(1)} KB) at path: ${f.relativePath}`
-        ).join('\n');
-        enhancedPrompt = `${prompt}\n\n[Attached files - use Read tool to access them]:\n${fileInfo}`;
-        logCtx('[SessionManager] Enhanced prompt with file info:', enhancedPrompt);
-      }
-
-      // Save user message to database for persistence
-      const existingMessages = this.getMessages(session.id);
-      const userMessage: Message = {
-        id: uuidv4(),
-        sessionId: session.id,
-        role: 'user',
-        content: messageContent, // Save full content including images and files
-        timestamp: Date.now(),
-      };
-      this.saveMessage(userMessage);
-      logCtx('[SessionManager] User message saved:', userMessage.id, 'with', messageContent.length, 'content blocks');
-      const messagesForContext = [...existingMessages, userMessage];
-
-      // Update session model to match current config (may have changed since session creation)
-      const currentModel = configStore.get('model');
-      if (currentModel && currentModel !== session.model) {
-        session.model = currentModel;
-        this.db.sessions.update(session.id, { model: currentModel });
-        this.sendToRenderer({
-          type: 'session.update',
-          payload: { sessionId: session.id, updates: { model: currentModel } },
-        });
-      }
-
-      // Run the agent
-      await this.agentRunner.run(session, enhancedPrompt, messagesForContext);
-
-      // 标题生成不再与首轮对话并发，避免与主请求竞争同一上游配额/通道导致体感变慢。
-      this.runSessionTitleGeneration(session, prompt, existingMessages)
-        .catch(err => logCtxError('[SessionManager] Title generation failed:', err));
-    } catch (error) {
-      logCtxError('[SessionManager] Error processing prompt:', error);
-      const errorText = error instanceof Error ? error.message : 'Unknown error';
-      const alreadyReportedToUser = Boolean(
-        error &&
-        typeof error === 'object' &&
-        (error as { alreadyReportedToUser?: boolean }).alreadyReportedToUser
+      logCtx('[SessionManager] Processing prompt for session:', session.id, 'traceId:', traceId);
+      logCtx(
+        '[SessionManager] Received content:',
+        content
+          ? JSON.stringify(
+              content.map((c) => ({
+                type: c.type,
+                hasData: !!(c as { source?: { data?: unknown } }).source?.data,
+              }))
+            )
+          : 'none'
       );
-      if (!alreadyReportedToUser) {
-        const assistantMessage: Message = {
+
+      // Ensure sandbox is initialized for this workspace unless the active
+      // provider manages its own execution sandboxing.
+      if (configStore.get('provider') !== 'codex_chatgpt') {
+        await this.ensureSandboxInitialized(session);
+      }
+
+      try {
+        // Use provided content blocks or fall back to simple text
+        let messageContent: ContentBlock[] =
+          content && content.length > 0 ? content : [{ type: 'text', text: prompt } as TextContent];
+
+        // Process file attachments - copy to .tmp directory
+        messageContent = await this.processFileAttachments(session, messageContent);
+
+        logCtx(
+          '[SessionManager] Final message content types:',
+          messageContent.map((c) => c.type)
+        );
+
+        // Build enhanced prompt with file information
+        let enhancedPrompt = prompt;
+        const fileAttachments = messageContent.filter(
+          (c) => c.type === 'file_attachment'
+        ) as FileAttachmentContent[];
+        if (fileAttachments.length > 0) {
+          const fileInfo = fileAttachments
+            .map(
+              (f) => `- ${f.filename} (${(f.size / 1024).toFixed(1)} KB) at path: ${f.relativePath}`
+            )
+            .join('\n');
+          enhancedPrompt = `${prompt}\n\n[Attached files - use Read tool to access them]:\n${fileInfo}`;
+          logCtx('[SessionManager] Enhanced prompt with file info:', enhancedPrompt);
+        }
+
+        // Save user message to database for persistence
+        const existingMessages = this.getMessages(session.id);
+        const userMessage: Message = {
           id: uuidv4(),
           sessionId: session.id,
-          role: 'assistant',
-          content: [{ type: 'text', text: `**Error**: ${errorText}` }],
+          role: 'user',
+          content: messageContent, // Save full content including images and files
           timestamp: Date.now(),
         };
-        this.saveMessage(assistantMessage);
+        this.saveMessage(userMessage);
+        logCtx(
+          '[SessionManager] User message saved:',
+          userMessage.id,
+          'with',
+          messageContent.length,
+          'content blocks'
+        );
+        const messagesForContext = [...existingMessages, userMessage];
+
+        // Update session model to match current config (may have changed since session creation)
+        const currentModel = configStore.get('model');
+        if (currentModel && currentModel !== session.model) {
+          session.model = currentModel;
+          this.db.sessions.update(session.id, { model: currentModel });
+          this.sendToRenderer({
+            type: 'session.update',
+            payload: { sessionId: session.id, updates: { model: currentModel } },
+          });
+        }
+
+        // Run the agent
+        await this.getActiveRunner().run(session, enhancedPrompt, messagesForContext);
+
+        // 标题生成不再与首轮对话并发，避免与主请求竞争同一上游配额/通道导致体感变慢。
+        this.runSessionTitleGeneration(session, prompt, existingMessages).catch((err) =>
+          logCtxError('[SessionManager] Title generation failed:', err)
+        );
+      } catch (error) {
+        logCtxError('[SessionManager] Error processing prompt:', error);
+        const errorText = error instanceof Error ? error.message : 'Unknown error';
+        const alreadyReportedToUser = Boolean(
+          error &&
+          typeof error === 'object' &&
+          (error as { alreadyReportedToUser?: boolean }).alreadyReportedToUser
+        );
+        if (!alreadyReportedToUser) {
+          const assistantMessage: Message = {
+            id: uuidv4(),
+            sessionId: session.id,
+            role: 'assistant',
+            content: [{ type: 'text', text: `**Error**: ${errorText}` }],
+            timestamp: Date.now(),
+          };
+          this.saveMessage(assistantMessage);
+          this.sendToRenderer({
+            type: 'stream.message',
+            payload: { sessionId: session.id, message: assistantMessage },
+          });
+        }
         this.sendToRenderer({
-          type: 'stream.message',
-          payload: { sessionId: session.id, message: assistantMessage },
+          type: 'error',
+          payload: { message: errorText },
         });
       }
-      this.sendToRenderer({
-        type: 'error',
-        payload: { message: errorText },
-      });
-    }
     }); // end runWithLogContext
   }
 
-  private async runSessionTitleGeneration(session: Session, prompt: string, existingMessages: Message[]): Promise<void> {
+  private async runSessionTitleGeneration(
+    session: Session,
+    prompt: string,
+    existingMessages: Message[]
+  ): Promise<void> {
     const token = Symbol(`title:${session.id}`);
     this.titleGenerationTokens.set(session.id, token);
     const shouldAbort = () => {
@@ -676,7 +786,11 @@ export class SessionManager {
     }
   }
 
-  private async withTimeout<T>(promise: Promise<T>, timeoutMs: number, sessionId: string): Promise<T | null> {
+  private async withTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    sessionId: string
+  ): Promise<T | null> {
     return new Promise((resolve) => {
       const timer = setTimeout(() => {
         logError('[SessionTitle] Generation timed out', { sessionId, timeoutMs });
@@ -697,7 +811,9 @@ export class SessionManager {
 
   private async generateTitleWithConfig(titlePrompt: string, cwd?: string): Promise<string | null> {
     // Always use pi-ai SDK for title generation
-    return normalizeGeneratedTitle(await generateTitleWithClaudeSdk(titlePrompt, configStore.getAll(), cwd));
+    return normalizeGeneratedTitle(
+      await generateTitleWithClaudeSdk(titlePrompt, configStore.getAll(), cwd)
+    );
   }
 
   private enqueuePrompt(session: Session, prompt: string, content?: ContentBlock[]): void {
@@ -706,11 +822,13 @@ export class SessionManager {
     this.promptQueues.set(session.id, queue);
 
     if (!this.activeSessions.has(session.id)) {
-      this.processQueue(session).catch(err => {
+      this.processQueue(session).catch((err) => {
         logError('[SessionManager] Queue processing error:', err);
         this.sendToRenderer({
           type: 'error',
-          payload: { message: `Failed to process message: ${err instanceof Error ? err.message : String(err)}` },
+          payload: {
+            message: `Failed to process message: ${err instanceof Error ? err.message : String(err)}`,
+          },
         });
       });
     } else {
@@ -792,6 +910,7 @@ export class SessionManager {
     log('[SessionManager] Stopping session:', sessionId);
     this.titleGenerationTokens.delete(sessionId);
     this.agentRunner.cancel(sessionId);
+    this.codexRunner.cancel(sessionId);
     // Cancel any pending sudo password requests for this session
     for (const [toolUseId, entry] of this.pendingSudoPasswords) {
       if (entry.sessionId === sessionId) {
@@ -832,7 +951,7 @@ export class SessionManager {
     this.messageCache.delete(sessionId);
     this.sessionTitleAttempts.delete(sessionId);
     this.titleGenerationTokens.delete(sessionId);
-    
+
     log('[SessionManager] Session deleted:', sessionId);
   }
 
@@ -864,34 +983,63 @@ export class SessionManager {
     });
   }
 
+  private updateSession(sessionId: string, updates: Partial<Session>): void {
+    if (!this.db.sessions.get(sessionId)) {
+      return;
+    }
+
+    const dbUpdates: Record<string, unknown> = { updated_at: Date.now() };
+    if (updates.title !== undefined) dbUpdates.title = updates.title;
+    if (updates.status !== undefined) dbUpdates.status = updates.status;
+    if (updates.cwd !== undefined) dbUpdates.cwd = updates.cwd;
+    if (updates.model !== undefined) dbUpdates.model = updates.model;
+    if (updates.claudeSessionId !== undefined)
+      dbUpdates.claude_session_id = updates.claudeSessionId;
+    if (updates.openaiThreadId !== undefined) dbUpdates.openai_thread_id = updates.openaiThreadId;
+    if (updates.mountedPaths !== undefined)
+      dbUpdates.mounted_paths = JSON.stringify(updates.mountedPaths);
+    if (updates.allowedTools !== undefined)
+      dbUpdates.allowed_tools = JSON.stringify(updates.allowedTools);
+    if (updates.memoryEnabled !== undefined)
+      dbUpdates.memory_enabled = updates.memoryEnabled ? 1 : 0;
+
+    this.db.sessions.update(sessionId, dbUpdates);
+    this.sendToRenderer({
+      type: 'session.update',
+      payload: { sessionId, updates },
+    });
+  }
+
   // Update session's working directory
   // Also clears SDK session cache because Claude SDK sessions are bound to cwd
   updateSessionCwd(sessionId: string, cwd: string): void {
     if (this.activeSessions.has(sessionId)) {
-      logWarn('[SessionManager] CWD change requested while session running; stopping active run first', { sessionId, cwd });
+      logWarn(
+        '[SessionManager] CWD change requested while session running; stopping active run first',
+        { sessionId, cwd }
+      );
       this.stopSession(sessionId);
     }
     const mountedPaths = this.buildMountedPaths(cwd);
     // Clear claude_session_id in DB so next query creates a new SDK session
     // (Claude SDK sessions cannot change cwd mid-session)
-    this.db.sessions.update(sessionId, { 
-      cwd, 
+    this.db.sessions.update(sessionId, {
+      cwd,
       mounted_paths: JSON.stringify(mountedPaths),
       claude_session_id: null,
       openai_thread_id: null,
-      updated_at: Date.now() 
+      updated_at: Date.now(),
     });
-    
+
     // Also clear the in-memory SDK session cache
-    if (this.agentRunner?.clearSdkSession) {
-      this.agentRunner.clearSdkSession(sessionId);
-    }
+    this.agentRunner?.clearSdkSession?.(sessionId);
+    this.codexRunner?.clearSdkSession?.(sessionId);
 
     this.sendToRenderer({
       type: 'session.update',
       payload: { sessionId, updates: { cwd, mountedPaths } },
     });
-    
+
     log('[SessionManager] Session cwd updated:', sessionId, '->', cwd, '(SDK session cleared)');
   }
 
@@ -919,7 +1067,7 @@ export class SessionManager {
         if (firstKey) this.messageCache.delete(firstKey);
       }
     }
-    
+
     log('[SessionManager] Message saved:', message.id, 'role:', message.role);
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -18,6 +18,9 @@ import type {
   ScheduleUpdateInput,
   ProviderModelInfo,
   LocalOllamaDiscoveryResult,
+  CodexAuthStatus,
+  CodexAuthActionResult,
+  ListModelsInput,
 } from '../renderer/types';
 import type { DiagnosticInput, DiagnosticResult } from '../renderer/types';
 import type {
@@ -56,7 +59,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       console.log('[Preload] Removing previous listener');
       ipcRenderer.removeListener('server-event', ipcListener);
     }
-    
+
     registeredCallback = callback;
     ipcListener = (_: Electron.IpcRendererEvent, data: ServerEvent) => {
       console.log('[Preload] Received event:', data.type);
@@ -64,10 +67,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
         registeredCallback(data);
       }
     };
-    
+
     console.log('[Preload] Registering new listener');
     ipcRenderer.on('server-event', ipcListener);
-    
+
     // Return cleanup function
     return () => {
       console.log('[Preload] Cleanup called');
@@ -96,7 +99,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Open links in default browser
   openExternal: (url: string) => ipcRenderer.invoke('shell.openExternal', url),
-  showItemInFolder: (filePath: string, cwd?: string) => ipcRenderer.invoke('shell.showItemInFolder', filePath, cwd),
+  showItemInFolder: (filePath: string, cwd?: string) =>
+    ipcRenderer.invoke('shell.showItemInFolder', filePath, cwd),
 
   // Select files using native dialog
   selectFiles: (): Promise<string[]> => ipcRenderer.invoke('dialog.selectFiles'),
@@ -114,11 +118,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   config: {
     get: (): Promise<AppConfig> => ipcRenderer.invoke('config.get'),
     getPresets: (): Promise<ProviderPresets> => ipcRenderer.invoke('config.getPresets'),
-    save: (config: Partial<AppConfig>): Promise<{ success: boolean; config: AppConfig }> => 
+    save: (config: Partial<AppConfig>): Promise<{ success: boolean; config: AppConfig }> =>
       ipcRenderer.invoke('config.save', config),
     createSet: (payload: CreateSetPayload): Promise<{ success: boolean; config: AppConfig }> =>
       ipcRenderer.invoke('config.createSet', payload),
-    renameSet: (payload: { id: string; name: string }): Promise<{ success: boolean; config: AppConfig }> =>
+    renameSet: (payload: {
+      id: string;
+      name: string;
+    }): Promise<{ success: boolean; config: AppConfig }> =>
       ipcRenderer.invoke('config.renameSet', payload),
     deleteSet: (payload: { id: string }): Promise<{ success: boolean; config: AppConfig }> =>
       ipcRenderer.invoke('config.deleteSet', payload),
@@ -127,7 +134,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
     isConfigured: (): Promise<boolean> => ipcRenderer.invoke('config.isConfigured'),
     test: (config: ApiTestInput): Promise<ApiTestResult> =>
       ipcRenderer.invoke('config.test', config),
-    listModels: (payload: { provider: AppConfig['provider']; apiKey: string; baseUrl?: string }): Promise<ProviderModelInfo[]> =>
+    getCodexAuthStatus: (codexPath?: string): Promise<CodexAuthStatus> =>
+      ipcRenderer.invoke('config.codexAuthStatus', { codexPath }),
+    codexLogin: (codexPath?: string): Promise<CodexAuthActionResult> =>
+      ipcRenderer.invoke('config.codexLogin', { codexPath }),
+    codexDeviceLogin: (codexPath?: string): Promise<CodexAuthActionResult> =>
+      ipcRenderer.invoke('config.codexDeviceLogin', { codexPath }),
+    codexLogout: (codexPath?: string): Promise<CodexAuthActionResult> =>
+      ipcRenderer.invoke('config.codexLogout', { codexPath }),
+    listModels: (payload: ListModelsInput): Promise<ProviderModelInfo[]> =>
       ipcRenderer.invoke('config.listModels', payload),
     diagnose: (input: DiagnosticInput): Promise<DiagnosticResult> =>
       ipcRenderer.invoke('config.diagnose', input),
@@ -145,7 +160,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // MCP methods
   mcp: {
     getServers: (): Promise<McpServerConfig[]> => ipcRenderer.invoke('mcp.getServers'),
-    getServer: (serverId: string): Promise<McpServerConfig | undefined> => ipcRenderer.invoke('mcp.getServer', serverId),
+    getServer: (serverId: string): Promise<McpServerConfig | undefined> =>
+      ipcRenderer.invoke('mcp.getServer', serverId),
     saveServer: (config: McpServerConfig): Promise<{ success: boolean }> =>
       ipcRenderer.invoke('mcp.saveServer', config),
     deleteServer: (serverId: string): Promise<{ success: boolean }> =>
@@ -161,11 +177,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // so the renderer process never has access to plaintext passwords.
   credentials: {
     getAll: (): Promise<CredentialRecord[]> => ipcRenderer.invoke('credentials.getAll'),
-    getById: (id: string): Promise<CredentialRecord | undefined> => ipcRenderer.invoke('credentials.getById', id),
-    getByType: (type: string): Promise<CredentialRecord[]> => ipcRenderer.invoke('credentials.getByType', type),
-    getByService: (service: string): Promise<CredentialRecord[]> => ipcRenderer.invoke('credentials.getByService', service),
-    save: (credential: CredentialSaveInput): Promise<CredentialRecord> => ipcRenderer.invoke('credentials.save', credential),
-    update: (id: string, updates: CredentialUpdateInput): Promise<CredentialRecord | undefined> => ipcRenderer.invoke('credentials.update', id, updates),
+    getById: (id: string): Promise<CredentialRecord | undefined> =>
+      ipcRenderer.invoke('credentials.getById', id),
+    getByType: (type: string): Promise<CredentialRecord[]> =>
+      ipcRenderer.invoke('credentials.getByType', type),
+    getByService: (service: string): Promise<CredentialRecord[]> =>
+      ipcRenderer.invoke('credentials.getByService', service),
+    save: (credential: CredentialSaveInput): Promise<CredentialRecord> =>
+      ipcRenderer.invoke('credentials.save', credential),
+    update: (id: string, updates: CredentialUpdateInput): Promise<CredentialRecord | undefined> =>
+      ipcRenderer.invoke('credentials.update', id, updates),
     delete: (id: string): Promise<boolean> => ipcRenderer.invoke('credentials.delete', id),
   },
 
@@ -180,13 +201,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('skills.setEnabled', skillId, enabled),
     validate: (skillPath: string): Promise<{ valid: boolean; errors: string[] }> =>
       ipcRenderer.invoke('skills.validate', skillPath),
-    getStoragePath: (): Promise<string> =>
-      ipcRenderer.invoke('skills.getStoragePath'),
+    getStoragePath: (): Promise<string> => ipcRenderer.invoke('skills.getStoragePath'),
     setStoragePath: (
       targetPath: string,
       migrate = true
-    ): Promise<{ success: boolean; path: string; migratedCount: number; skippedCount: number; error?: string }> =>
-      ipcRenderer.invoke('skills.setStoragePath', targetPath, migrate),
+    ): Promise<{
+      success: boolean;
+      path: string;
+      migratedCount: number;
+      skippedCount: number;
+      error?: string;
+    }> => ipcRenderer.invoke('skills.setStoragePath', targetPath, migrate),
     openStoragePath: (): Promise<{ success: boolean; path: string; error?: string }> =>
       ipcRenderer.invoke('skills.openStoragePath'),
   },
@@ -194,8 +219,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   plugins: {
     listCatalog: (options?: { installableOnly?: boolean }): Promise<PluginCatalogItemV2[]> =>
       ipcRenderer.invoke('plugins.listCatalog', options),
-    listInstalled: (): Promise<InstalledPlugin[]> =>
-      ipcRenderer.invoke('plugins.listInstalled'),
+    listInstalled: (): Promise<InstalledPlugin[]> => ipcRenderer.invoke('plugins.listInstalled'),
     install: (pluginName: string): Promise<PluginInstallResultV2> =>
       ipcRenderer.invoke('plugins.install', pluginName),
     setEnabled: (pluginId: string, enabled: boolean): Promise<PluginToggleResult> =>
@@ -204,7 +228,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       pluginId: string,
       component: PluginComponentKind,
       enabled: boolean
-    ): Promise<PluginToggleResult> => ipcRenderer.invoke('plugins.setComponentEnabled', pluginId, component, enabled),
+    ): Promise<PluginToggleResult> =>
+      ipcRenderer.invoke('plugins.setComponentEnabled', pluginId, component, enabled),
     uninstall: (pluginId: string): Promise<{ success: boolean }> =>
       ipcRenderer.invoke('plugins.uninstall', pluginId),
   },
@@ -215,10 +240,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       platform: string;
       mode: string;
       initialized: boolean;
-      wsl?: { 
-        available: boolean; 
-        distro?: string; 
-        nodeAvailable?: boolean; 
+      wsl?: {
+        available: boolean;
+        distro?: string;
+        nodeAvailable?: boolean;
         version?: string;
         pythonAvailable?: boolean;
         pythonVersion?: string;
@@ -261,18 +286,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
       pipAvailable?: boolean;
       claudeCodeAvailable?: boolean;
     }> => ipcRenderer.invoke('sandbox.checkLima'),
-    installNodeInWSL: (distro: string): Promise<boolean> => 
+    installNodeInWSL: (distro: string): Promise<boolean> =>
       ipcRenderer.invoke('sandbox.installNodeInWSL', distro),
     installPythonInWSL: (distro: string): Promise<boolean> =>
       ipcRenderer.invoke('sandbox.installPythonInWSL', distro),
-    installNodeInLima: (): Promise<boolean> =>
-      ipcRenderer.invoke('sandbox.installNodeInLima'),
-    installPythonInLima: (): Promise<boolean> =>
-      ipcRenderer.invoke('sandbox.installPythonInLima'),
-    startLimaInstance: (): Promise<boolean> =>
-      ipcRenderer.invoke('sandbox.startLimaInstance'),
-    stopLimaInstance: (): Promise<boolean> =>
-      ipcRenderer.invoke('sandbox.stopLimaInstance'),
+    installNodeInLima: (): Promise<boolean> => ipcRenderer.invoke('sandbox.installNodeInLima'),
+    installPythonInLima: (): Promise<boolean> => ipcRenderer.invoke('sandbox.installPythonInLima'),
+    startLimaInstance: (): Promise<boolean> => ipcRenderer.invoke('sandbox.startLimaInstance'),
+    stopLimaInstance: (): Promise<boolean> => ipcRenderer.invoke('sandbox.stopLimaInstance'),
     retrySetup: (): Promise<{ success: boolean; error?: string; result?: unknown }> =>
       ipcRenderer.invoke('sandbox.retrySetup'),
     retryLimaSetup: (): Promise<{ success: boolean; error?: string; result?: unknown }> =>
@@ -283,19 +304,23 @@ contextBridge.exposeInMainWorld('electronAPI', {
   logs: {
     getPath: (): Promise<string | null> => ipcRenderer.invoke('logs.getPath'),
     getDirectory: (): Promise<string> => ipcRenderer.invoke('logs.getDirectory'),
-    getAll: (): Promise<Array<{ name: string; path: string; size: number; mtime: Date }>> => 
+    getAll: (): Promise<Array<{ name: string; path: string; size: number; mtime: Date }>> =>
       ipcRenderer.invoke('logs.getAll'),
-    export: (): Promise<{ success: boolean; path?: string; size?: number; error?: string }> => 
+    export: (): Promise<{ success: boolean; path?: string; size?: number; error?: string }> =>
       ipcRenderer.invoke('logs.export'),
-    open: (): Promise<{ success: boolean; error?: string }> => 
-      ipcRenderer.invoke('logs.open'),
-    clear: (): Promise<{ success: boolean; deletedCount?: number; error?: string }> => 
+    open: (): Promise<{ success: boolean; error?: string }> => ipcRenderer.invoke('logs.open'),
+    clear: (): Promise<{ success: boolean; deletedCount?: number; error?: string }> =>
       ipcRenderer.invoke('logs.clear'),
-    setEnabled: (enabled: boolean): Promise<{ success: boolean; enabled?: boolean; error?: string }> =>
+    setEnabled: (
+      enabled: boolean
+    ): Promise<{ success: boolean; enabled?: boolean; error?: string }> =>
       ipcRenderer.invoke('logs.setEnabled', enabled),
     isEnabled: (): Promise<{ success: boolean; enabled?: boolean; error?: string }> =>
       ipcRenderer.invoke('logs.isEnabled'),
-    write: (level: 'info' | 'warn' | 'error', ...args: unknown[]): Promise<{ success: boolean; error?: string }> =>
+    write: (
+      level: 'info' | 'warn' | 'error',
+      ...args: unknown[]
+    ): Promise<{ success: boolean; error?: string }> =>
       ipcRenderer.invoke('logs.write', level, args),
   },
 
@@ -312,17 +337,29 @@ contextBridge.exposeInMainWorld('electronAPI', {
     }> => ipcRenderer.invoke('remote.getStatus'),
     setEnabled: (enabled: boolean): Promise<{ success: boolean; error?: string }> =>
       ipcRenderer.invoke('remote.setEnabled', enabled),
-    updateGatewayConfig: (config: Partial<GatewayConfig>): Promise<{ success: boolean; error?: string }> =>
+    updateGatewayConfig: (
+      config: Partial<GatewayConfig>
+    ): Promise<{ success: boolean; error?: string }> =>
       ipcRenderer.invoke('remote.updateGatewayConfig', config),
-    updateFeishuConfig: (config: FeishuChannelConfig): Promise<{ success: boolean; error?: string }> =>
+    updateFeishuConfig: (
+      config: FeishuChannelConfig
+    ): Promise<{ success: boolean; error?: string }> =>
       ipcRenderer.invoke('remote.updateFeishuConfig', config),
     getPairedUsers: (): Promise<PairedUser[]> => ipcRenderer.invoke('remote.getPairedUsers'),
-    getPendingPairings: (): Promise<PairingRequest[]> => ipcRenderer.invoke('remote.getPendingPairings'),
-    approvePairing: (channelType: string, userId: string): Promise<{ success: boolean; error?: string }> =>
+    getPendingPairings: (): Promise<PairingRequest[]> =>
+      ipcRenderer.invoke('remote.getPendingPairings'),
+    approvePairing: (
+      channelType: string,
+      userId: string
+    ): Promise<{ success: boolean; error?: string }> =>
       ipcRenderer.invoke('remote.approvePairing', channelType, userId),
-    revokePairing: (channelType: string, userId: string): Promise<{ success: boolean; error?: string }> =>
+    revokePairing: (
+      channelType: string,
+      userId: string
+    ): Promise<{ success: boolean; error?: string }> =>
       ipcRenderer.invoke('remote.revokePairing', channelType, userId),
-    getRemoteSessions: (): Promise<RemoteSessionMapping[]> => ipcRenderer.invoke('remote.getRemoteSessions'),
+    getRemoteSessions: (): Promise<RemoteSessionMapping[]> =>
+      ipcRenderer.invoke('remote.getRemoteSessions'),
     clearRemoteSession: (sessionId: string): Promise<{ success: boolean; error?: string }> =>
       ipcRenderer.invoke('remote.clearRemoteSession', sessionId),
     getTunnelStatus: (): Promise<{
@@ -346,8 +383,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('schedule.delete', id),
     toggle: (id: string, enabled: boolean): Promise<ScheduleTask | null> =>
       ipcRenderer.invoke('schedule.toggle', id, enabled),
-    runNow: (id: string): Promise<ScheduleTask | null> =>
-      ipcRenderer.invoke('schedule.runNow', id),
+    runNow: (id: string): Promise<ScheduleTask | null> => ipcRenderer.invoke('schedule.runNow', id),
   },
 });
 
@@ -376,12 +412,19 @@ declare global {
         getPresets: () => Promise<ProviderPresets>;
         save: (config: Partial<AppConfig>) => Promise<{ success: boolean; config: AppConfig }>;
         createSet: (payload: CreateSetPayload) => Promise<{ success: boolean; config: AppConfig }>;
-        renameSet: (payload: { id: string; name: string }) => Promise<{ success: boolean; config: AppConfig }>;
+        renameSet: (payload: {
+          id: string;
+          name: string;
+        }) => Promise<{ success: boolean; config: AppConfig }>;
         deleteSet: (payload: { id: string }) => Promise<{ success: boolean; config: AppConfig }>;
         switchSet: (payload: { id: string }) => Promise<{ success: boolean; config: AppConfig }>;
         isConfigured: () => Promise<boolean>;
         test: (config: ApiTestInput) => Promise<ApiTestResult>;
-        listModels: (payload: { provider: AppConfig['provider']; apiKey: string; baseUrl?: string }) => Promise<ProviderModelInfo[]>;
+        getCodexAuthStatus: (codexPath?: string) => Promise<CodexAuthStatus>;
+        codexLogin: (codexPath?: string) => Promise<CodexAuthActionResult>;
+        codexDeviceLogin: (codexPath?: string) => Promise<CodexAuthActionResult>;
+        codexLogout: (codexPath?: string) => Promise<CodexAuthActionResult>;
+        listModels: (payload: ListModelsInput) => Promise<ProviderModelInfo[]>;
         diagnose: (input: DiagnosticInput) => Promise<DiagnosticResult>;
         discoverLocal: (payload?: { baseUrl?: string }) => Promise<LocalOllamaDiscoveryResult>;
       };
@@ -405,7 +448,10 @@ declare global {
         getByType: (type: string) => Promise<CredentialRecord[]>;
         getByService: (service: string) => Promise<CredentialRecord[]>;
         save: (credential: CredentialSaveInput) => Promise<CredentialRecord>;
-        update: (id: string, updates: CredentialUpdateInput) => Promise<CredentialRecord | undefined>;
+        update: (
+          id: string,
+          updates: CredentialUpdateInput
+        ) => Promise<CredentialRecord | undefined>;
         delete: (id: string) => Promise<boolean>;
       };
       skills: {
@@ -418,7 +464,13 @@ declare global {
         setStoragePath: (
           targetPath: string,
           migrate?: boolean
-        ) => Promise<{ success: boolean; path: string; migratedCount: number; skippedCount: number; error?: string }>;
+        ) => Promise<{
+          success: boolean;
+          path: string;
+          migratedCount: number;
+          skippedCount: number;
+          error?: string;
+        }>;
         openStoragePath: () => Promise<{ success: boolean; path: string; error?: string }>;
       };
       plugins: {
@@ -438,10 +490,10 @@ declare global {
           platform: string;
           mode: string;
           initialized: boolean;
-          wsl?: { 
-            available: boolean; 
-            distro?: string; 
-            nodeAvailable?: boolean; 
+          wsl?: {
+            available: boolean;
+            distro?: string;
+            nodeAvailable?: boolean;
             version?: string;
             pythonAvailable?: boolean;
             pythonVersion?: string;
@@ -500,9 +552,14 @@ declare global {
         export: () => Promise<{ success: boolean; path?: string; size?: number; error?: string }>;
         open: () => Promise<{ success: boolean; error?: string }>;
         clear: () => Promise<{ success: boolean; deletedCount?: number; error?: string }>;
-        setEnabled: (enabled: boolean) => Promise<{ success: boolean; enabled?: boolean; error?: string }>;
+        setEnabled: (
+          enabled: boolean
+        ) => Promise<{ success: boolean; enabled?: boolean; error?: string }>;
         isEnabled: () => Promise<{ success: boolean; enabled?: boolean; error?: string }>;
-        write: (level: 'info' | 'warn' | 'error', ...args: unknown[]) => Promise<{ success: boolean; error?: string }>;
+        write: (
+          level: 'info' | 'warn' | 'error',
+          ...args: unknown[]
+        ) => Promise<{ success: boolean; error?: string }>;
       };
       remote: {
         getConfig: () => Promise<RemoteConfig>;
@@ -515,12 +572,22 @@ declare global {
           pendingPairings: number;
         }>;
         setEnabled: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;
-        updateGatewayConfig: (config: Partial<GatewayConfig>) => Promise<{ success: boolean; error?: string }>;
-        updateFeishuConfig: (config: FeishuChannelConfig) => Promise<{ success: boolean; error?: string }>;
+        updateGatewayConfig: (
+          config: Partial<GatewayConfig>
+        ) => Promise<{ success: boolean; error?: string }>;
+        updateFeishuConfig: (
+          config: FeishuChannelConfig
+        ) => Promise<{ success: boolean; error?: string }>;
         getPairedUsers: () => Promise<PairedUser[]>;
         getPendingPairings: () => Promise<PairingRequest[]>;
-        approvePairing: (channelType: string, userId: string) => Promise<{ success: boolean; error?: string }>;
-        revokePairing: (channelType: string, userId: string) => Promise<{ success: boolean; error?: string }>;
+        approvePairing: (
+          channelType: string,
+          userId: string
+        ) => Promise<{ success: boolean; error?: string }>;
+        revokePairing: (
+          channelType: string,
+          userId: string
+        ) => Promise<{ success: boolean; error?: string }>;
         getRemoteSessions: () => Promise<RemoteSessionMapping[]>;
         clearRemoteSession: (sessionId: string) => Promise<{ success: boolean; error?: string }>;
         getTunnelStatus: () => Promise<{

--- a/src/renderer/components/CodexAuthPanel.tsx
+++ b/src/renderer/components/CodexAuthPanel.tsx
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  CheckCircle,
+  Loader2,
+  LogIn,
+  LogOut,
+  MonitorSmartphone,
+  RefreshCw,
+  Terminal,
+} from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { CodexAuthStatus } from '../types';
+
+interface CodexAuthPanelProps {
+  codexPath: string;
+  setCodexPath: (value: string) => void;
+}
+
+type CodexAction = 'status' | 'login' | 'device-login' | 'logout' | null;
+
+export function CodexAuthPanel({ codexPath, setCodexPath }: CodexAuthPanelProps) {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<CodexAuthStatus | null>(null);
+  const [activeAction, setActiveAction] = useState<CodexAction>(null);
+
+  const loadStatus = useCallback(async () => {
+    setActiveAction('status');
+    try {
+      const nextStatus = await window.electronAPI.config.getCodexAuthStatus(
+        codexPath.trim() || undefined
+      );
+      setStatus(nextStatus);
+    } finally {
+      setActiveAction(null);
+    }
+  }, [codexPath]);
+
+  const runAction = useCallback(
+    async (action: Exclude<CodexAction, 'status' | null>) => {
+      setActiveAction(action);
+      try {
+        const result =
+          action === 'login'
+            ? await window.electronAPI.config.codexLogin(codexPath.trim() || undefined)
+            : action === 'device-login'
+              ? await window.electronAPI.config.codexDeviceLogin(codexPath.trim() || undefined)
+              : await window.electronAPI.config.codexLogout(codexPath.trim() || undefined);
+
+        setStatus({
+          ok: result.ok,
+          loggedIn: action === 'logout' ? false : result.ok,
+          cliFound: result.cliFound,
+          message: result.message,
+          stdout: result.stdout,
+          stderr: result.stderr,
+        });
+
+        await loadStatus();
+      } finally {
+        setActiveAction(null);
+      }
+    },
+    [codexPath, loadStatus]
+  );
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void loadStatus();
+    }, 150);
+    return () => window.clearTimeout(timer);
+  }, [loadStatus]);
+
+  const statusTone = useMemo(() => {
+    if (!status) {
+      return 'border-border-subtle bg-background/60 text-text-secondary';
+    }
+    if (status.ok && status.loggedIn) {
+      return 'border-success/30 bg-success/10 text-success';
+    }
+    return 'border-warning/30 bg-warning/10 text-warning';
+  }, [status]);
+
+  return (
+    <div className="space-y-3 py-5 border-b border-border-muted">
+      <label
+        htmlFor="codex-path-input"
+        className="flex items-center gap-2 text-sm font-medium text-text-primary"
+      >
+        <Terminal className="w-4 h-4" />
+        {t('api.codex.cliPath')}
+      </label>
+      <p className="text-xs leading-5 text-text-muted">{t('api.codex.description')}</p>
+      <input
+        id="codex-path-input"
+        type="text"
+        value={codexPath}
+        onChange={(e) => setCodexPath(e.target.value)}
+        placeholder={t('api.codex.cliPathPlaceholder')}
+        className="w-full px-4 py-3 rounded-lg bg-background border border-border text-text-primary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent transition-all"
+      />
+      <p className="text-xs text-text-muted">{t('api.codex.cliPathHint')}</p>
+
+      <div className={`rounded-xl border px-3 py-3 text-xs leading-5 ${statusTone}`}>
+        <div className="flex items-start gap-2">
+          {status?.ok && status.loggedIn ? (
+            <CheckCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          ) : (
+            <MonitorSmartphone className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          )}
+          <div>
+            <div className="font-medium">{t('api.codex.statusLabel')}</div>
+            <div>{status?.message || t('api.codex.statusChecking')}</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-2">
+        <button
+          type="button"
+          onClick={() => void loadStatus()}
+          disabled={activeAction !== null}
+          className="flex items-center justify-center gap-2 rounded-lg border border-border px-3 py-2 text-sm text-text-primary hover:bg-surface-hover disabled:opacity-50"
+        >
+          {activeAction === 'status' ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <RefreshCw className="h-4 w-4" />
+          )}
+          {t('api.codex.refreshStatus')}
+        </button>
+        <button
+          type="button"
+          onClick={() => void runAction('login')}
+          disabled={activeAction !== null}
+          className="flex items-center justify-center gap-2 rounded-lg border border-border px-3 py-2 text-sm text-text-primary hover:bg-surface-hover disabled:opacity-50"
+        >
+          {activeAction === 'login' ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <LogIn className="h-4 w-4" />
+          )}
+          {t('api.codex.login')}
+        </button>
+        <button
+          type="button"
+          onClick={() => void runAction('device-login')}
+          disabled={activeAction !== null}
+          className="flex items-center justify-center gap-2 rounded-lg border border-border px-3 py-2 text-sm text-text-primary hover:bg-surface-hover disabled:opacity-50"
+        >
+          {activeAction === 'device-login' ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <MonitorSmartphone className="h-4 w-4" />
+          )}
+          {t('api.codex.deviceLogin')}
+        </button>
+        <button
+          type="button"
+          onClick={() => void runAction('logout')}
+          disabled={activeAction !== null}
+          className="flex items-center justify-center gap-2 rounded-lg border border-border px-3 py-2 text-sm text-text-primary hover:bg-surface-hover disabled:opacity-50"
+        >
+          {activeAction === 'logout' ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <LogOut className="h-4 w-4" />
+          )}
+          {t('api.codex.logout')}
+        </button>
+      </div>
+
+      <div className="space-y-1 text-xs text-text-muted">
+        <p>{t('api.codex.officialOnly')}</p>
+        <p>{t('api.codex.manualLoginHint')}</p>
+        <p>{t('api.codex.deviceLoginHint')}</p>
+        <p>{t('api.codex.logHint')}</p>
+        <p>{t('api.codex.logoutHint')}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/ConfigModal.tsx
+++ b/src/renderer/components/ConfigModal.tsx
@@ -16,6 +16,7 @@ import type { AppConfig, ApiTestResult } from '../types';
 import { useApiConfigState } from '../hooks/useApiConfigState';
 import { ApiConfigSetManager } from './ApiConfigSetManager';
 import { CommonProviderSetupsCard, GuidanceInlineHint } from './ProviderGuidance';
+import { CodexAuthPanel } from './CodexAuthPanel';
 
 interface ConfigModalProps {
   isOpen: boolean;
@@ -26,7 +27,7 @@ interface ConfigModalProps {
 }
 
 const PROVIDER_LABELS: Record<
-  'openrouter' | 'anthropic' | 'openai' | 'gemini' | 'ollama' | 'custom',
+  'openrouter' | 'anthropic' | 'openai' | 'gemini' | 'ollama' | 'codex_chatgpt' | 'custom',
   string
 > = {
   openrouter: 'OpenRouter',
@@ -34,6 +35,7 @@ const PROVIDER_LABELS: Record<
   openai: 'OpenAI',
   gemini: 'Gemini',
   ollama: 'Ollama',
+  codex_chatgpt: 'Codex',
   custom: 'Custom',
 };
 
@@ -68,6 +70,8 @@ export function ConfigModal({
     testResult,
     friendlyTestDetails,
     isOllamaMode,
+    isCodexMode,
+    codexPath,
     requiresApiKey,
     protocolGuidanceText,
     protocolGuidanceTone,
@@ -86,6 +90,7 @@ export function ConfigModal({
     setModel,
     setCustomModel,
     toggleCustomModel,
+    setCodexPath,
     applyCommonProviderSetup,
     changeProvider,
     changeProtocol,
@@ -201,43 +206,54 @@ export function ConfigModal({
               {t('api.provider')}
             </label>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-              {(['openrouter', 'anthropic', 'openai', 'gemini', 'ollama', 'custom'] as const).map(
-                (p) => (
-                  <button
-                    key={p}
-                    onClick={() => changeProvider(p)}
-                    className={`px-3 py-2 rounded-lg text-sm font-medium transition-all ${
-                      provider === p
-                        ? 'bg-accent text-white'
-                        : 'bg-surface-hover text-text-secondary hover:bg-surface-active'
-                    }`}
-                  >
-                    {presets?.[p]?.name ||
-                      (p === 'custom' ? t('api.custom') : PROVIDER_LABELS[p]) ||
-                      p}
-                  </button>
-                )
-              )}
+              {(
+                [
+                  'openrouter',
+                  'anthropic',
+                  'openai',
+                  'gemini',
+                  'ollama',
+                  'codex_chatgpt',
+                  'custom',
+                ] as const
+              ).map((p) => (
+                <button
+                  key={p}
+                  onClick={() => changeProvider(p)}
+                  className={`px-3 py-2 rounded-lg text-sm font-medium transition-all ${
+                    provider === p
+                      ? 'bg-accent text-white'
+                      : 'bg-surface-hover text-text-secondary hover:bg-surface-active'
+                  }`}
+                >
+                  {presets?.[p]?.name ||
+                    (p === 'custom' ? t('api.custom') : PROVIDER_LABELS[p]) ||
+                    p}
+                </button>
+              ))}
             </div>
           </div>
 
-          {/* API Key */}
-          <div className="space-y-2">
-            <label className="flex items-center gap-2 text-sm font-medium text-text-primary">
-              <Key className="w-4 h-4" />
-              {t('api.apiKey')}
-            </label>
-            <input
-              type="password"
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-              placeholder={currentPreset?.keyPlaceholder || t('api.enterApiKey')}
-              className="w-full px-4 py-3 rounded-xl bg-background border border-border text-text-primary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent transition-all"
-            />
-            {currentPreset?.keyHint && (
-              <p className="text-xs text-text-muted">{currentPreset.keyHint}</p>
-            )}
-          </div>
+          {isCodexMode ? (
+            <CodexAuthPanel codexPath={codexPath} setCodexPath={setCodexPath} />
+          ) : (
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 text-sm font-medium text-text-primary">
+                <Key className="w-4 h-4" />
+                {t('api.apiKey')}
+              </label>
+              <input
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={currentPreset?.keyPlaceholder || t('api.enterApiKey')}
+                className="w-full px-4 py-3 rounded-xl bg-background border border-border text-text-primary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent transition-all"
+              />
+              {currentPreset?.keyHint && (
+                <p className="text-xs text-text-muted">{currentPreset.keyHint}</p>
+              )}
+            </div>
+          )}
 
           {/* Custom Protocol */}
           {provider === 'custom' && (
@@ -335,7 +351,7 @@ export function ConfigModal({
                 {t('api.model')}
               </label>
               <div className="flex items-center gap-2">
-                {isOllamaMode && (
+                {(isOllamaMode || provider === 'codex_chatgpt') && (
                   <button
                     type="button"
                     onClick={() => {
@@ -360,8 +376,12 @@ export function ConfigModal({
                   >
                     <Edit3 className="w-3 h-3" />
                     {isOllamaMode
-                      ? (useCustomModel ? t('api.useDetectedModels') : t('api.manualModel'))
-                      : (useCustomModel ? t('api.usePreset') : t('api.custom'))}
+                      ? useCustomModel
+                        ? t('api.useDetectedModels')
+                        : t('api.manualModel')
+                      : useCustomModel
+                        ? t('api.usePreset')
+                        : t('api.custom')}
                   </button>
                 )}
               </div>

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -39,7 +39,13 @@ export function Sidebar() {
   const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
   const setShowSettings = useAppStore((s) => s.setShowSettings);
-  const { deleteSession, batchDeleteSessions, getSessionMessages, getSessionTraceSteps, isElectron } = useIPC();
+  const {
+    deleteSession,
+    batchDeleteSessions,
+    getSessionMessages,
+    getSessionTraceSteps,
+    isElectron,
+  } = useIPC();
   const [hoveredSession, setHoveredSession] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [isSelectMode, setIsSelectMode] = useState(false);
@@ -106,12 +112,10 @@ export function Sidebar() {
     });
   }, []);
 
-  const visibleSessionIds = useMemo(
-    () => filteredSessions.map((s) => s.id),
-    [filteredSessions]
-  );
+  const visibleSessionIds = useMemo(() => filteredSessions.map((s) => s.id), [filteredSessions]);
 
-  const allVisibleSelected = visibleSessionIds.length > 0 && visibleSessionIds.every((id) => selectedIds.has(id));
+  const allVisibleSelected =
+    visibleSessionIds.length > 0 && visibleSessionIds.every((id) => selectedIds.has(id));
 
   const toggleSelectAll = useCallback(() => {
     if (allVisibleSelected) {
@@ -196,15 +200,19 @@ export function Sidebar() {
   };
 
   const toggleTheme = () => {
-    const next = settings.theme === 'dark' ? 'light' : settings.theme === 'light' ? 'system' : 'dark';
+    const next =
+      settings.theme === 'dark' ? 'light' : settings.theme === 'light' ? 'system' : 'dark';
     updateSettings({ theme: next });
   };
 
-  const themeIcon = settings.theme === 'dark'
-    ? <Sun className="w-4 h-4" />
-    : settings.theme === 'light'
-      ? <Moon className="w-4 h-4" />
-      : <Monitor className="w-4 h-4" />;
+  const themeIcon =
+    settings.theme === 'dark' ? (
+      <Sun className="w-4 h-4" />
+    ) : settings.theme === 'light' ? (
+      <Moon className="w-4 h-4" />
+    ) : (
+      <Monitor className="w-4 h-4" />
+    );
 
   if (sidebarCollapsed) {
     return (
@@ -267,7 +275,7 @@ export function Sidebar() {
             <img
               src={sidebarLogoSrc}
               alt={t('common.appLogoAlt')}
-              className="w-10 h-10 rounded-2xl object-cover border border-border-subtle bg-background/60 flex-shrink-0"
+              className="w-10 h-10 rounded-2xl object-contain p-1.5 border border-border-subtle bg-background/60 flex-shrink-0"
             />
             <div className="min-w-0">
               <h1 className="text-[1.34rem] leading-none font-semibold tracking-[-0.035em] text-text-primary">
@@ -455,32 +463,32 @@ export function Sidebar() {
           )}
         </div>
       ) : (
-      <div className="px-3 py-3 border-t border-border-muted">
-        <div className="flex items-center gap-2 rounded-2xl bg-background/50 px-3 py-2.5">
-          <button
-            onClick={() => setShowSettings(true)}
-            className="flex-1 min-w-0 flex items-center gap-2 text-left text-text-secondary hover:text-text-primary transition-colors"
-          >
-            <Settings className="w-4 h-4 flex-shrink-0" />
-            <div className="min-w-0">
-              <div className="text-[13px] font-medium text-text-primary">
-                {t('sidebar.settings')}
+        <div className="px-3 py-3 border-t border-border-muted">
+          <div className="flex items-center gap-2 rounded-2xl bg-background/50 px-3 py-2.5">
+            <button
+              onClick={() => setShowSettings(true)}
+              className="flex-1 min-w-0 flex items-center gap-2 text-left text-text-secondary hover:text-text-primary transition-colors"
+            >
+              <Settings className="w-4 h-4 flex-shrink-0" />
+              <div className="min-w-0">
+                <div className="text-[13px] font-medium text-text-primary">
+                  {t('sidebar.settings')}
+                </div>
+                <div className="text-[11px] text-text-muted truncate">
+                  {isConfigured ? t('sidebar.apiConfigured') : t('sidebar.apiNotConfigured')}
+                </div>
               </div>
-              <div className="text-[11px] text-text-muted truncate">
-                {isConfigured ? t('sidebar.apiConfigured') : t('sidebar.apiNotConfigured')}
-              </div>
-            </div>
-          </button>
+            </button>
 
-          <button
-            onClick={toggleTheme}
-            className="w-8 h-8 rounded-xl flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors flex-shrink-0"
-            title={t('sidebar.themeToggle')}
-          >
-            {themeIcon}
-          </button>
+            <button
+              onClick={toggleTheme}
+              className="w-8 h-8 rounded-xl flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors flex-shrink-0"
+              title={t('sidebar.themeToggle')}
+            >
+              {themeIcon}
+            </button>
+          </div>
         </div>
-      </div>
       )}
     </aside>
   );

--- a/src/renderer/components/WelcomeView.tsx
+++ b/src/renderer/components/WelcomeView.tsx
@@ -446,7 +446,7 @@ export function WelcomeView() {
             <img
               src={welcomeLogoSrc}
               alt={t('welcome.logoAlt')}
-              className="w-16 h-16 md:w-20 md:h-20 rounded-[1.4rem] object-cover border border-border-subtle bg-background/60 shadow-soft"
+              className="w-16 h-16 md:w-20 md:h-20 rounded-[1.4rem] object-contain p-2 border border-border-subtle bg-background/60 shadow-soft"
             />
             <div className="text-left">
               <h1 className="text-[2.35rem] md:text-[3.1rem] leading-none font-semibold tracking-[-0.05em] text-text-primary">

--- a/src/renderer/components/settings/SettingsAPI.tsx
+++ b/src/renderer/components/settings/SettingsAPI.tsx
@@ -23,6 +23,7 @@ import { useApiConfigState } from '../../hooks/useApiConfigState';
 import { ApiConfigSetManager } from '../ApiConfigSetManager';
 import { CommonProviderSetupsCard, GuidanceInlineHint } from '../ProviderGuidance';
 import ApiDiagnosticsPanel from '../ApiDiagnosticsPanel';
+import { CodexAuthPanel } from '../CodexAuthPanel';
 import { SettingsContentSection, SERVICE_OPTIONS } from './shared';
 import type { UserCredential, CredentialDraft } from './shared';
 
@@ -60,6 +61,8 @@ export function SettingsAPI() {
     isDiscoveringLocalOllama,
     enableThinking,
     isOllamaMode,
+    isCodexMode,
+    codexPath,
     requiresApiKey,
     protocolGuidanceText,
     protocolGuidanceTone,
@@ -81,6 +84,7 @@ export function SettingsAPI() {
     setMaxTokens,
     toggleCustomModel,
     setEnableThinking,
+    setCodexPath,
     applyCommonProviderSetup,
     changeProvider,
     changeProtocol,
@@ -140,50 +144,67 @@ export function SettingsAPI() {
           {t('api.provider')}
         </label>
         <p className="text-xs leading-5 text-text-muted">{t('api.providerDescription')}</p>
-        <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-2">
-          {(['openrouter', 'anthropic', 'openai', 'gemini', 'ollama', 'custom'] as const).map(
-            (p) => (
-              <button
-                key={p}
-                onClick={() => changeProvider(p)}
-                disabled={isLoadingConfig}
-                className={`px-3 py-2 rounded-lg text-sm transition-colors border ${
-                  provider === p
-                    ? 'border-accent bg-accent/10 text-accent font-medium'
-                    : 'border-border-muted text-text-secondary hover:border-border hover:text-text-primary disabled:opacity-50'
-                }`}
-              >
-                {p === 'custom' ? t('api.moreModels') : presets?.[p]?.name || p}
-              </button>
-            )
-          )}
+        <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-7 gap-2">
+          {(
+            [
+              'openrouter',
+              'anthropic',
+              'openai',
+              'gemini',
+              'ollama',
+              'codex_chatgpt',
+              'custom',
+            ] as const
+          ).map((p) => (
+            <button
+              key={p}
+              onClick={() => changeProvider(p)}
+              disabled={isLoadingConfig}
+              className={`px-3 py-2 rounded-lg text-sm transition-colors border ${
+                provider === p
+                  ? 'border-accent bg-accent/10 text-accent font-medium'
+                  : 'border-border-muted text-text-secondary hover:border-border hover:text-text-primary disabled:opacity-50'
+              }`}
+            >
+              {p === 'custom' ? t('api.moreModels') : presets?.[p]?.name || p}
+            </button>
+          ))}
         </div>
       </div>
 
-      {/* API Key */}
-      <div className="space-y-3 py-5 border-b border-border-muted">
-        <label htmlFor="api-key-input" className="flex items-center gap-2 text-sm font-medium text-text-primary">
-          <Key className="w-4 h-4" />
-          {t('api.apiKey')}
-        </label>
-        <p className="text-xs leading-5 text-text-muted">{t('api.apiKeyDescription')}</p>
-        <input
-          id="api-key-input"
-          type="password"
-          value={apiKey}
-          onChange={(e) => setApiKey(e.target.value)}
-          placeholder={currentPreset?.keyPlaceholder || t('api.enterApiKey')}
-          className="w-full px-4 py-3 rounded-lg bg-background border border-border text-text-primary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent transition-all"
-        />
-        {currentPreset?.keyHint && (
-          <p className="text-xs text-text-muted">{currentPreset.keyHint}</p>
-        )}
-      </div>
+      {isCodexMode ? (
+        <CodexAuthPanel codexPath={codexPath} setCodexPath={setCodexPath} />
+      ) : (
+        <div className="space-y-3 py-5 border-b border-border-muted">
+          <label
+            htmlFor="api-key-input"
+            className="flex items-center gap-2 text-sm font-medium text-text-primary"
+          >
+            <Key className="w-4 h-4" />
+            {t('api.apiKey')}
+          </label>
+          <p className="text-xs leading-5 text-text-muted">{t('api.apiKeyDescription')}</p>
+          <input
+            id="api-key-input"
+            type="password"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            placeholder={currentPreset?.keyPlaceholder || t('api.enterApiKey')}
+            className="w-full px-4 py-3 rounded-lg bg-background border border-border text-text-primary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent transition-all"
+          />
+          {currentPreset?.keyHint && (
+            <p className="text-xs text-text-muted">{currentPreset.keyHint}</p>
+          )}
+        </div>
+      )}
 
       {/* Custom Protocol */}
       {provider === 'custom' && (
         <div className="space-y-3 py-5 border-b border-border-muted">
-          <label id="api-protocol-label" className="flex items-center gap-2 text-sm font-medium text-text-primary">
+          <label
+            id="api-protocol-label"
+            className="flex items-center gap-2 text-sm font-medium text-text-primary"
+          >
             <Server className="w-4 h-4" />
             {t('api.protocol')}
           </label>
@@ -216,7 +237,10 @@ export function SettingsAPI() {
       {(provider === 'custom' || provider === 'ollama') && (
         <div className="space-y-3 py-5 border-b border-border-muted">
           <div className="flex items-center justify-between gap-2">
-            <label htmlFor="api-base-url-input" className="flex items-center gap-2 text-sm font-medium text-text-primary">
+            <label
+              htmlFor="api-base-url-input"
+              className="flex items-center gap-2 text-sm font-medium text-text-primary"
+            >
               <Server className="w-4 h-4" />
               {t('api.baseUrl')}
             </label>
@@ -271,12 +295,15 @@ export function SettingsAPI() {
       {/* Model Selection */}
       <div className="space-y-3 py-5 border-b border-border-muted">
         <div className="flex items-center justify-between">
-          <label htmlFor="api-model-input" className="flex items-center gap-2 text-sm font-medium text-text-primary">
+          <label
+            htmlFor="api-model-input"
+            className="flex items-center gap-2 text-sm font-medium text-text-primary"
+          >
             <Cpu className="w-4 h-4" />
             {t('api.model')}
           </label>
           <div className="flex items-center gap-2">
-            {isOllamaMode && (
+            {(isOllamaMode || provider === 'codex_chatgpt') && (
               <button
                 type="button"
                 onClick={() => {
@@ -301,8 +328,12 @@ export function SettingsAPI() {
               >
                 <Edit3 className="w-3 h-3" />
                 {isOllamaMode
-                  ? (useCustomModel ? t('api.useDetectedModels') : t('api.manualModel'))
-                  : (useCustomModel ? t('api.usePreset') : t('api.custom'))}
+                  ? useCustomModel
+                    ? t('api.useDetectedModels')
+                    : t('api.manualModel')
+                  : useCustomModel
+                    ? t('api.usePreset')
+                    : t('api.custom')}
               </button>
             )}
           </div>
@@ -342,7 +373,10 @@ export function SettingsAPI() {
         {(provider === 'ollama' || provider === 'custom') && (
           <div className="grid grid-cols-2 gap-3 pt-2">
             <div>
-              <label htmlFor="api-context-window-input" className="block text-xs font-medium text-text-secondary mb-1">
+              <label
+                htmlFor="api-context-window-input"
+                className="block text-xs font-medium text-text-secondary mb-1"
+              >
                 {t('api.contextWindow')}
               </label>
               <input
@@ -357,7 +391,10 @@ export function SettingsAPI() {
               />
             </div>
             <div>
-              <label htmlFor="api-max-tokens-input" className="block text-xs font-medium text-text-secondary mb-1">
+              <label
+                htmlFor="api-max-tokens-input"
+                className="block text-xs font-medium text-text-secondary mb-1"
+              >
                 {t('api.maxOutputTokens')}
               </label>
               <input
@@ -419,13 +456,15 @@ export function SettingsAPI() {
         </div>
       )}
       {/* Diagnostics Panel */}
-      <ApiDiagnosticsPanel
-        result={diagnosticResult}
-        isRunning={isDiagnosing}
-        onRunDiagnostics={handleDiagnose}
-        onRunDeepDiagnostics={isOllamaMode ? handleDeepDiagnose : undefined}
-        disabled={requiresApiKey && !apiKey.trim()}
-      />
+      {!isCodexMode && (
+        <ApiDiagnosticsPanel
+          result={diagnosticResult}
+          isRunning={isDiagnosing}
+          onRunDiagnostics={handleDiagnose}
+          onRunDeepDiagnostics={isOllamaMode ? handleDeepDiagnose : undefined}
+          disabled={requiresApiKey && !apiKey.trim()}
+        />
+      )}
 
       {/* Save Button */}
       <div className="space-y-3 py-5 border-b border-border-muted">

--- a/src/renderer/hooks/useApiConfigState.ts
+++ b/src/renderer/hooks/useApiConfigState.ts
@@ -14,10 +14,7 @@ import type {
   ProviderType,
 } from '../types';
 import { isLoopbackBaseUrl } from '../../shared/network/loopback';
-import {
-  DEFAULT_OLLAMA_BASE_URL,
-  normalizeOllamaBaseUrl,
-} from '../../shared/ollama-base-url';
+import { DEFAULT_OLLAMA_BASE_URL, normalizeOllamaBaseUrl } from '../../shared/ollama-base-url';
 import { API_PROVIDER_PRESETS, getModelInputGuidance } from '../../shared/api-model-presets';
 import {
   COMMON_PROVIDER_SETUPS,
@@ -74,6 +71,7 @@ const PROFILE_KEYS: ProviderProfileKey[] = [
   'openai',
   'gemini',
   'ollama',
+  'codex_chatgpt',
   'custom:anthropic',
   'custom:openai',
   'custom:gemini',
@@ -90,7 +88,8 @@ function isProviderType(value: unknown): value is ProviderType {
     value === 'custom' ||
     value === 'openai' ||
     value === 'gemini' ||
-    value === 'ollama'
+    value === 'ollama' ||
+    value === 'codex_chatgpt'
   );
 }
 
@@ -120,6 +119,9 @@ export function profileKeyToProvider(profileKey: ProviderProfileKey): {
 } {
   if (profileKey === 'ollama') {
     return { provider: 'ollama', customProtocol: 'openai' };
+  }
+  if (profileKey === 'codex_chatgpt') {
+    return { provider: 'codex_chatgpt', customProtocol: 'openai' };
   }
   if (profileKey === 'custom:openai') {
     return { provider: 'custom', customProtocol: 'openai' };
@@ -175,6 +177,9 @@ function modelPresetForProfile(profileKey: ProviderProfileKey, presets: Provider
   if (profileKey === 'ollama') {
     return presets.ollama;
   }
+  if (profileKey === 'codex_chatgpt') {
+    return presets.codex_chatgpt;
+  }
   if (profileKey === 'custom:openai') {
     return presets.openai;
   }
@@ -196,7 +201,7 @@ function defaultProfileForKey(
   return {
     apiKey: '',
     baseUrl: preset.baseUrl,
-    model: profileKey === 'ollama' ? '' : (preset.models[0]?.id || ''),
+    model: profileKey === 'ollama' ? '' : preset.models[0]?.id || '',
     customModel: '',
     useCustomModel: prefersCustomInput,
     contextWindow: '',
@@ -265,9 +270,8 @@ function normalizeProfile(
   );
   return {
     apiKey: profile?.apiKey || '',
-    baseUrl: profileKey === 'ollama'
-      ? (normalizeOllamaBaseUrl(rawBaseUrl) || fallback.baseUrl)
-      : rawBaseUrl,
+    baseUrl:
+      profileKey === 'ollama' ? normalizeOllamaBaseUrl(rawBaseUrl) || fallback.baseUrl : rawBaseUrl,
     model: hasPresetModel ? modelValue : fallback.model,
     customModel: hasPresetModel ? '' : modelValue,
     useCustomModel: !hasPresetModel,
@@ -359,7 +363,8 @@ function toPersistedProfiles(
 export function buildApiConfigDraftSignature(
   activeProfileKey: ProviderProfileKey,
   profiles: Record<ProviderProfileKey, UIProviderProfile>,
-  enableThinking: boolean
+  enableThinking: boolean,
+  codexPath = ''
 ): string {
   const persisted = toPersistedProfiles(profiles);
   return JSON.stringify({
@@ -371,6 +376,7 @@ export function buildApiConfigDraftSignature(
       baseUrl: persisted[key]?.baseUrl || '',
       model: persisted[key]?.model || '',
     })),
+    codexPath,
   });
 }
 
@@ -570,6 +576,8 @@ interface ApiConfigState {
   pendingConfigSetAction: PendingConfigSetAction | null;
   // Extended thinking flag
   enableThinking: boolean;
+  // Optional Codex CLI path override
+  codexPath: string;
   // Remember last custom protocol so switching back to custom restores it
   lastCustomProtocol: CustomProtocolType;
   // Signature of the last persisted state (used for dirty-check)
@@ -611,6 +619,7 @@ type ApiConfigAction =
         profiles: Record<ProviderProfileKey, UIProviderProfile>;
         activeProfileKey: ProviderProfileKey;
         enableThinking: boolean;
+        codexPath: string;
         configSets: ApiConfigSet[];
         activeConfigSetId: string;
         lastCustomProtocol: CustomProtocolType;
@@ -621,6 +630,7 @@ type ApiConfigAction =
   | { type: 'SET_ACTIVE_PROFILE_KEY'; payload: ProviderProfileKey }
   // Enable thinking toggle
   | { type: 'SET_ENABLE_THINKING'; payload: boolean }
+  | { type: 'SET_CODEX_PATH'; payload: string }
   // Patch one profile in the profiles map
   | { type: 'PATCH_PROFILE'; profileKey: ProviderProfileKey; patch: Partial<UIProviderProfile> }
   // Replace a profile using a functional updater
@@ -679,6 +689,7 @@ function apiConfigReducer(state: ApiConfigState, action: ApiConfigAction): ApiCo
         profiles: action.payload.profiles,
         activeProfileKey: action.payload.activeProfileKey,
         enableThinking: action.payload.enableThinking,
+        codexPath: action.payload.codexPath,
         configSets: action.payload.configSets,
         activeConfigSetId: action.payload.activeConfigSetId,
         pendingConfigSetAction: null,
@@ -691,6 +702,9 @@ function apiConfigReducer(state: ApiConfigState, action: ApiConfigAction): ApiCo
 
     case 'SET_ENABLE_THINKING':
       return { ...state, enableThinking: action.payload };
+
+    case 'SET_CODEX_PATH':
+      return { ...state, codexPath: action.payload };
 
     case 'PATCH_PROFILE':
       return {
@@ -726,7 +740,10 @@ function apiConfigReducer(state: ApiConfigState, action: ApiConfigAction): ApiCo
     case 'CLEAR_DISCOVERED_MODELS':
       return {
         ...state,
-        discoveredModels: clearDiscoveredModelsForProfile(state.discoveredModels, action.profileKey),
+        discoveredModels: clearDiscoveredModelsForProfile(
+          state.discoveredModels,
+          action.profileKey
+        ),
       };
 
     case 'DELETE_DISCOVERED_MODELS': {
@@ -824,34 +841,39 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
         ? 'gemini'
         : 'anthropic';
 
-  const [state, dispatch] = useReducer(apiConfigReducer, undefined, (): ApiConfigState => ({
-    presets: FALLBACK_PROVIDER_PRESETS,
-    profiles: initialBootstrap.snapshot.profiles,
-    activeProfileKey: initialBootstrap.snapshot.activeProfileKey,
-    configSets: initialBootstrap.configSets,
-    activeConfigSetId: initialBootstrap.activeConfigSetId,
-    pendingConfigSetAction: null,
-    isMutatingConfigSet: false,
-    lastCustomProtocol: initialLastCustomProtocol,
-    enableThinking: Boolean(initialConfig?.enableThinking),
-    discoveredModels: {},
-    isLoadingConfig: true,
-    savedDraftSignature: '',
-    isSaving: false,
-    isTesting: false,
-    isRefreshingModels: false,
-    isDiscoveringLocalOllama: false,
-    errorText: '',
-    errorKey: null,
-    errorValues: undefined,
-    successText: '',
-    successKey: null,
-    successValues: undefined,
-    lastSaveCompletedAt: 0,
-    testResult: null,
-    diagnosticResult: null,
-    isDiagnosing: false,
-  }));
+  const [state, dispatch] = useReducer(
+    apiConfigReducer,
+    undefined,
+    (): ApiConfigState => ({
+      presets: FALLBACK_PROVIDER_PRESETS,
+      profiles: initialBootstrap.snapshot.profiles,
+      activeProfileKey: initialBootstrap.snapshot.activeProfileKey,
+      configSets: initialBootstrap.configSets,
+      activeConfigSetId: initialBootstrap.activeConfigSetId,
+      pendingConfigSetAction: null,
+      isMutatingConfigSet: false,
+      lastCustomProtocol: initialLastCustomProtocol,
+      enableThinking: Boolean(initialConfig?.enableThinking),
+      codexPath: initialConfig?.codexPath || '',
+      discoveredModels: {},
+      isLoadingConfig: true,
+      savedDraftSignature: '',
+      isSaving: false,
+      isTesting: false,
+      isRefreshingModels: false,
+      isDiscoveringLocalOllama: false,
+      errorText: '',
+      errorKey: null,
+      errorValues: undefined,
+      successText: '',
+      successKey: null,
+      successValues: undefined,
+      lastSaveCompletedAt: 0,
+      testResult: null,
+      diagnosticResult: null,
+      isDiagnosing: false,
+    })
+  );
 
   // Destructure state for convenience — avoids `state.X` in every expression
   const {
@@ -864,6 +886,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     isMutatingConfigSet,
     lastCustomProtocol,
     enableThinking,
+    codexPath,
     discoveredModels,
     isLoadingConfig,
     savedDraftSignature,
@@ -929,13 +952,13 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     profiles[activeProfileKey] || defaultProfileForKey(activeProfileKey, presets);
   const modelPreset = modelPresetForProfile(activeProfileKey, presets);
   const currentPreset = modelPreset;
-  const hasDiscoveredOllamaModels =
-    provider === 'ollama' && Object.prototype.hasOwnProperty.call(discoveredModels, activeProfileKey);
-  const modelOptions = provider === 'ollama'
-    ? (discoveredModels[activeProfileKey] || [])
-    : hasDiscoveredOllamaModels
-      ? (discoveredModels[activeProfileKey] || [])
-      : modelPreset.models;
+  const supportsModelRefresh = provider === 'ollama' || provider === 'codex_chatgpt';
+  const hasRefreshedModels =
+    supportsModelRefresh &&
+    Object.prototype.hasOwnProperty.call(discoveredModels, activeProfileKey);
+  const modelOptions = hasRefreshedModels
+    ? discoveredModels[activeProfileKey] || []
+    : modelPreset.models;
   const modelInputGuidance = getModelInputGuidance(provider, customProtocol);
 
   const currentConfigSet = useMemo(
@@ -956,10 +979,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
   const customModel = currentProfile.customModel;
   const useCustomModel = currentProfile.useCustomModel;
   const shouldShowOllamaManualModelToggle =
-    provider !== 'ollama'
-      || useCustomModel
-      || Boolean(error)
-      || modelOptions.length === 0;
+    provider !== 'ollama' || useCustomModel || Boolean(error) || modelOptions.length === 0;
   const contextWindow = currentProfile.contextWindow;
   const maxTokens = currentProfile.maxTokens;
   const detectedProviderSetup = useMemo(
@@ -1104,6 +1124,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
   ]);
 
   const allowEmptyApiKey =
+    provider === 'codex_chatgpt' ||
     provider === 'ollama' ||
     (provider === 'custom' &&
       ((customProtocol === 'anthropic' && isCustomAnthropicLoopbackGateway(baseUrl)) ||
@@ -1111,8 +1132,8 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
         (customProtocol === 'gemini' && isCustomGeminiLoopbackGateway(baseUrl))));
   const requiresApiKey = !allowEmptyApiKey;
   const currentDraftSignature = useMemo(
-    () => buildApiConfigDraftSignature(activeProfileKey, profiles, enableThinking),
-    [activeProfileKey, profiles, enableThinking]
+    () => buildApiConfigDraftSignature(activeProfileKey, profiles, enableThinking, codexPath),
+    [activeProfileKey, codexPath, enableThinking, profiles]
   );
   const hasUnsavedChanges =
     savedDraftSignature !== '' && currentDraftSignature !== savedDraftSignature;
@@ -1138,13 +1159,15 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
           profiles: bootstrap.snapshot.profiles,
           activeProfileKey: bootstrap.snapshot.activeProfileKey,
           enableThinking: bootstrap.snapshot.enableThinking,
+          codexPath: config?.codexPath || '',
           configSets: bootstrap.configSets,
           activeConfigSetId: bootstrap.activeConfigSetId,
           lastCustomProtocol: resolvedLastCustomProtocol,
           savedDraftSignature: buildApiConfigDraftSignature(
             bootstrap.snapshot.activeProfileKey,
             bootstrap.snapshot.profiles,
-            bootstrap.snapshot.enableThinking
+            bootstrap.snapshot.enableThinking,
+            config?.codexPath || ''
           ),
         },
       });
@@ -1181,7 +1204,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
 
   const changeProtocol = useCallback((newProtocol: CustomProtocolType) => {
     dispatch({ type: 'SET_LAST_CUSTOM_PROTOCOL', payload: newProtocol });
-    dispatch({ type: 'SET_ACTIVE_PROFILE_KEY', payload: profileKeyFromProvider('custom', newProtocol) });
+    dispatch({
+      type: 'SET_ACTIVE_PROFILE_KEY',
+      payload: profileKeyFromProvider('custom', newProtocol),
+    });
   }, []);
 
   const setApiKey = useCallback(
@@ -1225,6 +1251,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     },
     [updateActiveProfile]
   );
+
+  const setCodexPath = useCallback((value: string) => {
+    dispatch({ type: 'SET_CODEX_PATH', payload: value });
+  }, []);
 
   const applyCommonProviderSetup = useCallback(
     (setupId: string) => {
@@ -1354,7 +1384,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
           if (!inPreset) {
             return {
               ...current,
-              model: provider === 'ollama' ? '' : (preset.models[0]?.id || ''),
+              model: provider === 'ollama' ? '' : preset.models[0]?.id || '',
             };
           }
         }
@@ -1395,6 +1425,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
         baseUrl: resolvedBaseUrl || undefined,
         customProtocol,
         model: finalModel,
+        codexPath: provider === 'codex_chatgpt' ? codexPath.trim() || undefined : undefined,
       });
       dispatch({ type: 'SET_TEST_RESULT', payload: result });
       if (result.ok && hasUnsavedChanges) {
@@ -1417,6 +1448,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     apiKey,
     baseUrl,
     currentPreset.baseUrl,
+    codexPath,
     customModel,
     customProtocol,
     model,
@@ -1430,65 +1462,69 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     showSuccessKey,
   ]);
 
-  const handleDiagnose = useCallback(async (verificationLevel: 'fast' | 'deep' = 'fast') => {
-    if (requiresApiKey && !apiKey.trim()) {
-      showErrorKey('api.testError.missing_key');
-      return;
-    }
+  const handleDiagnose = useCallback(
+    async (verificationLevel: 'fast' | 'deep' = 'fast') => {
+      if (requiresApiKey && !apiKey.trim()) {
+        showErrorKey('api.testError.missing_key');
+        return;
+      }
 
-    clearError();
-    dispatch({ type: 'SET_IS_DIAGNOSING', payload: true });
-    dispatch({ type: 'SET_DIAGNOSTIC_RESULT', payload: null });
-    dispatch({ type: 'SET_TEST_RESULT', payload: null });
-    try {
-      const resolvedBaseUrl =
-        provider === 'custom' || provider === 'ollama'
-          ? baseUrl.trim()
-          : (baseUrl.trim() || currentPreset.baseUrl || '').trim();
+      clearError();
+      dispatch({ type: 'SET_IS_DIAGNOSING', payload: true });
+      dispatch({ type: 'SET_DIAGNOSTIC_RESULT', payload: null });
+      dispatch({ type: 'SET_TEST_RESULT', payload: null });
+      try {
+        const resolvedBaseUrl =
+          provider === 'custom' || provider === 'ollama'
+            ? baseUrl.trim()
+            : (baseUrl.trim() || currentPreset.baseUrl || '').trim();
 
-      const finalModel = useCustomModel ? customModel.trim() : model;
+        const finalModel = useCustomModel ? customModel.trim() : model;
 
-      const result = await window.electronAPI.config.diagnose({
-        provider,
-        apiKey: apiKey.trim(),
-        baseUrl: resolvedBaseUrl || undefined,
-        customProtocol,
-        model: finalModel || undefined,
-        verificationLevel,
-      });
-      dispatch({ type: 'SET_DIAGNOSTIC_RESULT', payload: result });
-    } catch (err) {
-      showErrorText((err as Error).message || 'Diagnosis failed');
-    } finally {
-      dispatch({ type: 'SET_IS_DIAGNOSING', payload: false });
-    }
-  }, [
-    requiresApiKey,
-    apiKey,
-    baseUrl,
-    provider,
-    customProtocol,
-    model,
-    customModel,
-    useCustomModel,
-    currentPreset.baseUrl,
-    clearError,
-    showErrorKey,
-    showErrorText,
-  ]);
+        const result = await window.electronAPI.config.diagnose({
+          provider,
+          apiKey: apiKey.trim(),
+          baseUrl: resolvedBaseUrl || undefined,
+          customProtocol,
+          model: finalModel || undefined,
+          verificationLevel,
+        });
+        dispatch({ type: 'SET_DIAGNOSTIC_RESULT', payload: result });
+      } catch (err) {
+        showErrorText((err as Error).message || 'Diagnosis failed');
+      } finally {
+        dispatch({ type: 'SET_IS_DIAGNOSING', payload: false });
+      }
+    },
+    [
+      requiresApiKey,
+      apiKey,
+      baseUrl,
+      provider,
+      customProtocol,
+      model,
+      customModel,
+      useCustomModel,
+      currentPreset.baseUrl,
+      clearError,
+      showErrorKey,
+      showErrorText,
+    ]
+  );
 
   const handleDeepDiagnose = useCallback(async () => {
     await handleDiagnose('deep');
   }, [handleDiagnose]);
 
   const refreshModelOptions = useCallback(async () => {
-    if (!isElectron || provider !== 'ollama') {
+    if (!isElectron || (provider !== 'ollama' && provider !== 'codex_chatgpt')) {
       return [];
     }
 
     const requestedProfileKey = activeProfileKey;
     const requestedBaseUrl = baseUrl.trim();
     const requestId = ++ollamaRefreshRequestIdRef.current;
+    const requestedProvider = provider;
 
     dispatch({ type: 'SET_IS_REFRESHING_MODELS', payload: true });
     clearError();
@@ -1497,14 +1533,15 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
         provider,
         apiKey: apiKey.trim(),
         baseUrl: requestedBaseUrl || undefined,
+        codexPath: provider === 'codex_chatgpt' ? codexPath.trim() || undefined : undefined,
       });
 
       const latestTarget = latestOllamaTargetRef.current;
       if (
-        requestId !== ollamaRefreshRequestIdRef.current
-        || latestTarget.provider !== 'ollama'
-        || latestTarget.activeProfileKey !== requestedProfileKey
-        || latestTarget.baseUrl !== requestedBaseUrl
+        requestId !== ollamaRefreshRequestIdRef.current ||
+        latestTarget.provider !== requestedProvider ||
+        latestTarget.activeProfileKey !== requestedProfileKey ||
+        latestTarget.baseUrl !== requestedBaseUrl
       ) {
         return models;
       }
@@ -1534,10 +1571,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     } catch (refreshError) {
       const latestTarget = latestOllamaTargetRef.current;
       if (
-        requestId !== ollamaRefreshRequestIdRef.current
-        || latestTarget.provider !== 'ollama'
-        || latestTarget.activeProfileKey !== requestedProfileKey
-        || latestTarget.baseUrl !== requestedBaseUrl
+        requestId !== ollamaRefreshRequestIdRef.current ||
+        latestTarget.provider !== requestedProvider ||
+        latestTarget.activeProfileKey !== requestedProfileKey ||
+        latestTarget.baseUrl !== requestedBaseUrl
       ) {
         return [];
       }
@@ -1557,7 +1594,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     activeProfileKey,
     apiKey,
     baseUrl,
-    presets,
+    codexPath,
     provider,
     clearError,
     showErrorKey,
@@ -1622,10 +1659,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
         });
         const latestTarget = latestOllamaTargetRef.current;
         if (
-          requestId !== ollamaDiscoverRequestIdRef.current
-          || latestTarget.provider !== 'ollama'
-          || latestTarget.activeProfileKey !== requestedProfileKey
-          || latestTarget.baseUrl !== requestedBaseUrl
+          requestId !== ollamaDiscoverRequestIdRef.current ||
+          latestTarget.provider !== 'ollama' ||
+          latestTarget.activeProfileKey !== requestedProfileKey ||
+          latestTarget.baseUrl !== requestedBaseUrl
         ) {
           return result;
         }
@@ -1656,10 +1693,10 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       } catch (discoveryError) {
         const latestTarget = latestOllamaTargetRef.current;
         if (
-          requestId !== ollamaDiscoverRequestIdRef.current
-          || latestTarget.provider !== 'ollama'
-          || latestTarget.activeProfileKey !== requestedProfileKey
-          || latestTarget.baseUrl !== requestedBaseUrl
+          requestId !== ollamaDiscoverRequestIdRef.current ||
+          latestTarget.provider !== 'ollama' ||
+          latestTarget.activeProfileKey !== requestedProfileKey ||
+          latestTarget.baseUrl !== requestedBaseUrl
         ) {
           return null;
         }
@@ -1705,6 +1742,13 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     return () => clearTimeout(timer);
   }, [provider, baseUrl, refreshModelOptions]);
 
+  useEffect(() => {
+    if (provider !== 'codex_chatgpt' || modelPreset.models.length > 0) {
+      return;
+    }
+    void refreshModelOptions();
+  }, [modelPreset.models.length, provider, refreshModelOptions]);
+
   const handleSave = useCallback(
     async (options?: { silentSuccess?: boolean }) => {
       if (requiresApiKey && !apiKey.trim()) {
@@ -1743,6 +1787,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
           profiles: persistedProfiles,
           activeConfigSetId,
           enableThinking,
+          codexPath,
         };
 
         if (onSave) {
@@ -1778,6 +1823,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
       baseUrl,
       currentDraftSignature,
       currentPreset.baseUrl,
+      codexPath,
       customModel,
       customProtocol,
       enableThinking,
@@ -2058,6 +2104,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     modelInputPlaceholder: modelInputGuidance.placeholder,
     modelInputHint: modelInputGuidance.hint,
     enableThinking,
+    codexPath,
     isSaving,
     isTesting,
     isRefreshingModels,
@@ -2072,6 +2119,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     handleDiagnose,
     handleDeepDiagnose,
     isOllamaMode: provider === 'ollama',
+    isCodexMode: provider === 'codex_chatgpt',
     shouldShowOllamaManualModelToggle,
     requiresApiKey,
     detectedProviderSetup,
@@ -2096,6 +2144,7 @@ export function useApiConfigState(options: UseApiConfigStateOptions = {}) {
     setMaxTokens,
     toggleCustomModel,
     setEnableThinking,
+    setCodexPath,
     applyCommonProviderSetup,
     changeProvider,
     changeProtocol,

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -155,6 +155,23 @@
     "enableThinking": "Enable Thinking Mode",
     "enableThinkingHint": "Show Claude's thinking process step by step. This provides more transparency but may increase token usage.",
     "enableThinkingOllamaHint": "Most Ollama models do not support thinking mode. Enable only if your model explicitly supports it.",
+    "codex": {
+      "description": "Use the official Codex CLI sign-in flow shared with your ChatGPT account. No API key is stored in Open Cowork.",
+      "cliPath": "Codex CLI Path",
+      "cliPathPlaceholder": "Leave empty to use codex from PATH",
+      "cliPathHint": "Optional. Set this only if the `codex` command is not already available in your PATH.",
+      "statusLabel": "Codex sign-in status",
+      "statusChecking": "Checking Codex CLI status...",
+      "refreshStatus": "Refresh Status",
+      "login": "Browser Login",
+      "deviceLogin": "Device Login",
+      "logout": "Logout",
+      "officialOnly": "This integration only uses the official Codex CLI flow. It does not scrape ChatGPT sessions or private endpoints.",
+      "manualLoginHint": "Manual terminal login command: `codex login`.",
+      "deviceLoginHint": "If browser login stalls or the localhost callback fails, use `codex login --device-auth`.",
+      "logHint": "Codex login diagnostics are written to `codex-login.log`.",
+      "logoutHint": "If Codex was previously configured in API-key mode, run logout first, then sign in again with ChatGPT."
+    },
     "testSuccess": "Connection successful ({{ms}}ms)",
     "testSuccessNeedSave": "Connection test passed. Save settings before starting a session.",
     "testError": {

--- a/src/renderer/i18n/locales/zh.json
+++ b/src/renderer/i18n/locales/zh.json
@@ -155,6 +155,23 @@
     "enableThinking": "启用思考模式",
     "enableThinkingHint": "显示 Claude 的思考过程。这提供更多透明度，但可能增加 token 消耗。",
     "enableThinkingOllamaHint": "大多数 Ollama 模型不支持思考模式，仅在模型明确支持时启用。",
+    "codex": {
+      "description": "使用与 ChatGPT 账号共享的官方 Codex CLI 登录流程。Open Cowork 不会保存 API Key。",
+      "cliPath": "Codex CLI 路径",
+      "cliPathPlaceholder": "留空则使用 PATH 中的 codex",
+      "cliPathHint": "可选。只有当系统 PATH 中找不到 `codex` 命令时才需要填写。",
+      "statusLabel": "Codex 登录状态",
+      "statusChecking": "正在检查 Codex CLI 状态...",
+      "refreshStatus": "刷新状态",
+      "login": "浏览器登录",
+      "deviceLogin": "设备码登录",
+      "logout": "退出登录",
+      "officialOnly": "该集成只使用官方 Codex CLI 流程，不会抓取 ChatGPT 会话或私有接口。",
+      "manualLoginHint": "手动终端登录命令：`codex login`。",
+      "deviceLoginHint": "如果浏览器登录卡住，或本地 localhost 回调失败，请改用 `codex login --device-auth`。",
+      "logHint": "Codex 登录诊断信息会写入 `codex-login.log`。",
+      "logoutHint": "如果你的 Codex 之前处于 API Key 模式，请先退出登录，再使用 ChatGPT 重新登录。"
+    },
     "testSuccess": "连接成功（{{ms}}ms）",
     "testSuccessNeedSave": "连接测试成功，请点击“保存设置”后再开始会话。",
     "testError": {

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -79,8 +79,8 @@ export interface ToolResultContent {
   content: string;
   isError?: boolean;
   images?: Array<{
-    data: string;          // base64 encoded image data
-    mimeType: string;      // e.g., 'image/png'
+    data: string; // base64 encoded image data
+    mimeType: string; // e.g., 'image/png'
   }>;
 }
 
@@ -315,8 +315,20 @@ export interface PermissionRule {
 
 // IPC Event types
 export type ClientEvent =
-  | { type: 'session.start'; payload: { title: string; prompt: string; cwd?: string; allowedTools?: string[]; content?: ContentBlock[] } }
-  | { type: 'session.continue'; payload: { sessionId: string; prompt: string; content?: ContentBlock[] } }
+  | {
+      type: 'session.start';
+      payload: {
+        title: string;
+        prompt: string;
+        cwd?: string;
+        allowedTools?: string[];
+        content?: ContentBlock[];
+      };
+    }
+  | {
+      type: 'session.continue';
+      payload: { sessionId: string; prompt: string; content?: ContentBlock[] };
+    }
   | { type: 'session.stop'; payload: { sessionId: string } }
   | { type: 'session.delete'; payload: { sessionId: string } }
   | { type: 'session.batchDelete'; payload: { sessionIds: string[] } }
@@ -332,17 +344,17 @@ export type ClientEvent =
   | { type: 'workdir.select'; payload: { sessionId?: string; currentPath?: string } };
 
 // Sandbox setup types (app startup)
-export type SandboxSetupPhase = 
-  | 'checking'      // Checking WSL/Lima availability
-  | 'creating'      // Creating Lima instance (macOS only)
-  | 'starting'      // Starting Lima instance (macOS only)  
-  | 'installing_node'   // Installing Node.js
+export type SandboxSetupPhase =
+  | 'checking' // Checking WSL/Lima availability
+  | 'creating' // Creating Lima instance (macOS only)
+  | 'starting' // Starting Lima instance (macOS only)
+  | 'installing_node' // Installing Node.js
   | 'installing_python' // Installing Python
-  | 'installing_pip'    // Installing pip
-  | 'installing_deps'   // Installing skill dependencies (markitdown, pypdf, etc.)
-  | 'ready'         // Ready to use
-  | 'skipped'       // No sandbox needed (native mode)
-  | 'error';        // Setup failed
+  | 'installing_pip' // Installing pip
+  | 'installing_deps' // Installing skill dependencies (markitdown, pypdf, etc.)
+  | 'ready' // Ready to use
+  | 'skipped' // No sandbox needed (native mode)
+  | 'error'; // Setup failed
 
 export interface SandboxSetupProgress {
   phase: SandboxSetupPhase;
@@ -354,11 +366,11 @@ export interface SandboxSetupProgress {
 
 // Sandbox sync types (per-session file sync)
 export type SandboxSyncPhase =
-  | 'starting_agent'  // Starting WSL/Lima agent
-  | 'syncing_files'   // Syncing files to sandbox
-  | 'syncing_skills'  // Copying skills
-  | 'ready'           // Sync complete
-  | 'error';          // Sync failed
+  | 'starting_agent' // Starting WSL/Lima agent
+  | 'syncing_files' // Syncing files to sandbox
+  | 'syncing_skills' // Copying skills
+  | 'ready' // Sync complete
+  | 'error'; // Sync failed
 
 export interface SandboxSyncStatus {
   sessionId: string;
@@ -373,8 +385,14 @@ export type ServerEvent =
   | { type: 'stream.message'; payload: { sessionId: string; message: Message } }
   | { type: 'stream.partial'; payload: { sessionId: string; delta: string } }
   | { type: 'stream.thinking'; payload: { sessionId: string; delta: string } }
-  | { type: 'stream.executionTime'; payload: { sessionId: string; messageId: string; executionTimeMs: number } }
-  | { type: 'session.status'; payload: { sessionId: string; status: SessionStatus; error?: string } }
+  | {
+      type: 'stream.executionTime';
+      payload: { sessionId: string; messageId: string; executionTimeMs: number };
+    }
+  | {
+      type: 'session.status';
+      payload: { sessionId: string; status: SessionStatus; error?: string };
+    }
   | { type: 'session.update'; payload: { sessionId: string; updates: Partial<Session> } }
   | { type: 'session.list'; payload: { sessions: Session[] } }
   | { type: 'permission.request'; payload: PermissionRequest }
@@ -382,21 +400,37 @@ export type ServerEvent =
   | { type: 'sudo.password.request'; payload: SudoPasswordRequest }
   | { type: 'sudo.password.dismiss'; payload: { toolUseId: string } }
   | { type: 'trace.step'; payload: { sessionId: string; step: TraceStep } }
-  | { type: 'trace.update'; payload: { sessionId: string; stepId: string; updates: Partial<TraceStep> } }
+  | {
+      type: 'trace.update';
+      payload: { sessionId: string; stepId: string; updates: Partial<TraceStep> };
+    }
   | { type: 'folder.selected'; payload: { path: string } }
   | { type: 'config.status'; payload: { isConfigured: boolean; config: AppConfig } }
   | { type: 'sandbox.progress'; payload: SandboxSetupProgress }
   | { type: 'sandbox.sync'; payload: SandboxSyncStatus }
   | { type: 'skills.storageChanged'; payload: SkillsStorageChangeEvent }
-  | { type: 'plugins.runtimeApplied'; payload: { sessionId: string; plugins: Array<{ name: string; path: string }> } }
+  | {
+      type: 'plugins.runtimeApplied';
+      payload: { sessionId: string; plugins: Array<{ name: string; path: string }> };
+    }
   | { type: 'workdir.changed'; payload: { path: string } }
   | { type: 'session.contextInfo'; payload: { sessionId: string; contextWindow: number } }
-  | { type: 'navigate.to'; payload: { page: 'welcome' | 'settings' | 'session'; tab?: string; sessionId?: string } }
+  | {
+      type: 'navigate.to';
+      payload: { page: 'welcome' | 'settings' | 'session'; tab?: string; sessionId?: string };
+    }
   | { type: 'native-theme.changed'; payload: { shouldUseDarkColors: boolean } }
   | { type: 'new-session' }
   | { type: 'navigate'; payload: string }
   | { type: 'scheduled-task.error'; payload: { taskId: string; error: string } }
-  | { type: 'error'; payload: { message: string; code?: 'CONFIG_REQUIRED_ACTIVE_SET'; action?: 'open_api_settings' } };
+  | {
+      type: 'error';
+      payload: {
+        message: string;
+        code?: 'CONFIG_REQUIRED_ACTIVE_SET';
+        action?: 'open_api_settings';
+      };
+    };
 
 // Settings types
 export interface Settings {
@@ -410,7 +444,15 @@ export interface Settings {
 }
 
 // Tool types
-export type ToolName = 'read' | 'write' | 'edit' | 'glob' | 'grep' | 'bash' | 'webFetch' | 'webSearch';
+export type ToolName =
+  | 'read'
+  | 'write'
+  | 'edit'
+  | 'glob'
+  | 'grep'
+  | 'bash'
+  | 'webFetch'
+  | 'webSearch';
 
 export interface ToolResult {
   success: boolean;
@@ -427,7 +469,14 @@ export interface ExecutionContext {
 }
 
 // App Config types
-export type ProviderType = 'openrouter' | 'anthropic' | 'custom' | 'openai' | 'gemini' | 'ollama';
+export type ProviderType =
+  | 'openrouter'
+  | 'anthropic'
+  | 'custom'
+  | 'openai'
+  | 'gemini'
+  | 'ollama'
+  | 'codex_chatgpt';
 export type CustomProtocolType = 'anthropic' | 'openai' | 'gemini';
 export type AppTheme = 'dark' | 'light' | 'system';
 export type ProviderProfileKey =
@@ -436,6 +485,7 @@ export type ProviderProfileKey =
   | 'openai'
   | 'gemini'
   | 'ollama'
+  | 'codex_chatgpt'
   | 'custom:anthropic'
   | 'custom:openai'
   | 'custom:gemini';
@@ -480,6 +530,7 @@ export interface AppConfig {
   activeConfigSetId: ConfigSetId;
   configSets: ApiConfigSet[];
   claudeCodePath?: string;
+  codexPath?: string;
   defaultWorkdir?: string;
   globalSkillsPath?: string;
   theme?: AppTheme;
@@ -503,11 +554,19 @@ export interface ProviderPresets {
   openai: ProviderPreset;
   gemini: ProviderPreset;
   ollama: ProviderPreset;
+  codex_chatgpt: ProviderPreset;
 }
 
 export interface ProviderModelInfo {
   id: string;
   name: string;
+}
+
+export interface ListModelsInput {
+  provider: AppConfig['provider'];
+  apiKey: string;
+  baseUrl?: string;
+  codexPath?: string;
 }
 
 export interface ApiTestInput {
@@ -516,8 +575,26 @@ export interface ApiTestInput {
   baseUrl?: string;
   customProtocol?: AppConfig['customProtocol'];
   model?: string;
+  codexPath?: string;
   useLiveRequest?: boolean;
   verificationLevel?: DiagnosticVerificationLevel;
+}
+
+export interface CodexAuthStatus {
+  ok: boolean;
+  loggedIn: boolean;
+  cliFound: boolean;
+  message: string;
+  stdout?: string;
+  stderr?: string;
+}
+
+export interface CodexAuthActionResult {
+  ok: boolean;
+  cliFound: boolean;
+  message: string;
+  stdout?: string;
+  stderr?: string;
 }
 
 export interface ApiTestResult {
@@ -580,10 +657,7 @@ export interface LocalServiceInfo {
   models?: string[];
 }
 
-export type LocalOllamaDiscoveryStatus =
-  | 'unavailable'
-  | 'service_available'
-  | 'models_available';
+export type LocalOllamaDiscoveryStatus = 'unavailable' | 'service_available' | 'models_available';
 
 export interface LocalOllamaDiscoveryResult {
   available: boolean;

--- a/src/shared/api-model-presets.ts
+++ b/src/shared/api-model-presets.ts
@@ -1,4 +1,11 @@
-export type SharedProviderType = 'openrouter' | 'anthropic' | 'custom' | 'openai' | 'gemini' | 'ollama';
+export type SharedProviderType =
+  | 'openrouter'
+  | 'anthropic'
+  | 'custom'
+  | 'openai'
+  | 'gemini'
+  | 'ollama'
+  | 'codex_chatgpt';
 
 export type SharedCustomProtocolType = 'anthropic' | 'openai' | 'gemini';
 
@@ -17,6 +24,7 @@ export interface SharedProviderPresets {
   openai: SharedProviderPreset;
   gemini: SharedProviderPreset;
   ollama: SharedProviderPreset;
+  codex_chatgpt: SharedProviderPreset;
 }
 
 export interface ModelInputGuidance {
@@ -94,6 +102,26 @@ export const API_PROVIDER_PRESETS: SharedProviderPresets = {
     keyPlaceholder: '可留空',
     keyHint: '多数 Ollama 部署可留空；如果你的代理层要求鉴权，也可以填写 Key',
   },
+  codex_chatgpt: {
+    name: 'Codex (ChatGPT)',
+    baseUrl: '',
+    models: [
+      { id: 'gpt-5.4', name: 'gpt-5.4' },
+      { id: 'gpt-5.4-mini', name: 'gpt-5.4-mini' },
+      { id: 'gpt-5.3-codex', name: 'gpt-5.3-codex' },
+      { id: 'gpt-5.3-codex-spark', name: 'gpt-5.3-codex-spark' },
+      { id: 'gpt-5.2-codex', name: 'gpt-5.2-codex' },
+      { id: 'gpt-5.2', name: 'gpt-5.2' },
+      { id: 'gpt-5.1-codex-max', name: 'gpt-5.1-codex-max' },
+      { id: 'gpt-5.1', name: 'gpt-5.1' },
+      { id: 'gpt-5.1-codex', name: 'gpt-5.1-codex' },
+      { id: 'gpt-5-codex', name: 'gpt-5-codex' },
+      { id: 'gpt-5-codex-mini', name: 'gpt-5-codex-mini' },
+      { id: 'gpt-5', name: 'gpt-5' },
+    ],
+    keyPlaceholder: 'No API key required',
+    keyHint: 'Uses the official Codex CLI login shared with your ChatGPT account.',
+  },
   custom: {
     name: '更多模型',
     baseUrl: '',
@@ -128,7 +156,13 @@ export const PI_AI_CURATED_PRESETS: Record<string, { piProvider: string; pick: s
   },
   anthropic: {
     piProvider: 'anthropic',
-    pick: ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5', 'claude-sonnet-4-5', 'claude-3-7-sonnet-latest'],
+    pick: [
+      'claude-opus-4-6',
+      'claude-sonnet-4-6',
+      'claude-haiku-4-5',
+      'claude-sonnet-4-5',
+      'claude-3-7-sonnet-latest',
+    ],
   },
   openai: {
     piProvider: 'openai',
@@ -136,7 +170,14 @@ export const PI_AI_CURATED_PRESETS: Record<string, { piProvider: string; pick: s
   },
   gemini: {
     piProvider: 'google',
-    pick: ['gemini-3.1-pro-preview', 'gemini-3-flash-preview', 'gemini-3.1-flash-lite-preview', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite'],
+    pick: [
+      'gemini-3.1-pro-preview',
+      'gemini-3-flash-preview',
+      'gemini-3.1-flash-lite-preview',
+      'gemini-2.5-pro',
+      'gemini-2.5-flash',
+      'gemini-2.5-flash-lite',
+    ],
   },
 };
 
@@ -183,6 +224,13 @@ export function getModelInputGuidance(
     return {
       placeholder: 'qwen3.5:0.8b, llama3.2:latest, deepseek-r1:latest',
       hint: 'Use the exact model ID returned by your Ollama server.',
+    };
+  }
+
+  if (provider === 'codex_chatgpt') {
+    return {
+      placeholder: 'gpt-5.4, gpt-5.4-mini, gpt-5.3-codex',
+      hint: 'Use a Codex CLI model ID supported by your current ChatGPT plan or Codex installation.',
     };
   }
 

--- a/tests/api-config-state.test.ts
+++ b/tests/api-config-state.test.ts
@@ -20,6 +20,7 @@ describe('api config state helpers', () => {
   it('maps provider/protocol to profile key and back', () => {
     expect(profileKeyFromProvider('openrouter')).toBe('openrouter');
     expect(profileKeyFromProvider('ollama')).toBe('ollama');
+    expect(profileKeyFromProvider('codex_chatgpt')).toBe('codex_chatgpt');
     expect(profileKeyFromProvider('custom', 'openai')).toBe('custom:openai');
     expect(profileKeyFromProvider('custom', 'gemini')).toBe('custom:gemini');
     expect(profileKeyToProvider('custom:anthropic')).toEqual({
@@ -32,6 +33,10 @@ describe('api config state helpers', () => {
     });
     expect(profileKeyToProvider('ollama')).toEqual({
       provider: 'ollama',
+      customProtocol: 'openai',
+    });
+    expect(profileKeyToProvider('codex_chatgpt')).toEqual({
+      provider: 'codex_chatgpt',
       customProtocol: 'openai',
     });
   });
@@ -110,6 +115,16 @@ describe('api config state helpers', () => {
     expect(getModelInputGuidance('ollama').placeholder).toContain('qwen');
   });
 
+  it('exposes codex presets and guidance', () => {
+    expect(FALLBACK_PROVIDER_PRESETS.codex_chatgpt.models.map((item) => item.id)).toContain(
+      'gpt-5.4'
+    );
+    expect(FALLBACK_PROVIDER_PRESETS.codex_chatgpt.models.map((item) => item.id)).toContain(
+      'gpt-5.4-mini'
+    );
+    expect(getModelInputGuidance('codex_chatgpt').placeholder).toContain('gpt-5.4');
+  });
+
   it('loads existing profile values without overwriting them with defaults', () => {
     const config = {
       provider: 'custom',
@@ -161,7 +176,9 @@ describe('api config state helpers', () => {
     const snapshot = buildApiConfigSnapshot(config, FALLBACK_PROVIDER_PRESETS);
     expect(snapshot.profiles.openai.apiKey).toBe('sk-openai');
     expect(snapshot.profiles.openrouter.baseUrl).toBe(FALLBACK_PROVIDER_PRESETS.openrouter.baseUrl);
-    expect(snapshot.profiles['custom:anthropic'].model).toBe(FALLBACK_PROVIDER_PRESETS.custom.models[0]?.id);
+    expect(snapshot.profiles['custom:anthropic'].model).toBe(
+      FALLBACK_PROVIDER_PRESETS.custom.models[0]?.id
+    );
     expect(snapshot.profiles['custom:anthropic'].useCustomModel).toBe(true);
     expect(snapshot.profiles['custom:anthropic'].customModel).toBe('');
   });
@@ -245,19 +262,35 @@ describe('api config state helpers', () => {
 
   it('exposes updated preset lists and custom guidance', () => {
     expect(FALLBACK_PROVIDER_PRESETS.openai.models.map((item) => item.id)).toContain('gpt-5.4');
-    expect(FALLBACK_PROVIDER_PRESETS.openai.models.map((item) => item.id)).toContain('gpt-5.3-codex');
+    expect(FALLBACK_PROVIDER_PRESETS.openai.models.map((item) => item.id)).toContain(
+      'gpt-5.3-codex'
+    );
     expect(FALLBACK_PROVIDER_PRESETS.openai.models.map((item) => item.id)).not.toContain('gpt-5.2');
-    expect(FALLBACK_PROVIDER_PRESETS.anthropic.models.map((item) => item.id)).toContain('claude-sonnet-4-6');
-    expect(FALLBACK_PROVIDER_PRESETS.gemini.models.map((item) => item.id)).toContain('gemini-3.1-pro-preview');
-    expect(FALLBACK_PROVIDER_PRESETS.custom.models.map((item) => item.id)).toContain('kimi-k2-thinking');
+    expect(FALLBACK_PROVIDER_PRESETS.anthropic.models.map((item) => item.id)).toContain(
+      'claude-sonnet-4-6'
+    );
+    expect(FALLBACK_PROVIDER_PRESETS.gemini.models.map((item) => item.id)).toContain(
+      'gemini-3.1-pro-preview'
+    );
+    expect(FALLBACK_PROVIDER_PRESETS.custom.models.map((item) => item.id)).toContain(
+      'kimi-k2-thinking'
+    );
     expect(FALLBACK_PROVIDER_PRESETS.custom.models.map((item) => item.id)).toContain('glm-5');
-    expect(FALLBACK_PROVIDER_PRESETS.custom.models.map((item) => item.id)).toContain('MiniMax-M2.5');
-    expect(FALLBACK_PROVIDER_PRESETS.custom.models.map((item) => item.id)).toContain('grok-code-fast-1');
-    expect(FALLBACK_PROVIDER_PRESETS.custom.models.map((item) => item.id)).toContain('mistral-large-latest');
+    expect(FALLBACK_PROVIDER_PRESETS.custom.models.map((item) => item.id)).toContain(
+      'MiniMax-M2.5'
+    );
+    expect(FALLBACK_PROVIDER_PRESETS.custom.models.map((item) => item.id)).toContain(
+      'grok-code-fast-1'
+    );
+    expect(FALLBACK_PROVIDER_PRESETS.custom.models.map((item) => item.id)).toContain(
+      'mistral-large-latest'
+    );
 
     expect(getModelInputGuidance('custom', 'openai').placeholder).toContain('deepseek-chat');
     expect(getModelInputGuidance('custom', 'openai').placeholder).not.toContain('kimi');
-    expect(getModelInputGuidance('custom', 'openai').hint).toContain('selected protocol or endpoint');
+    expect(getModelInputGuidance('custom', 'openai').hint).toContain(
+      'selected protocol or endpoint'
+    );
   });
 
   it('wires local Ollama discovery through the shared config hook', () => {
@@ -269,9 +302,11 @@ describe('api config state helpers', () => {
     expect(source).toContain("showErrorKey('api.localOllamaNoModels')");
     expect(source).toContain('ollamaDiscoverRequestIdRef');
     // useReducer refactor: cleared via dispatch action instead of direct setter
-    expect(source).toContain("dispatch({ type: 'CLEAR_DISCOVERED_MODELS', profileKey: requestedProfileKey })");
+    expect(source).toContain(
+      "dispatch({ type: 'CLEAR_DISCOVERED_MODELS', profileKey: requestedProfileKey })"
+    );
     expect(source).toContain('autoSelectModelId: models[0]?.id');
-    expect(source).not.toContain('showErrorKey(\'api.localOllamaModelUnavailable\'');
+    expect(source).not.toContain("showErrorKey('api.localOllamaModelUnavailable'");
     expect(source).not.toContain('shouldAutoDiscoverLocalOllamaBaseUrl(baseUrl)');
   });
 

--- a/tests/codex-models.test.ts
+++ b/tests/codex-models.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { extractCodexModelIds, getFallbackCodexModels } from '../src/main/codex/codex-models';
+
+describe('codex models helpers', () => {
+  it('parses official Codex model ids from docs-like content', () => {
+    const ids = extractCodexModelIds(`
+      ## Recommended models
+      gpt-5.4
+      codex -m gpt-5.4
+      gpt-5.4-mini
+      codex -m gpt-5.4-mini
+      gpt-5.3-codex
+      codex -m gpt-5.3-codex
+      gpt-5.3-codex-spark
+      codex -m gpt-5.3-codex-spark
+      ## Alternative models
+      gpt-5.2-codex
+      codex -m gpt-5.2-codex
+    `);
+
+    expect(ids).toEqual([
+      'gpt-5.4',
+      'gpt-5.4-mini',
+      'gpt-5.3-codex',
+      'gpt-5.3-codex-spark',
+      'gpt-5.2-codex',
+    ]);
+  });
+
+  it('keeps a current fallback Codex model list', () => {
+    expect(getFallbackCodexModels().map((item) => item.id)).toEqual(
+      expect.arrayContaining(['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex'])
+    );
+  });
+});

--- a/tests/config-store-profiles.test.ts
+++ b/tests/config-store-profiles.test.ts
@@ -81,31 +81,26 @@ describe('ConfigStore provider profiles', () => {
           apiKey: 'sk-openai',
           baseUrl: 'https://api.openai.com/v1',
           model: 'gpt-5.2',
-
         },
         openrouter: {
           apiKey: 'sk-openrouter',
           baseUrl: 'https://openrouter.ai/api',
           model: 'anthropic/claude-sonnet-4.5',
-
         },
         anthropic: {
           apiKey: 'sk-ant',
           baseUrl: 'https://api.anthropic.com',
           model: 'claude-sonnet-4-5',
-
         },
         'custom:anthropic': {
           apiKey: 'sk-custom-ant',
           baseUrl: 'https://custom.example/anthropic',
           model: 'glm-4.7',
-
         },
         'custom:openai': {
           apiKey: 'sk-custom-openai',
           baseUrl: 'https://custom.example/openai/v1',
           model: 'gpt-5.2',
-
         },
       },
       enableDevLogs: true,
@@ -284,5 +279,19 @@ describe('ConfigStore provider profiles', () => {
     expect(store.hasUsableCredentialsForActiveSet()).toBe(false);
     expect(store.hasAnyUsableCredentials()).toBe(false);
     expect(store.isConfigured()).toBe(false);
+  });
+
+  it('treats codex provider as usable when a model is selected without api key', () => {
+    const store = new ConfigStore();
+
+    store.update({
+      provider: 'codex_chatgpt',
+      apiKey: '',
+      model: 'gpt-5-codex',
+    });
+
+    expect(store.hasUsableCredentialsForActiveSet()).toBe(true);
+    expect(store.hasAnyUsableCredentials()).toBe(true);
+    expect(store.isConfigured()).toBe(true);
   });
 });

--- a/tests/config-test-routing.test.ts
+++ b/tests/config-test-routing.test.ts
@@ -4,10 +4,15 @@ import type { AppConfig } from '../src/main/config/config-store';
 
 const mocks = vi.hoisted(() => ({
   probeWithClaudeSdk: vi.fn(),
+  getCodexAuthStatus: vi.fn(),
 }));
 
 vi.mock('../src/main/claude/claude-sdk-one-shot', () => ({
   probeWithClaudeSdk: mocks.probeWithClaudeSdk,
+}));
+
+vi.mock('../src/main/codex/codex-cli', () => ({
+  getCodexAuthStatus: mocks.getCodexAuthStatus,
 }));
 
 import { runConfigApiTest } from '../src/main/config/config-test-routing';
@@ -36,6 +41,7 @@ function createConfig(): AppConfig {
 describe('runConfigApiTest', () => {
   beforeEach(() => {
     mocks.probeWithClaudeSdk.mockReset();
+    mocks.getCodexAuthStatus.mockReset();
   });
 
   it('routes all providers through probeWithClaudeSdk', async () => {
@@ -168,5 +174,35 @@ describe('runConfigApiTest', () => {
 
     expect(result).toEqual(probeFailure);
     expect(mocks.probeWithClaudeSdk).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes codex_chatgpt through Codex CLI auth status', async () => {
+    mocks.getCodexAuthStatus.mockResolvedValue({
+      ok: true,
+      loggedIn: true,
+      cliFound: true,
+      message: 'signed in',
+    });
+
+    const result = await runConfigApiTest(
+      {
+        provider: 'codex_chatgpt',
+        apiKey: '',
+        model: 'gpt-5-codex',
+        codexPath: 'C:/tools/codex.cmd',
+      },
+      {
+        ...createConfig(),
+        provider: 'codex_chatgpt',
+        activeProfileKey: 'codex_chatgpt',
+        apiKey: '',
+        model: 'gpt-5-codex',
+        codexPath: 'codex',
+      }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mocks.getCodexAuthStatus).toHaveBeenCalledWith('C:/tools/codex.cmd');
+    expect(mocks.probeWithClaudeSdk).not.toHaveBeenCalled();
   });
 });

--- a/tests/path-resolver-containment.test.ts
+++ b/tests/path-resolver-containment.test.ts
@@ -1,33 +1,31 @@
 import { describe, expect, it } from 'vitest';
+import path from 'node:path';
 import { PathResolver } from '../src/main/sandbox/path-resolver';
+import type { MountedPath } from '../src/renderer/types';
+
+const testMounts: MountedPath[] = [{ virtual: '/mnt/workspace', real: '/tmp/project' }];
 
 describe('PathResolver containment', () => {
   it('rejects virtual paths that only share a prefix with the mount root', () => {
     const resolver = new PathResolver();
-    resolver.registerSession('session-1', [
-      { virtual: '/mnt/workspace', real: '/tmp/project' },
-    ] as any);
+    resolver.registerSession('session-1', testMounts);
 
     expect(resolver.resolve('session-1', '/mnt/workspace-evil/secret.txt')).toBeNull();
   });
 
   it('rejects real paths that only share a prefix with the mount root', () => {
     const resolver = new PathResolver();
-    resolver.registerSession('session-1', [
-      { virtual: '/mnt/workspace', real: '/tmp/project' },
-    ] as any);
+    resolver.registerSession('session-1', testMounts);
 
     expect(resolver.virtualize('session-1', '/tmp/project-evil/secret.txt')).toBeNull();
   });
 
   it('allows filenames that contain double dots but are not traversal segments', () => {
     const resolver = new PathResolver();
-    resolver.registerSession('session-1', [
-      { virtual: '/mnt/workspace', real: '/tmp/project' },
-    ] as any);
+    resolver.registerSession('session-1', testMounts);
 
     expect(resolver.resolve('session-1', '/mnt/workspace/notes..final.md')).toBe(
-      '/tmp/project/notes..final.md'
+      path.join('/tmp/project', '/notes..final.md')
     );
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { resolve } from 'path';
 import { builtinModules } from 'module';
 
 // Node built-in modules must be external for Electron main process
-const nodeBuiltins = builtinModules.flatMap(m => [m, `node:${m}`]);
+const nodeBuiltins = builtinModules.flatMap((m) => [m, `node:${m}`]);
 const ignoredWatchPaths = [
   '**/release/**',
   '**/dist/**',
@@ -16,6 +16,7 @@ const ignoredWatchPaths = [
 ];
 
 export default defineConfig({
+  base: './',
   plugins: [
     react(),
     electron([


### PR DESCRIPTION
## Summary
- add an official `codex_chatgpt` provider flow that uses the Codex CLI login status and shared ChatGPT auth instead of API keys or unofficial session scraping
- fix Windows Codex login UX and execution by resolving global CLI installs, handling `.cmd` launch correctly, and surfacing browser, device-auth, and logout guidance in the settings UI
- refresh Codex model handling to use current official models with a docs-backed refresh fallback, and fix packaged renderer asset paths so logos load correctly in desktop builds

## Testing
- npm run typecheck
- npm run lint
- npx vitest run