### PR TITLE
ci: skip platform builds on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
 
   build-macos:
     name: Build macOS
+    if: github.event_name == 'push'
+    needs: lint-and-test
     runs-on: macos-14
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -184,6 +186,8 @@ jobs:
 
   build-windows:
     name: Build Windows
+    if: github.event_name == 'push'
+    needs: lint-and-test
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary
- Build macOS and Build Windows jobs now only run on **push to main/dev**, skipped on PRs
- Builds depend on lint-and-test passing first (`needs: lint-and-test`)
- PR quality is covered by lint + test (~2-3 min) + Codex AI review (~7 min)

## Before vs After

| Event | Before | After |
|-------|--------|-------|
| PR | lint + test + macOS build + Windows build (~15-20 min) | lint + test only (~2-3 min) |
| Push to main | lint + test + macOS build + Windows build (parallel) | lint + test → macOS build + Windows build (sequential) |

## Test plan
- [ ] Open a PR and verify only lint-and-test runs (no build jobs)
- [ ] Merge to main and verify all 3 jobs run