### PR TITLE
fix(windows): embed legacy cleanup tool in installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Electron Builder (unsigned)
         run: npx electron-builder --mac dir --publish never
         env:
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
 
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v7
@@ -158,7 +158,7 @@ jobs:
       - name: Electron Builder
         run: npx electron-builder --win nsis --publish never
         env:
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v7
@@ -166,5 +166,7 @@ jobs:
           name: open-cowork-windows
           path: |
             release/*.exe
+            release/*.cmd
+            release/*.ps1
           retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Electron Builder (unsigned)
         run: npx electron-builder --mac dmg --publish never
         env:
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
 
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
@@ -111,4 +111,6 @@ jobs:
         with:
           files: |
             release/*.exe
+            release/*.cmd
+            release/*.ps1
           draft: true

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -7,6 +7,7 @@ directories:
   buildResources: resources
 
 npmRebuild: true
+beforeBuild: ./scripts/stage-mcp-resources.js
 afterPack: ./scripts/after-pack.js
 afterAllArtifactBuild: ./scripts/compress-dmg.js
 
@@ -47,9 +48,9 @@ files:
 
 # MCP servers (compiled JavaScript files, cross-platform)
 # NOTE: Platform-specific extraResources OVERRIDE this global section,
-# so dist-mcp must also be listed in each platform's extraResources.
+# so dist-mcp-stage must also be listed in each platform's extraResources.
 extraResources:
-  - from: dist-mcp
+  - from: dist-mcp-stage
     to: mcp
 
 # Skills are extracted via extraResources (per-platform) to avoid asar symlink issues.
@@ -73,7 +74,7 @@ win:
   artifactName: ${productName}-${version}-win-${arch}.${ext}
   signAndEditExecutable: false
   extraResources:
-    - from: dist-mcp
+    - from: dist-mcp-stage
       to: mcp
     - from: resources/node/win32-x64
       to: node
@@ -99,7 +100,7 @@ mac:
     NSScreenCaptureUsageDescription: 'Open Cowork needs screen recording access for GUI automation.'
     NSAccessibilityUsageDescription: 'Open Cowork needs accessibility access for GUI automation.'
   extraResources:
-    - from: dist-mcp
+    - from: dist-mcp-stage
       to: mcp
     - from: resources/node/darwin-${arch}
       to: node
@@ -122,7 +123,7 @@ linux:
         - x64
   artifactName: ${productName}-${version}-linux-${arch}.${ext}
   extraResources:
-    - from: dist-mcp
+    - from: dist-mcp-stage
       to: mcp
     - from: resources/node/linux-x64
       to: node

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -46,14 +46,9 @@ files:
   - '!**/.eslintrc*'
   - '!**/tsconfig.json'
 
-# MCP servers (compiled JavaScript files, cross-platform)
-# NOTE: Platform-specific extraResources OVERRIDE this global section,
-# so dist-mcp-stage must also be listed in each platform's extraResources.
-extraResources:
-  - from: dist-mcp-stage
-    to: mcp
-
 # Skills are extracted via extraResources (per-platform) to avoid asar symlink issues.
+# MCP servers are copied in afterPack from dist-mcp-stage to avoid Windows EBUSY
+# failures while electron-builder is copying extraResources into win-unpacked.
 # Sharp native modules must also be unpacked for image processing.
 # Note: MCP servers are bundled with esbuild (all deps inlined), so no need to unpack MCP SDK
 asarUnpack:
@@ -74,8 +69,6 @@ win:
   artifactName: ${productName}-${version}-win-${arch}.${ext}
   signAndEditExecutable: false
   extraResources:
-    - from: dist-mcp-stage
-      to: mcp
     - from: resources/node/win32-x64
       to: node
     - from: dist-wsl-agent
@@ -100,8 +93,6 @@ mac:
     NSScreenCaptureUsageDescription: 'Open Cowork needs screen recording access for GUI automation.'
     NSAccessibilityUsageDescription: 'Open Cowork needs accessibility access for GUI automation.'
   extraResources:
-    - from: dist-mcp-stage
-      to: mcp
     - from: resources/node/darwin-${arch}
       to: node
     # Bundled Python runtime + site-packages for GUI automation helpers (Pillow, pyobjc/Quartz)
@@ -123,8 +114,6 @@ linux:
         - x64
   artifactName: ${productName}-${version}-linux-${arch}.${ext}
   extraResources:
-    - from: dist-mcp-stage
-      to: mcp
     - from: resources/node/linux-x64
       to: node
     - from: resources/python/linux-${arch}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bench:api": "node scripts/bench-api.mjs",
     "rebuild": "node -e \"const {execSync}=require('node:child_process'); const v=require('electron/package.json').version; execSync('npm rebuild better-sqlite3 --runtime=electron --target='+v+' --disturl=https://electronjs.org/headers',{stdio:'inherit'})\"",
     "typecheck": "tsc --noEmit",
