### PR TITLE
ci: allow Codex review on Dependabot PRs

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -12,7 +12,6 @@ jobs:
   pr-review:
     if: |
       github.event.pull_request.draft == false &&
-      !endsWith(github.actor, '[bot]') &&
       !contains(github.event.pull_request.labels.*.name, 'bot-skip')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
Remove `!endsWith(github.actor, '[bot]')` filter from PR review workflow so Dependabot PRs also get Codex AI review.

Previously caught peer dependency conflicts in #77, #75, #65, #63 — all confirmed install-blocking by bot review. Use `bot-skip` label to skip review on specific PRs if needed.

## Test plan
- [ ] Wait for Codex review on this PR
- [ ] After merge, verify new Dependabot PRs get reviewed