### PR TITLE
fix(remote): resolve Feishu WebSocket connection failures

### DIFF
--- a/src/main/remote/channels/feishu/feishu-ws-client.ts
+++ b/src/main/remote/channels/feishu/feishu-ws-client.ts
@@ -34,6 +34,7 @@ export class FeishuWSClient extends EventEmitter {
   private wsClient: Lark.WSClient | null = null;
   private connected: boolean = false;
   private stopped: boolean = false;
+  private starting: boolean = false;
   private reconnectAttempts: number = 0;
   private maxReconnectAttempts: number = 10;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -47,31 +48,33 @@ export class FeishuWSClient extends EventEmitter {
    * Start the WebSocket connection
    */
   async start(): Promise<void> {
-    if (this.connected) {
-      logWarn('[FeishuWS] Already connected');
+    if (this.connected || this.starting) {
+      logWarn('[FeishuWS] Already connected or connecting');
       return;
     }
 
-    // Allow re-use after a stop()
+    this.starting = true;
     this.stopped = false;
 
     const { appId, appSecret } = this.config;
 
     if (!appId || !appSecret) {
+      this.starting = false;
       throw new Error('Feishu appId and appSecret are required');
     }
 
     log('[FeishuWS] Starting long connection...');
 
     try {
-      // Create API client for sending messages
+      // Close any lingering previous connection before creating a new one
+      await this.closeWSClient();
+
       this.client = new Lark.Client({
         appId,
         appSecret,
         disableTokenCache: false,
       });
 
-      // Create WebSocket client for receiving messages
       const loggerLevel = this.getLoggerLevel();
 
       this.wsClient = new Lark.WSClient({
@@ -80,10 +83,16 @@ export class FeishuWSClient extends EventEmitter {
         loggerLevel,
       });
 
-      // Start WebSocket connection with event dispatcher
+      // Bail out if stop() was called while we were setting up
+      if (this.stopped) {
+        await this.closeWSClient();
+        this.client = null;
+        this.starting = false;
+        return;
+      }
+
       await this.wsClient.start({
         eventDispatcher: new Lark.EventDispatcher({}).register({
-          // Handle im.message.receive_v1 event (receive message v2.0)
           'im.message.receive_v1': async (data: Record<string, unknown>) => {
             try {
               await this.handleMessageReceive(data);
@@ -94,16 +103,25 @@ export class FeishuWSClient extends EventEmitter {
         }),
       });
 
+      // Double-check: stop() may have been called during the async start above
+      if (this.stopped) {
+        await this.closeWSClient();
+        this.client = null;
+        this.starting = false;
+        return;
+      }
+
       this.connected = true;
+      this.starting = false;
       this.reconnectAttempts = 0;
       log('[FeishuWS] Long connection established successfully');
       this.emit('connected');
     } catch (error) {
+      this.starting = false;
       logError('[FeishuWS] Failed to start:', error);
       this.connected = false;
       this.emit('error', error);
 
-      // Try to reconnect
       this.scheduleReconnect();
     }
   }
@@ -116,20 +134,31 @@ export class FeishuWSClient extends EventEmitter {
 
     this.stopped = true;
 
-    // Cancel any pending reconnect timer
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
 
-    // Note: The Lark SDK doesn't expose a direct stop method
-    // Setting to null will allow garbage collection
-    this.wsClient = null;
+    await this.closeWSClient();
     this.client = null;
     this.connected = false;
 
     this.emit('disconnected');
     log('[FeishuWS] Long connection stopped');
+  }
+
+  /**
+   * Close the underlying Lark WSClient connection
+   */
+  private async closeWSClient(): Promise<void> {
+    if (this.wsClient) {
+      try {
+        this.wsClient.close({ force: true });
+      } catch (err) {
+        logWarn('[FeishuWS] Error closing WSClient:', err);
+      }
+      this.wsClient = null;
+    }
   }
 
   /**

--- a/src/main/remote/gateway.ts
+++ b/src/main/remote/gateway.ts
@@ -347,7 +347,7 @@ export class RemoteGateway extends EventEmitter {
         if (!allowlist || allowlist.length === 0) {
           return false; // Empty allowlist means deny all
         }
-        return allowlist.includes(message.sender.id);
+        return allowlist.includes(`${message.channelType}:${message.sender.id}`);
 
       case 'pairing': {
         // Check if user is paired

--- a/src/main/remote/gateway.ts
+++ b/src/main/remote/gateway.ts
@@ -347,7 +347,11 @@ export class RemoteGateway extends EventEmitter {
         if (!allowlist || allowlist.length === 0) {
           return false; // Empty allowlist means deny all
         }
-        return allowlist.includes(`${message.channelType}:${message.sender.id}`);
+        // Support both scoped (channelType:userId) and legacy (userId) formats
+        return (
+          allowlist.includes(`${message.channelType}:${message.sender.id}`) ||
+          allowlist.includes(message.sender.id)
+        );
 
       case 'pairing': {
         // Check if user is paired

--- a/src/main/remote/remote-config-store.ts
+++ b/src/main/remote/remote-config-store.ts
@@ -65,9 +65,10 @@ class RemoteConfigStore {
   private migrateAuthMode(): void {
     const gateway = this.store.get('gateway');
     if (gateway?.auth?.mode === 'pairing') {
-      // Carry over already-paired user IDs so they are not locked out
+      // Carry over already-paired user IDs so they are not locked out.
+      // Use channelType:userId format to preserve channel scoping.
       const pairedUsers = this.store.get('pairedUsers', []);
-      const allowlist = pairedUsers.map((u: PairedUser) => u.userId);
+      const allowlist = pairedUsers.map((u: PairedUser) => `${u.channelType}:${u.userId}`);
 
       log(
         '[RemoteConfig] Migrating auth mode from pairing to allowlist, preserving',
@@ -235,6 +236,7 @@ class RemoteConfigStore {
     }
 
     this.store.set('pairedUsers', users);
+    this.syncAllowlist(users);
     log('[RemoteConfig] Paired user added:', user.userId);
   }
 
@@ -247,11 +249,25 @@ class RemoteConfigStore {
 
     if (newUsers.length !== users.length) {
       this.store.set('pairedUsers', newUsers);
+      this.syncAllowlist(newUsers);
       log('[RemoteConfig] Paired user removed:', userId);
       return true;
     }
 
     return false;
+  }
+
+  /**
+   * Sync allowlist from paired users when auth mode is allowlist
+   */
+  private syncAllowlist(users: PairedUser[]): void {
+    const gateway = this.store.get('gateway');
+    if (gateway?.auth?.mode === 'allowlist') {
+      this.store.set(
+        'gateway.auth.allowlist',
+        users.map((u) => `${u.channelType}:${u.userId}`)
+      );
+    }
   }
 
   /**

--- a/src/main/remote/remote-config-store.ts
+++ b/src/main/remote/remote-config-store.ts
@@ -27,7 +27,10 @@ class RemoteConfigStore {
   constructor() {
     // Cast to satisfy the Record<string, unknown> constraint of the encrypted store utility;
     // RemoteConfig & { pairedUsers: PairedUser[] } is structurally compatible at runtime.
-    type RemoteConfigRecord = RemoteConfig & { pairedUsers: PairedUser[] } & Record<string, unknown>;
+    type RemoteConfigRecord = RemoteConfig & { pairedUsers: PairedUser[] } & Record<
+        string,
+        unknown
+      >;
     this.store = createEncryptedStoreWithKeyRotation<RemoteConfigRecord>({
       stableKey: 'open-cowork-remote-stable-v1',
       legacyKeys: [
@@ -51,26 +54,34 @@ class RemoteConfigStore {
       log,
       warn: logWarn,
     }) as unknown as Store<RemoteConfig & { pairedUsers: PairedUser[] }>;
-    
+
     // Migrate: change pairing mode to allowlist (allow everyone by default)
     this.migrateAuthMode();
   }
-  
+
   /**
-   * Migrate old pairing mode to allowlist
+   * Migrate old pairing mode to allowlist, preserving existing paired users
    */
   private migrateAuthMode(): void {
     const gateway = this.store.get('gateway');
     if (gateway?.auth?.mode === 'pairing') {
-      log('[RemoteConfig] Migrating auth mode from pairing to allowlist');
+      // Carry over already-paired user IDs so they are not locked out
+      const pairedUsers = this.store.get('pairedUsers', []);
+      const allowlist = pairedUsers.map((u: PairedUser) => u.userId);
+
+      log(
+        '[RemoteConfig] Migrating auth mode from pairing to allowlist, preserving',
+        allowlist.length,
+        'users'
+      );
       this.store.set('gateway.auth', {
         mode: 'allowlist',
-        allowlist: [],
+        allowlist,
         requirePairing: false,
       });
     }
   }
-  
+
   /**
    * Get all remote config
    */
@@ -80,14 +91,14 @@ class RemoteConfigStore {
       channels: this.store.get('channels'),
     };
   }
-  
+
   /**
    * Get gateway config
    */
   getGatewayConfig(): GatewayConfig {
     return this.store.get('gateway');
   }
-  
+
   /**
    * Filter prototype pollution keys from user-controlled objects
    */
@@ -104,17 +115,20 @@ class RemoteConfigStore {
    */
   setGatewayConfig(config: Partial<GatewayConfig>): void {
     const current = this.getGatewayConfig();
-    this.store.set('gateway', { ...current, ...this.filterProtoPollution(config as Record<string, unknown>) });
+    this.store.set('gateway', {
+      ...current,
+      ...this.filterProtoPollution(config as Record<string, unknown>),
+    });
     log('[RemoteConfig] Gateway config updated');
   }
-  
+
   /**
    * Get feishu channel config
    */
   getFeishuConfig(): FeishuChannelConfig | undefined {
     return this.store.get('channels.feishu');
   }
-  
+
   /**
    * Set feishu channel config
    */
@@ -122,14 +136,14 @@ class RemoteConfigStore {
     this.store.set('channels.feishu', config);
     log('[RemoteConfig] Feishu config updated');
   }
-  
+
   /**
    * Get wechat channel config
    */
   getWechatConfig(): WechatChannelConfig | undefined {
     return this.store.get('channels.wechat');
   }
-  
+
   /**
    * Set wechat channel config
    */
@@ -137,14 +151,14 @@ class RemoteConfigStore {
     this.store.set('channels.wechat', config);
     log('[RemoteConfig] WeChat config updated');
   }
-  
+
   /**
    * Get telegram channel config
    */
   getTelegramConfig(): TelegramChannelConfig | undefined {
     return this.store.get('channels.telegram');
   }
-  
+
   /**
    * Set telegram channel config
    */
@@ -152,14 +166,14 @@ class RemoteConfigStore {
     this.store.set('channels.telegram', config);
     log('[RemoteConfig] Telegram config updated');
   }
-  
+
   /**
    * Get dingtalk channel config
    */
   getDingtalkConfig(): DingtalkChannelConfig | undefined {
     return this.store.get('channels.dingtalk');
   }
-  
+
   /**
    * Set dingtalk channel config
    */
@@ -167,14 +181,14 @@ class RemoteConfigStore {
     this.store.set('channels.dingtalk', config);
     log('[RemoteConfig] DingTalk config updated');
   }
-  
+
   /**
    * Get websocket channel config
    */
   getWebSocketConfig(): WebSocketChannelConfig | undefined {
     return this.store.get('channels.websocket');
   }
-  
+
   /**
    * Set websocket channel config
    */
@@ -182,14 +196,14 @@ class RemoteConfigStore {
     this.store.set('channels.websocket', config);
     log('[RemoteConfig] WebSocket config updated');
   }
-  
+
   /**
    * Check if remote is enabled
    */
   isEnabled(): boolean {
     return this.store.get('gateway.enabled', false);
   }
-  
+
   /**
    * Enable/disable remote
    */
@@ -197,68 +211,64 @@ class RemoteConfigStore {
     this.store.set('gateway.enabled', enabled);
     log('[RemoteConfig] Remote enabled:', enabled);
   }
-  
+
   /**
    * Get all paired users
    */
   getPairedUsers(): PairedUser[] {
     return this.store.get('pairedUsers', []);
   }
-  
+
   /**
    * Add paired user
    */
   addPairedUser(user: PairedUser): void {
     const users = this.getPairedUsers();
     const existingIndex = users.findIndex(
-      u => u.channelType === user.channelType && u.userId === user.userId
+      (u) => u.channelType === user.channelType && u.userId === user.userId
     );
-    
+
     if (existingIndex >= 0) {
       users[existingIndex] = user;
     } else {
       users.push(user);
     }
-    
+
     this.store.set('pairedUsers', users);
     log('[RemoteConfig] Paired user added:', user.userId);
   }
-  
+
   /**
    * Remove paired user
    */
   removePairedUser(channelType: string, userId: string): boolean {
     const users = this.getPairedUsers();
-    const newUsers = users.filter(
-      u => !(u.channelType === channelType && u.userId === userId)
-    );
-    
+    const newUsers = users.filter((u) => !(u.channelType === channelType && u.userId === userId));
+
     if (newUsers.length !== users.length) {
       this.store.set('pairedUsers', newUsers);
       log('[RemoteConfig] Paired user removed:', userId);
       return true;
     }
-    
+
     return false;
   }
-  
+
   /**
    * Check if user is paired
    */
   isPaired(channelType: string, userId: string): boolean {
     const users = this.getPairedUsers();
-    return users.some(
-      u => u.channelType === channelType && u.userId === userId
-    );
+    return users.some((u) => u.channelType === channelType && u.userId === userId);
   }
-  
+
   /**
    * Get config file path
    */
   getPath(): string {
     return this.store.path;
   }
-  
+
   /**
    * Reset all config
    */

--- a/src/main/remote/remote-manager.ts
+++ b/src/main/remote/remote-manager.ts
@@ -252,12 +252,6 @@ export class RemoteManager extends EventEmitter {
     // Stop tunnel first
     await tunnelManager.stop();
 
-    // Clear all pending send timers
-    for (const timer of this.sendTimers.values()) {
-      clearTimeout(timer);
-    }
-    this.sendTimers.clear();
-
     try {
       await this.gateway.stop();
       this.gateway = undefined;


### PR DESCRIPTION
## Summary
Re-submission of #93 (reverted in #104 for proper review).

- Call `WSClient.close({ force: true })` to properly tear down Lark SDK connections
- Add `starting` concurrency guard to prevent duplicate connections
- Preserve paired users when migrating auth mode from pairing to allowlist
- Use `channelType:userId` scoped format in allowlist with backward compat for legacy plain userId
- Sync allowlist on add/remove paired users
- Remove duplicate `sendTimers.clear()`

Closes #92

## Test plan
- [ ] Wait for Codex review to confirm no new findings
- [ ] 758 tests pass, 0 lint errors
- [ ] Manual: Feishu bot message delivery after config save / restart
- [ ] Manual: previously paired users not locked out after upgrade