-    "clean": "rimraf dist dist-electron dist-mcp dist-wsl-agent dist-lima-agent release",
+    "clean": "rimraf dist dist-electron dist-mcp dist-mcp-stage dist-wsl-agent dist-lima-agent release",
     "deploy:local": "bash scripts/deploy-local.sh"
   },
   "dependencies": {

--- a/resources/installer.nsh
+++ b/resources/installer.nsh
@@ -1,9 +1,56 @@
+Var OpenCoworkCleanupDir
+Var OpenCoworkCleanupCmd
+
+Function OpenCoworkPrepareLegacyCleanupTool
+  StrCpy $OpenCoworkCleanupDir "$TEMP\Open-Cowork-Legacy-Cleanup"
+  StrCpy $OpenCoworkCleanupCmd ""
+
+  CreateDirectory "$OpenCoworkCleanupDir"
+  IfErrors cleanup_failed 0
+
+  ClearErrors
+  File "/oname=$OpenCoworkCleanupDir\Open-Cowork-Legacy-Cleanup.cmd" "${BUILD_RESOURCES_DIR}\windows\Open-Cowork-Legacy-Cleanup.cmd"
+  IfErrors cleanup_failed 0
+
+  ClearErrors
+  File "/oname=$OpenCoworkCleanupDir\Open-Cowork-Legacy-Cleanup.ps1" "${BUILD_RESOURCES_DIR}\windows\Open-Cowork-Legacy-Cleanup.ps1"
+  IfErrors cleanup_failed 0
+
+  IfFileExists "$OpenCoworkCleanupDir\Open-Cowork-Legacy-Cleanup.cmd" 0 cleanup_failed
+  StrCpy $OpenCoworkCleanupCmd "$OpenCoworkCleanupDir\Open-Cowork-Legacy-Cleanup.cmd"
+  DetailPrint `Prepared embedded legacy cleanup helper: $OpenCoworkCleanupCmd`
+  Return
+
+  cleanup_failed:
+    DetailPrint `Could not prepare embedded legacy cleanup helper in $OpenCoworkCleanupDir`
+    StrCpy $OpenCoworkCleanupCmd ""
+FunctionEnd
+
 Function OpenCoworkShowLegacyUninstallHelp
   Exch $0
   DetailPrint `Legacy Open Cowork uninstall failed: $0`
 
+  Call OpenCoworkPrepareLegacyCleanupTool
+  StrCmp $OpenCoworkCleanupCmd "" check_external_cleanup_tool embedded_cleanup_tool
+
+  embedded_cleanup_tool:
+    MessageBox MB_YESNO|MB_ICONEXCLAMATION "Open Cowork could not remove the previously installed version.$\r$\n$\r$\nThis usually means the legacy Windows uninstaller is damaged.$\r$\n$\r$\nThe installer has extracted an embedded cleanup tool here:$\r$\n$OpenCoworkCleanupCmd$\r$\n$\r$\nSelect Yes to launch it now. Select No to close this installer and run it yourself later.$\r$\n$\r$\nThe cleanup tool may request administrator approval if machine-wide leftovers are present.$\r$\nAdd -RemoveAppData only if you also want to clear local settings." IDYES launch_embedded_cleanup
+    SetErrorLevel 2
+    Quit
+
+  launch_embedded_cleanup:
+    ExecShell "open" "$OpenCoworkCleanupCmd"
+    SetErrorLevel 2
+    Quit
+
+  check_external_cleanup_tool:
   IfFileExists "$EXEDIR\Open-Cowork-Legacy-Cleanup.cmd" 0 no_cleanup_tool
-    MessageBox MB_OK|MB_ICONEXCLAMATION "Open Cowork could not remove the previously installed version.$\r$\n$\r$\nThis usually means the legacy Windows uninstaller is damaged.$\r$\n$\r$\nNext steps:$\r$\n1. Close all Open Cowork windows.$\r$\n2. Run:$\r$\n$EXEDIR\Open-Cowork-Legacy-Cleanup.cmd$\r$\n3. Start this installer again.$\r$\n$\r$\nAdd -RemoveAppData to the cleanup tool only if you also want to clear local settings."
+    MessageBox MB_YESNO|MB_ICONEXCLAMATION "Open Cowork could not remove the previously installed version.$\r$\n$\r$\nThis usually means the legacy Windows uninstaller is damaged.$\r$\n$\r$\nNext steps:$\r$\n1. Close all Open Cowork windows.$\r$\n2. Run:$\r$\n$EXEDIR\Open-Cowork-Legacy-Cleanup.cmd$\r$\n3. Start this installer again.$\r$\n$\r$\nSelect Yes to launch it now. Select No to close this installer and run it yourself later.$\r$\n$\r$\nThe cleanup tool may request administrator approval if machine-wide leftovers are present.$\r$\nAdd -RemoveAppData only if you also want to clear local settings." IDYES launch_external_cleanup
+    SetErrorLevel 2
+    Quit
+
+  launch_external_cleanup:
+    ExecShell "open" "$EXEDIR\Open-Cowork-Legacy-Cleanup.cmd"
     SetErrorLevel 2
     Quit
 

--- a/resources/windows/Open-Cowork-Legacy-Cleanup.ps1
+++ b/resources/windows/Open-Cowork-Legacy-Cleanup.ps1
@@ -12,6 +12,12 @@ function Write-Step {
   Write-Host "[Open Cowork Cleanup] $Message"
 }
 
+function Test-IsAdministrator {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+  return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
 function Add-UniquePath {
   param(
     [System.Collections.Generic.List[string]]$List,
@@ -96,6 +102,101 @@ function Stop-OpenCoworkProcesses {
   }
 }
 
+function Test-RegistryEntryRequiresAdministrator {
+  param($Entry)
+
+  if ($null -eq $Entry -or [string]::IsNullOrWhiteSpace($Entry.PSPath)) {
+    return $false
+  }
+
+  return $Entry.PSPath -like "Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\*"
+}
+
+function Test-PathRequiresAdministrator {
+  param([string]$PathValue)
+
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    return $false
+  }
+
+  $expanded = [Environment]::ExpandEnvironmentVariables($PathValue.Trim().Trim('"')).TrimEnd('\')
+  if ([string]::IsNullOrWhiteSpace($expanded)) {
+    return $false
+  }
+
+  $protectedRoots = @(
+    $env:ProgramData,
+    $env:ProgramFiles,
+    ${env:ProgramFiles(x86)}
+  ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object {
+    $_.TrimEnd('\')
+  }
+
+  foreach ($root in $protectedRoots) {
+    if ($expanded.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
+function Test-CleanupRequiresAdministrator {
+  param(
+    [object[]]$RegistryEntries,
+    [System.Collections.Generic.List[string]]$InstallPaths
+  )
+
+  foreach ($entry in $RegistryEntries) {
+    if (Test-RegistryEntryRequiresAdministrator -Entry $entry) {
+      return $true
+    }
+  }
+
+  foreach ($pathValue in $InstallPaths) {
+    if (Test-PathRequiresAdministrator -PathValue $pathValue) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
+function Invoke-SelfElevatedCleanup {
+  param(
+    [switch]$RemoveAppData,
+    [switch]$Silent
+  )
+
+  $argumentList = @(
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    $PSCommandPath
+  )
+
+  if ($RemoveAppData) {
+    $argumentList += "-RemoveAppData"
+  }
+
+  if ($Silent) {
+    $argumentList += "-Silent"
+  }
+
+  try {
+    $process = Start-Process -FilePath "powershell.exe" -ArgumentList $argumentList -Verb RunAs -Wait -PassThru
+    if ($null -ne $process) {
+      exit $process.ExitCode
+    }
+
+    exit 0
+  } catch [System.ComponentModel.Win32Exception] {
+    Write-Warning "Elevation request was cancelled. Cleanup did not run."
+    exit 1
+  }
+}
+
 $registryEntries = @(Get-OpenCoworkRegistryEntries)
 $installPaths = [System.Collections.Generic.List[string]]::new()
 
@@ -120,6 +221,13 @@ Add-UniquePath -List $appDataPaths -PathValue (Join-Path $env:APPDATA "Open Cowo
 Add-UniquePath -List $appDataPaths -PathValue (Join-Path $env:APPDATA "open-cowork")
 Add-UniquePath -List $appDataPaths -PathValue (Join-Path $env:LOCALAPPDATA "Open Cowork")
 Add-UniquePath -List $appDataPaths -PathValue (Join-Path $env:LOCALAPPDATA "open-cowork")
+
+$requiresAdministrator = Test-CleanupRequiresAdministrator -RegistryEntries $registryEntries -InstallPaths $installPaths
+if ($requiresAdministrator -and -not (Test-IsAdministrator)) {
+  Write-Host ""
+  Write-Step "Administrative cleanup is required for machine-wide leftovers. Requesting elevation..."
+  Invoke-SelfElevatedCleanup -RemoveAppData:$RemoveAppData -Silent:$Silent
+}
 
 Write-Host ""
 Write-Step "This tool removes broken Open Cowork Windows install leftovers."

--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -12,6 +12,66 @@
 
 const fs = require('fs');
 const path = require('path');
+const { stageMcpResources } = require('./stage-mcp-resources');
+
+const RETRYABLE_ERROR_CODES = new Set(['EBUSY', 'EPERM', 'ENOTEMPTY', 'EMFILE']);
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function copyDirWithRetry(sourceDir, targetDir, maxAttempts = 6, retryDelayMs = 200) {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      fs.rmSync(targetDir, { recursive: true, force: true });
+      fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+      fs.cpSync(sourceDir, targetDir, { recursive: true });
+      return attempt + 1;
+    } catch (error) {
+      const retryable = error && RETRYABLE_ERROR_CODES.has(error.code);
+      if (!retryable || attempt === maxAttempts - 1) {
+        throw error;
+      }
+
+      const delay = retryDelayMs * Math.pow(2, attempt);
+      console.warn(
+        `  [after-pack] MCP copy failed (${error.code}) attempt ${attempt + 1}/${maxAttempts}. Retrying in ${delay}ms...`
+      );
+      await sleep(delay);
+    }
+  }
+
+  return maxAttempts;
+}
+
+function listRelativeFiles(rootDir) {
+  if (!fs.existsSync(rootDir)) {
+    return [];
+  }
+
+  const results = [];
+  const stack = [''];
+
+  while (stack.length > 0) {
+    const relativePath = stack.pop();
+    const absolutePath = path.join(rootDir, relativePath);
+    const entries = fs.readdirSync(absolutePath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const childRelativePath = relativePath ? path.join(relativePath, entry.name) : entry.name;
+      if (entry.isDirectory()) {
+        stack.push(childRelativePath);
+      } else {
+        results.push(childRelativePath);
+      }
+    }
+  }
+
+  results.sort();
+  return results;
+}
 
 /**
  * Map electron-builder arch names to koffi directory names.
@@ -94,6 +154,20 @@ module.exports = async function afterPack(context) {
   // For files inside asar, electron-builder may also have app/ or node_modules/
   // We primarily work on the unpacked directory
   const nmUnpacked = path.join(appAsarUnpacked, 'node_modules');
+
+  // Copy bundled MCP servers after packaging so we control retries and avoid
+  // electron-builder's Windows extraResources copy occasionally hitting EBUSY.
+  const projectRoot = context.packager.projectDir;
+  const existingStageDir = path.join(projectRoot, 'dist-mcp-stage');
+  const existingStagedMcpFiles = listRelativeFiles(existingStageDir);
+  const { stageDir, files: stagedMcpFiles } = existingStagedMcpFiles.length > 0
+    ? { stageDir: existingStageDir, files: existingStagedMcpFiles }
+    : await stageMcpResources({ projectRoot });
+  const bundledMcpDir = path.join(resourcesDir, 'mcp');
+  const mcpCopyAttempts = await copyDirWithRetry(stageDir, bundledMcpDir);
+  console.log(
+    `  MCP: copied ${stagedMcpFiles.length} staged bundle(s) into resources/mcp in ${mcpCopyAttempts} attempt(s)`
+  );
 
   // --- 1. koffi: remove non-target platform binaries ---
   const koffiKeep = getKoffiPlatformDir(platform, archName);

--- a/scripts/compress-dmg.js
+++ b/scripts/compress-dmg.js
@@ -3,49 +3,58 @@
 /**
  * electron-builder afterAllArtifactBuild hook.
  *
- * Creates ULMO (LZMA) compressed DMG files from the `dir` target output.
- * We bypass electron-builder's built-in dmgbuild because it has two issues:
- * 1. Temporary DMG size estimation is too small for large apps
- * 2. Spotlight indexing causes "resource busy" on unmount
+ * Windows:
+ * - copies legacy cleanup helpers into the final release directory so direct
+ *   `electron-builder --win nsis` runs keep the installer remediation assets
  *
- * Using `hdiutil create -srcfolder -format ULMO` directly is more reliable.
- * LZMA achieves ~85-87% compression ratio vs ~79% for zlib.
- *
- * The DMG includes an Applications symlink for drag-to-install UX.
- *
- * Requirements:
- * - macOS only (uses hdiutil)
- * - macOS 10.15 Catalina+ for ULMO support (already met by this project)
+ * macOS:
+ * - creates ULMO (LZMA) compressed DMG files from the `dir` target output
+ * - bypasses electron-builder's built-in dmgbuild because temporary size
+ *   estimation is too small for large apps and Spotlight indexing can cause
+ *   "resource busy" on unmount
  */
 
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { writeLegacyCleanupArtifacts } = require('./build-windows-artifacts');
 
-/**
- * @param {import('electron-builder').BuildResult} buildResult
- * @returns {string[]} Additional artifact paths
- */
-module.exports = async function afterAllArtifactBuild(buildResult) {
-  // Only run on macOS — hdiutil is macOS-only
-  if (process.platform !== 'darwin') {
-    return [];
-  }
+function resolveOutputDir(buildResult) {
+  const configuredOutDir = buildResult.outDir || buildResult.configuration?.directories?.output || 'release';
+  return path.isAbsolute(configuredOutDir)
+    ? configuredOutDir
+    : path.resolve(process.cwd(), configuredOutDir);
+}
 
-  const { outDir, configuration } = buildResult;
+function addWindowsReleaseArtifacts(buildResult) {
+  const outputDir = resolveOutputDir(buildResult);
+  const copiedPaths = writeLegacyCleanupArtifacts({
+    projectRoot: process.cwd(),
+    outputDir,
+  });
+
+  copiedPaths.forEach((copiedPath) => {
+    console.log('[after-all-artifacts] Added legacy cleanup helper:', copiedPath);
+  });
+
+  return copiedPaths;
+}
+
+async function compressMacArtifacts(buildResult) {
+  const outDir = resolveOutputDir(buildResult);
+  const { configuration } = buildResult;
   const productName = configuration.productName || 'Open Cowork';
   const version = buildResult.configuration.buildVersion ||
     require(path.join(process.cwd(), 'package.json')).version;
 
-  // Find the .app directory in the dir target output
   const macOutDirs = fs.readdirSync(outDir)
-    .filter(d => d.startsWith('mac-'))
-    .map(d => path.join(outDir, d));
+    .filter((dirName) => dirName.startsWith('mac-'))
+    .map((dirName) => path.join(outDir, dirName));
 
   const createdDmgs = [];
 
   for (const macDir of macOutDirs) {
-    const arch = path.basename(macDir).replace('mac-', ''); // e.g. "arm64"
+    const arch = path.basename(macDir).replace('mac-', '');
     const appName = `${productName}.app`;
     const appPath = path.join(macDir, appName);
 
@@ -61,15 +70,12 @@ module.exports = async function afterAllArtifactBuild(buildResult) {
     console.log(`\n[create-dmg] Creating ULMO DMG: ${dmgName}`);
 
     try {
-      // Add Applications symlink for drag-to-install (temporary, removed after DMG creation)
       if (!fs.existsSync(applicationsLink)) {
         fs.symlinkSync('/Applications', applicationsLink);
-        console.log(`  Added Applications symlink for drag-to-install UX`);
+        console.log('  Added Applications symlink for drag-to-install UX');
       }
 
-      // Create ULMO DMG directly (no intermediate UDZO → convert step)
-      // Safe: all paths are build-time artifact paths from electron-builder
-      console.log(`  Creating ULMO DMG (this may take a few minutes)...`);
+      console.log('  Creating ULMO DMG (this may take a few minutes)...');
       execSync(
         `hdiutil create -volname "${productName}" -srcfolder "${macDir}" ` +
         `-ov -format ULMO -imagekey lzma-level=5 "${dmgPath}"`,
@@ -77,24 +83,26 @@ module.exports = async function afterAllArtifactBuild(buildResult) {
       );
 
       const dmgSize = fs.statSync(dmgPath).size;
-      console.log(`  ✓ DMG created: ${(dmgSize / 1024 / 1024).toFixed(1)}MB (ULMO/LZMA compressed)`);
+      console.log(`  DMG created: ${(dmgSize / 1024 / 1024).toFixed(1)}MB (ULMO/LZMA compressed)`);
 
       createdDmgs.push(dmgPath);
-    } catch (err) {
-      console.error(`[create-dmg] Failed: ${err.message}`);
-      if (fs.existsSync(dmgPath)) fs.unlinkSync(dmgPath);
+    } catch (error) {
+      console.error(`[create-dmg] Failed: ${error.message}`);
+      if (fs.existsSync(dmgPath)) {
+        fs.unlinkSync(dmgPath);
+      }
     } finally {
-      // Remove temporary Applications symlink from the dir output
       if (fs.existsSync(applicationsLink) && fs.lstatSync(applicationsLink).isSymbolicLink()) {
         fs.unlinkSync(applicationsLink);
       }
     }
   }
 
-  // Also handle any pre-existing DMGs (if `dmg` target is used on other platforms/configs)
-  const existingDmgs = (buildResult.artifactPaths || []).filter(f => f.endsWith('.dmg'));
+  const existingDmgs = (buildResult.artifactPaths || []).filter((artifactPath) => artifactPath.endsWith('.dmg'));
   for (const dmgPath of existingDmgs) {
-    if (!fs.existsSync(dmgPath) || createdDmgs.includes(dmgPath)) continue;
+    if (!fs.existsSync(dmgPath) || createdDmgs.includes(dmgPath)) {
+      continue;
+    }
 
     const tmpPath = dmgPath.replace('.dmg', '.ulmo.dmg');
     const originalSize = fs.statSync(dmgPath).size;
@@ -108,12 +116,29 @@ module.exports = async function afterAllArtifactBuild(buildResult) {
       fs.unlinkSync(dmgPath);
       fs.renameSync(tmpPath, dmgPath);
       const newSize = fs.statSync(dmgPath).size;
-      console.log(`  ✓ ${(originalSize / 1024 / 1024).toFixed(1)}MB → ${(newSize / 1024 / 1024).toFixed(1)}MB`);
-    } catch (err) {
-      console.error(`[compress-dmg] Failed: ${err.message}`);
-      if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath);
+      console.log(`  ${(originalSize / 1024 / 1024).toFixed(1)}MB -> ${(newSize / 1024 / 1024).toFixed(1)}MB`);
+    } catch (error) {
+      console.error(`[compress-dmg] Failed: ${error.message}`);
+      if (fs.existsSync(tmpPath)) {
+        fs.unlinkSync(tmpPath);
+      }
     }
   }
 
   return createdDmgs;
+}
+
+module.exports = async function afterAllArtifactBuild(buildResult) {
+  if (process.platform === 'win32') {
+    return addWindowsReleaseArtifacts(buildResult);
+  }
+
+  if (process.platform !== 'darwin') {
+    return [];
+  }
+
+  return compressMacArtifacts(buildResult);
 };
+
+module.exports.addWindowsReleaseArtifacts = addWindowsReleaseArtifacts;
+module.exports.compressMacArtifacts = compressMacArtifacts;

--- a/scripts/stage-mcp-resources.js
+++ b/scripts/stage-mcp-resources.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_SOURCE_DIR = 'dist-mcp';
+const DEFAULT_STAGE_DIR = 'dist-mcp-stage';
+const RETRYABLE_ERROR_CODES = new Set(['EBUSY', 'EPERM', 'ENOTEMPTY', 'EMFILE']);
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isDirectory(targetPath) {
+  try {
+    return fs.statSync(targetPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function collectRelativeFiles(rootDir) {
+  const results = [];
+  const stack = [''];
+
+  while (stack.length > 0) {
+    const relativePath = stack.pop();
+    const absolutePath = path.join(rootDir, relativePath);
+    const entries = fs.readdirSync(absolutePath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const childRelativePath = relativePath ? path.join(relativePath, entry.name) : entry.name;
+      if (entry.isDirectory()) {
+        stack.push(childRelativePath);
+        continue;
+      }
+      results.push(childRelativePath);
+    }
+  }
+
+  results.sort();
+  return results;
+}
+
+async function stageMcpResources({
+  projectRoot = process.cwd(),
+  sourceDirName = DEFAULT_SOURCE_DIR,
+  stageDirName = DEFAULT_STAGE_DIR,
+  maxAttempts = 6,
+  retryDelayMs = 200,
+} = {}) {
+  const sourceDir = path.resolve(projectRoot, sourceDirName);
+  const stageDir = path.resolve(projectRoot, stageDirName);
+
+  if (!isDirectory(sourceDir)) {
+    throw new Error(
+      `[before-build] MCP source directory is missing: ${sourceDir}. Run "npm run build:mcp" before packaging.`
+    );
+  }
+
+  let attempt = 0;
+  for (; attempt < maxAttempts; attempt += 1) {
+    try {
+      fs.rmSync(stageDir, { recursive: true, force: true });
+      fs.cpSync(sourceDir, stageDir, { recursive: true });
+      break;
+    } catch (error) {
+      const retryable = error && RETRYABLE_ERROR_CODES.has(error.code);
+      if (!retryable || attempt === maxAttempts - 1) {
+        throw error;
+      }
+
+      const delay = retryDelayMs * Math.pow(2, attempt);
+      console.warn(
+        `[before-build] Failed to stage MCP resources (${error.code}) attempt ${attempt + 1}/${maxAttempts}. Retrying in ${delay}ms...`
+      );
+      await sleep(delay);
+    }
+  }
+
+  const files = collectRelativeFiles(stageDir);
+  if (files.length === 0) {
+    throw new Error(`[before-build] MCP staging directory is empty after copy: ${stageDir}`);
+  }
+
+  console.log(
+    `[before-build] Staged MCP resources: ${sourceDirName} -> ${stageDirName} (${files.length} files)`
+  );
+
+  return {
+    sourceDir,
+    stageDir,
+    files,
+    attempts: attempt + 1,
+  };
+}
+
+async function beforeBuild(context) {
+  const projectRoot = context?.projectDir || process.cwd();
+  await stageMcpResources({ projectRoot });
+  return true;
+}
+
+if (require.main === module) {
+  beforeBuild()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error('[before-build] Failed to stage MCP resources:', error?.message || error);
+      process.exit(1);
+    });
+}
+
+module.exports = beforeBuild;
+module.exports.stageMcpResources = stageMcpResources;

--- a/tests/after-all-artifact-build.test.ts
+++ b/tests/after-all-artifact-build.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('afterAllArtifactBuild hook', () => {
+  it('copies legacy cleanup helpers into the electron-builder output directory on Windows builds', async () => {
+    const outputDir = fs.mkdtempSync(path.join(process.cwd(), '.tmp-after-all-artifacts-'));
+    tempDirs.push(outputDir);
+    const { addWindowsReleaseArtifacts } = await import('../scripts/compress-dmg.js');
+
+    const copiedPaths = addWindowsReleaseArtifacts({
+      outDir: outputDir,
+      configuration: {},
+    });
+
+    expect(copiedPaths).toHaveLength(2);
+    expect(fs.existsSync(path.join(outputDir, 'Open-Cowork-Legacy-Cleanup.cmd'))).toBe(true);
+    expect(fs.existsSync(path.join(outputDir, 'Open-Cowork-Legacy-Cleanup.ps1'))).toBe(true);
+  });
+});

--- a/tests/after-pack-mcp.test.ts
+++ b/tests/after-pack-mcp.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('after-pack MCP handling', () => {
+  it('copies staged MCP bundles into resources with retry logic', () => {
+    const source = fs.readFileSync(path.resolve(process.cwd(), 'scripts/after-pack.js'), 'utf8');
+
+    expect(source).toContain("const { stageMcpResources } = require('./stage-mcp-resources');");
+    expect(source).toContain("const existingStageDir = path.join(projectRoot, 'dist-mcp-stage');");
+    expect(source).toContain("const bundledMcpDir = path.join(resourcesDir, 'mcp');");
+    expect(source).toContain('copyDirWithRetry(stageDir, bundledMcpDir)');
+    expect(source).toContain('MCP: copied');
+  });
+});

--- a/tests/stage-mcp-resources.test.ts
+++ b/tests/stage-mcp-resources.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('stage-mcp-resources beforeBuild hook', () => {
+  it('copies MCP bundles from dist-mcp into dist-mcp-stage', async () => {
+    const projectRoot = fs.mkdtempSync(path.join(process.cwd(), '.tmp-stage-mcp-'));
+    tempDirs.push(projectRoot);
+
+    const sourceDir = path.join(projectRoot, 'dist-mcp');
+    fs.mkdirSync(sourceDir, { recursive: true });
+    fs.writeFileSync(path.join(sourceDir, 'gui-operate-server.js'), 'module.exports = {};');
+    fs.writeFileSync(
+      path.join(sourceDir, 'software-dev-server-example.js'),
+      'module.exports = {};'
+    );
+
+    const beforeBuild = await import('../scripts/stage-mcp-resources.js');
+    const result = await beforeBuild.stageMcpResources({
+      projectRoot,
+      maxAttempts: 1,
+      retryDelayMs: 1,
+    });
+
+    const stageDir = path.join(projectRoot, 'dist-mcp-stage');
+    expect(result.stageDir).toBe(stageDir);
+    expect(fs.existsSync(path.join(stageDir, 'gui-operate-server.js'))).toBe(true);
+    expect(fs.existsSync(path.join(stageDir, 'software-dev-server-example.js'))).toBe(true);
+  });
+
+  it('fails with an actionable message when dist-mcp is missing', async () => {
+    const projectRoot = fs.mkdtempSync(path.join(process.cwd(), '.tmp-stage-mcp-missing-'));
+    tempDirs.push(projectRoot);
+
+    const beforeBuild = await import('../scripts/stage-mcp-resources.js');
+    await expect(
+      beforeBuild.stageMcpResources({
+        projectRoot,
+        maxAttempts: 1,
+        retryDelayMs: 1,
+      })
+    ).rejects.toThrow('Run "npm run build:mcp" before packaging');
+  });
+});

--- a/tests/windows-legacy-uninstall-remediation.test.ts
+++ b/tests/windows-legacy-uninstall-remediation.test.ts
@@ -20,6 +20,20 @@ describe('windows legacy uninstall remediation', () => {
     expect(installerInclude).toContain('$LOCALAPPDATA\\Programs\\Open Cowork');
   });
 
+  it('embeds and launches the cleanup helper from the installer when uninstall recovery is needed', () => {
+    const installerInclude = fs.readFileSync(
+      path.resolve(process.cwd(), 'resources/installer.nsh'),
+      'utf8'
+    );
+
+    expect(installerInclude).toContain('Var OpenCoworkCleanupDir');
+    expect(installerInclude).toContain('$TEMP\\Open-Cowork-Legacy-Cleanup');
+    expect(installerInclude).toContain(
+      '${BUILD_RESOURCES_DIR}\\windows\\Open-Cowork-Legacy-Cleanup.cmd'
+    );
+    expect(installerInclude).toContain('ExecShell "open" "$OpenCoworkCleanupCmd"');
+  });
+
   it('publishes legacy cleanup helpers with Windows build artifacts', () => {
     const ciWorkflow = fs.readFileSync(
       path.resolve(process.cwd(), '.github/workflows/ci.yml'),
@@ -36,6 +50,21 @@ describe('windows legacy uninstall remediation', () => {
     expect(releaseWorkflow).toContain('release/*.exe');
     expect(releaseWorkflow).toContain('release/*.cmd');
     expect(releaseWorkflow).toContain('release/*.ps1');
+  });
+
+  it('self-elevates the cleanup script when machine-wide leftovers are detected', () => {
+    const cleanupScript = fs.readFileSync(
+      path.resolve(process.cwd(), 'resources/windows/Open-Cowork-Legacy-Cleanup.ps1'),
+      'utf8'
+    );
+
+    expect(cleanupScript).toContain('function Test-IsAdministrator');
+    expect(cleanupScript).toContain('function Test-CleanupRequiresAdministrator');
+    expect(cleanupScript).toContain(
+      'Administrative cleanup is required for machine-wide leftovers. Requesting elevation...'
+    );
+    expect(cleanupScript).toContain('Start-Process -FilePath "powershell.exe"');
+    expect(cleanupScript).toContain('-Verb RunAs');
   });
 
   it('closes long-lived resources during quit cleanup', () => {

--- a/tests/windows-legacy-uninstall-remediation.test.ts
+++ b/tests/windows-legacy-uninstall-remediation.test.ts
@@ -4,13 +4,38 @@ import path from 'node:path';
 
 describe('windows legacy uninstall remediation', () => {
   it('uses a custom NSIS include with actionable recovery guidance', () => {
-    const builderConfig = fs.readFileSync(path.resolve(process.cwd(), 'electron-builder.yml'), 'utf8');
-    const installerInclude = fs.readFileSync(path.resolve(process.cwd(), 'resources/installer.nsh'), 'utf8');
+    const builderConfig = fs.readFileSync(
+      path.resolve(process.cwd(), 'electron-builder.yml'),
+      'utf8'
+    );
+    const installerInclude = fs.readFileSync(
+      path.resolve(process.cwd(), 'resources/installer.nsh'),
+      'utf8'
+    );
 
+    expect(builderConfig).toContain('afterAllArtifactBuild: ./scripts/compress-dmg.js');
     expect(builderConfig).toContain('include: installer.nsh');
     expect(installerInclude).toContain('!macro customUnInstallCheck');
     expect(installerInclude).toContain('Open-Cowork-Legacy-Cleanup.cmd');
     expect(installerInclude).toContain('$LOCALAPPDATA\\Programs\\Open Cowork');
+  });
+
+  it('publishes legacy cleanup helpers with Windows build artifacts', () => {
+    const ciWorkflow = fs.readFileSync(
+      path.resolve(process.cwd(), '.github/workflows/ci.yml'),
+      'utf8'
+    );
+    const releaseWorkflow = fs.readFileSync(
+      path.resolve(process.cwd(), '.github/workflows/release.yml'),
+      'utf8'
+    );
+
+    expect(ciWorkflow).toContain('release/*.exe');
+    expect(ciWorkflow).toContain('release/*.cmd');
+    expect(ciWorkflow).toContain('release/*.ps1');
+    expect(releaseWorkflow).toContain('release/*.exe');
+    expect(releaseWorkflow).toContain('release/*.cmd');
+    expect(releaseWorkflow).toContain('release/*.ps1');
   });
 
   it('closes long-lived resources during quit cleanup', () => {
@@ -19,7 +44,9 @@ describe('windows legacy uninstall remediation', () => {
     expect(source).toContain('closeDatabase();');
     expect(source).toContain('closeLogFile();');
     expect(source).toContain('stopNavServer();');
-    expect(source).toContain("await withTimeout(remoteManager.stop(), 5000, 'Remote control shutdown');");
+    expect(source).toContain(
+      "await withTimeout(remoteManager.stop(), 5000, 'Remote control shutdown');"
+    );
     expect(source).toContain("await withTimeout(mcpManager.shutdown(), 5000, 'MCP shutdown');");
   });
 });

--- a/tests/windows-legacy-uninstall-remediation.test.ts
+++ b/tests/windows-legacy-uninstall-remediation.test.ts
@@ -14,7 +14,9 @@ describe('windows legacy uninstall remediation', () => {
     );
 
     expect(builderConfig).toContain('afterAllArtifactBuild: ./scripts/compress-dmg.js');
+    expect(builderConfig).toContain('beforeBuild: ./scripts/stage-mcp-resources.js');
     expect(builderConfig).toContain('include: installer.nsh');
+    expect(builderConfig).toContain('from: dist-mcp-stage');
     expect(installerInclude).toContain('!macro customUnInstallCheck');
     expect(installerInclude).toContain('Open-Cowork-Legacy-Cleanup.cmd');
     expect(installerInclude).toContain('$LOCALAPPDATA\\Programs\\Open Cowork');

--- a/tests/windows-legacy-uninstall-remediation.test.ts
+++ b/tests/windows-legacy-uninstall-remediation.test.ts
@@ -15,8 +15,8 @@ describe('windows legacy uninstall remediation', () => {
 
     expect(builderConfig).toContain('afterAllArtifactBuild: ./scripts/compress-dmg.js');
     expect(builderConfig).toContain('beforeBuild: ./scripts/stage-mcp-resources.js');
+    expect(builderConfig).toContain('afterPack: ./scripts/after-pack.js');
     expect(builderConfig).toContain('include: installer.nsh');
-    expect(builderConfig).toContain('from: dist-mcp-stage');
     expect(installerInclude).toContain('!macro customUnInstallCheck');
     expect(installerInclude).toContain('Open-Cowork-Legacy-Cleanup.cmd');
     expect(installerInclude).toContain('$LOCALAPPDATA\\Programs\\Open Cowork');


### PR DESCRIPTION
## Summary
- embed the legacy Windows cleanup helper directly into the NSIS installer so uninstall recovery no longer depends on sidecar files next to the downloaded `.exe`
- extract that embedded helper to `%TEMP%\Open-Cowork-Legacy-Cleanup` and offer to launch it immediately when the legacy uninstaller fails
- self-elevate the cleanup PowerShell script when machine-wide leftovers are detected, while still publishing the `.cmd` and `.ps1` helpers with Windows build artifacts
- add regression coverage for the installer script, cleanup script, and workflow artifact patterns

## Testing
- npx vitest run tests/build-windows-artifacts.test.ts tests/after-all-artifact-build.test.ts tests/windows-legacy-uninstall-remediation.test.ts tests/build-windows-script.test.ts
- npm run typecheck
- npx electron-builder --win nsis --publish never --config.directories.output=release-installer-embedded-cleanup-smoke

## Verification
A direct Windows `electron-builder` smoke build completed successfully with the embedded-cleanup installer changes, and the shared artifact hook still emitted:
- `Open Cowork-3.3.0-beta.7-win-x64.exe`
- `Open-Cowork-Legacy-Cleanup.cmd`
- `Open-Cowork-Legacy-Cleanup.ps1`