### PR TITLE
fix: set scrypt maxmem for startup key derivation

### DIFF
--- a/src/main/credentials/credentials-store.ts
+++ b/src/main/credentials/credentials-store.ts
@@ -3,7 +3,11 @@ import * as crypto from 'crypto';
 import * as os from 'os';
 import { safeStorage } from 'electron';
 import { log, logWarn } from '../utils/logger';
-import { getLegacyDerivedKeyBuffers, getStableDerivedKeyBuffer } from '../utils/store-encryption';
+import {
+  SECURE_SCRYPT_OPTIONS,
+  getLegacyDerivedKeyBuffers,
+  getStableDerivedKeyBuffer,
+} from '../utils/store-encryption';
 
 /**
  * User Credential - stored information for automated login
@@ -89,7 +93,7 @@ function getMachineBoundKey(): Buffer {
   }
 
   const seed = `${os.hostname()}:${os.userInfo().username}:open-cowork-credentials-stable-v1`;
-  _machineBoundKeyCache = crypto.scryptSync(seed, salt, 32, { N: 65536, r: 8, p: 1 });
+  _machineBoundKeyCache = crypto.scryptSync(seed, salt, 32, SECURE_SCRYPT_OPTIONS);
   log(
     '[CredentialsStore] Derived machine-bound key from hostname and username (safeStorage unavailable)'
   );

--- a/src/main/utils/store-encryption.ts
+++ b/src/main/utils/store-encryption.ts
@@ -38,10 +38,21 @@ function buildLegacyDirCandidates(moduleDirname: string): string[] {
 }
 
 /** Secure scrypt parameters for new key derivation. */
-const SECURE_SCRYPT_OPTIONS: crypto.ScryptOptions = { N: 65536, r: 8, p: 1 };
+const SCRYPT_MAXMEM_HEADROOM = 1024 * 1024;
+
+function createScryptOptions(N: number, r: number, p: number): crypto.ScryptOptions {
+  return {
+    N,
+    r,
+    p,
+    maxmem: 128 * N * r + SCRYPT_MAXMEM_HEADROOM,
+  };
+}
+
+export const SECURE_SCRYPT_OPTIONS: crypto.ScryptOptions = createScryptOptions(65536, 8, 1);
 
 /** Legacy scrypt parameters — Node.js defaults used by earlier releases. */
-const LEGACY_SCRYPT_OPTIONS: crypto.ScryptOptions = { N: 16384, r: 8, p: 1 };
+export const LEGACY_SCRYPT_OPTIONS: crypto.ScryptOptions = createScryptOptions(16384, 8, 1);
 
 function deriveKeyBuffer(
   seed: string,

--- a/tests/credentials-store-legacy-key.test.ts
+++ b/tests/credentials-store-legacy-key.test.ts
@@ -5,6 +5,12 @@ const mocks = vi.hoisted(() => ({
   stores: new Map<string, Record<string, unknown>>(),
 }));
 
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+  },
+}));
+
 vi.mock('electron-store', () => {
   class MockStore<T extends Record<string, unknown>> {
     public store: Record<string, unknown>;
@@ -49,6 +55,10 @@ describe('credentialsStore legacy key migration', () => {
   beforeEach(() => {
     mocks.stores.clear();
     vi.resetModules();
+  });
+
+  it('initializes when safeStorage falls back to a scrypt-derived machine key', async () => {
+    await expect(import('../src/main/credentials/credentials-store')).resolves.toBeDefined();
   });
 
   it('decrypts credentials written with the legacy credentials-key store and rewrites them as GCM', async () => {

--- a/tests/store-encryption.test.ts
+++ b/tests/store-encryption.test.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -124,5 +125,16 @@ describe('createEncryptedStoreWithKeyRotation', () => {
     expect(backups).toHaveLength(1);
     expect(fs.existsSync(path.join(tempDir, backups[0]))).toBe(true);
     expect(fs.existsSync(storePath)).toBe(false);
+  });
+
+  it('sets maxmem high enough for secure scrypt derivation', async () => {
+    registerStoreMocks(tempDir);
+
+    const { SECURE_SCRYPT_OPTIONS } = await import('../src/main/utils/store-encryption');
+
+    expect(() =>
+      crypto.scryptSync('stable-seed', 'open-cowork-salt', 32, SECURE_SCRYPT_OPTIONS)
+    ).not.toThrow();
+    expect(SECURE_SCRYPT_OPTIONS.maxmem).toBeGreaterThan(128 * 65536 * 8);
   });
 });


### PR DESCRIPTION
## Summary\n- set explicit maxmem headroom for both secure and legacy scrypt key derivation paths\n- reuse the secure scrypt options in the credentials-store fallback machine key path\n- add regression coverage for fallback initialization and secure scrypt options\n\n## Testing\n- npx vitest run tests/store-encryption.test.ts tests/credentials-store-legacy-key.test.ts\n- npm run typecheck\n\n## Context\nThis fixes the Windows/Electron startup failure caused by RangeError: Invalid scrypt params: error:030000AC:digital envelope routines::memory limit exceeded when beta.7 falls back to machine-bound key derivation.