### PR TITLE
fix(mcp): prefer system npx on Windows

### DIFF
--- a/src/main/mcp/mcp-manager.ts
+++ b/src/main/mcp/mcp-manager.ts
@@ -56,6 +56,22 @@ function normalizeWindowsPathForComparison(candidate: string): string {
   return path.win32.normalize(candidate).replace(/\//g, '\\').toLowerCase();
 }
 
+function getTrustedWindowsNpxDirectories(
+  env: Record<string, string | undefined> = process.env
+): string[] {
+  const candidates = [env.ProgramW6432, env.ProgramFiles, env['ProgramFiles(x86)']].filter(
+    (value): value is string => typeof value === 'string' && value.trim().length > 0
+  );
+
+  return Array.from(
+    new Set(
+      candidates.map((directory) =>
+        normalizeWindowsPathForComparison(path.win32.join(directory, 'nodejs'))
+      )
+    )
+  );
+}
+
 export function findPreferredWindowsNpxPath(
   pathEnv: string | undefined,
   bundledNpxPath: string | null,
@@ -63,11 +79,13 @@ export function findPreferredWindowsNpxPath(
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const fs = require('fs');
     return fs.existsSync(candidate);
-  }
+  },
+  trustedDirectories?: string[]
 ): string | null {
   const bundledNormalized = bundledNpxPath
     ? normalizeWindowsPathForComparison(bundledNpxPath)
     : null;
+  const normalizedTrustedDirectories = trustedDirectories?.map(normalizeWindowsPathForComparison);
 
   for (const rawEntry of (pathEnv || '').split(';')) {
     const entry = rawEntry.trim().replace(/^"(.*)"$/, '$1');
@@ -81,6 +99,13 @@ export function findPreferredWindowsNpxPath(
     }
 
     if (bundledNormalized && normalizeWindowsPathForComparison(candidate) === bundledNormalized) {
+      continue;
+    }
+
+    if (
+      normalizedTrustedDirectories &&
+      !normalizedTrustedDirectories.includes(normalizeWindowsPathForComparison(entry))
+    ) {
       continue;
     }
 
@@ -197,7 +222,12 @@ export class MCPManager {
     const bundledNpxPath = this.getBundledNodePath()?.npx ?? null;
 
     if (process.platform === 'win32') {
-      const preferredNpxPath = findPreferredWindowsNpxPath(pathEnv, bundledNpxPath);
+      const preferredNpxPath = findPreferredWindowsNpxPath(
+        pathEnv,
+        bundledNpxPath,
+        undefined,
+        getTrustedWindowsNpxDirectories(process.env)
+      );
       if (!preferredNpxPath) {
         throw new Error(
           'npx is not available. Install Node.js so Open Cowork can use your system npx.cmd, or reinstall the app to restore the bundled runtime.'

--- a/src/main/mcp/mcp-manager.ts
+++ b/src/main/mcp/mcp-manager.ts
@@ -56,6 +56,10 @@ function normalizeWindowsPathForComparison(candidate: string): string {
   return path.win32.normalize(candidate).replace(/\//g, '\\').toLowerCase();
 }
 
+function normalizeWindowsDirectoryForComparison(candidate: string): string {
+  return normalizeWindowsPathForComparison(candidate).replace(/[\\/]+$/, '');
+}
+
 function getTrustedWindowsNpxDirectories(
   env: Record<string, string | undefined> = process.env
 ): string[] {
@@ -66,7 +70,7 @@ function getTrustedWindowsNpxDirectories(
   return Array.from(
     new Set(
       candidates.map((directory) =>
-        normalizeWindowsPathForComparison(path.win32.join(directory, 'nodejs'))
+        normalizeWindowsDirectoryForComparison(path.win32.join(directory, 'nodejs'))
       )
     )
   );
@@ -85,7 +89,9 @@ export function findPreferredWindowsNpxPath(
   const bundledNormalized = bundledNpxPath
     ? normalizeWindowsPathForComparison(bundledNpxPath)
     : null;
-  const normalizedTrustedDirectories = trustedDirectories?.map(normalizeWindowsPathForComparison);
+  const normalizedTrustedDirectories = trustedDirectories?.map(
+    normalizeWindowsDirectoryForComparison
+  );
 
   for (const rawEntry of (pathEnv || '').split(';')) {
     const entry = rawEntry.trim().replace(/^"(.*)"$/, '$1');
@@ -104,7 +110,7 @@ export function findPreferredWindowsNpxPath(
 
     if (
       normalizedTrustedDirectories &&
-      !normalizedTrustedDirectories.includes(normalizeWindowsPathForComparison(entry))
+      !normalizedTrustedDirectories.includes(normalizeWindowsDirectoryForComparison(entry))
     ) {
       continue;
     }

--- a/src/main/mcp/mcp-manager.ts
+++ b/src/main/mcp/mcp-manager.ts
@@ -52,6 +52,44 @@ export interface MCPTool {
   serverName: string;
 }
 
+function normalizeWindowsPathForComparison(candidate: string): string {
+  return path.win32.normalize(candidate).replace(/\//g, '\\').toLowerCase();
+}
+
+export function findPreferredWindowsNpxPath(
+  pathEnv: string | undefined,
+  bundledNpxPath: string | null,
+  pathExists: (candidate: string) => boolean = (candidate) => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require('fs');
+    return fs.existsSync(candidate);
+  }
+): string | null {
+  const bundledNormalized = bundledNpxPath
+    ? normalizeWindowsPathForComparison(bundledNpxPath)
+    : null;
+
+  for (const rawEntry of (pathEnv || '').split(';')) {
+    const entry = rawEntry.trim().replace(/^"(.*)"$/, '$1');
+    if (!entry) {
+      continue;
+    }
+
+    const candidate = path.win32.join(entry, 'npx.cmd');
+    if (!pathExists(candidate)) {
+      continue;
+    }
+
+    if (bundledNormalized && normalizeWindowsPathForComparison(candidate) === bundledNormalized) {
+      continue;
+    }
+
+    return candidate;
+  }
+
+  return bundledNpxPath;
+}
+
 /**
  * MCP Manager - Manages connections to MCP servers and exposes their tools
  */
@@ -153,6 +191,38 @@ export class MCPManager {
 
     this.npxPath = bundledNode.npx;
     log(`[MCPManager] Using bundled npx: ${this.npxPath}`);
+  }
+
+  private async resolvePreferredNpxPath(pathEnv: string | undefined): Promise<string> {
+    const bundledNpxPath = this.getBundledNodePath()?.npx ?? null;
+
+    if (process.platform === 'win32') {
+      const preferredNpxPath = findPreferredWindowsNpxPath(pathEnv, bundledNpxPath);
+      if (!preferredNpxPath) {
+        throw new Error(
+          'npx is not available. Install Node.js so Open Cowork can use your system npx.cmd, or reinstall the app to restore the bundled runtime.'
+        );
+      }
+
+      this.npxPath = preferredNpxPath;
+      if (
+        bundledNpxPath &&
+        normalizeWindowsPathForComparison(preferredNpxPath) !==
+          normalizeWindowsPathForComparison(bundledNpxPath)
+      ) {
+        log(`[MCPManager] Using system npx on Windows: ${this.npxPath}`);
+      } else {
+        log(`[MCPManager] Using bundled npx: ${this.npxPath}`);
+      }
+
+      return preferredNpxPath;
+    }
+
+    await this.checkNpxInPath();
+    if (!this.npxPath) {
+      throw new Error('Bundled npx is unavailable.');
+    }
+    return this.npxPath;
   }
 
   /**
@@ -615,16 +685,13 @@ export class MCPManager {
         }
       }
 
-      // If command is 'npx', check if it's in PATH
-      if (command === 'npx' || command.endsWith('/npx')) {
-        // Check if npx is in PATH, throw error if not found
-        await this.checkNpxInPath();
+      // Get environment variables before resolving npx so Windows can prefer a
+      // real system npx.cmd later in PATH over the prepended bundled runtime.
+      const env = await this.getEnhancedEnv(config.env || {});
 
-        // Use the resolved npx path
-        if (this.npxPath) {
-          command = this.npxPath;
-          log(`[MCPManager] Using npx from PATH: ${command}`);
-        }
+      // If command is 'npx', resolve the concrete executable path now.
+      if (command === 'npx' || command.endsWith('/npx')) {
+        command = await this.resolvePreferredNpxPath(env.PATH);
       }
 
       // Windows: resolve bare commands (e.g. 'npx', 'node') to their .cmd/.exe equivalents.
@@ -652,8 +719,6 @@ export class MCPManager {
       commandForLogging = command;
       argsForLogging = args;
 
-      // Get environment variables
-      const env = await this.getEnhancedEnv(config.env || {});
       log('[MCPManager] Server auth env summary', {
         server: config.name,
         OPENAI_API_KEY: env.OPENAI_API_KEY?.trim() ? 'set' : 'unset',

--- a/tests/mcp-npx-resolution.test.ts
+++ b/tests/mcp-npx-resolution.test.ts
@@ -39,4 +39,26 @@ describe('findPreferredWindowsNpxPath', () => {
 
     expect(resolved).toBe('C:\\Program Files\\nodejs\\npx.cmd');
   });
+
+  it('ignores untrusted PATH entries and keeps searching for a trusted system npx.cmd', () => {
+    const bundled = 'C:\\open-cowork\\resources\\node\\npx.cmd';
+    const pathEnv = ['C:\\Users\\tester\\AppData\\Roaming\\npm', 'C:\\Program Files\\nodejs'].join(
+      ';'
+    );
+
+    const resolved = findPreferredWindowsNpxPath(
+      pathEnv,
+      bundled,
+      (candidate) => {
+        return (
+          candidate === bundled ||
+          candidate === 'C:\\Users\\tester\\AppData\\Roaming\\npm\\npx.cmd' ||
+          candidate === 'C:\\Program Files\\nodejs\\npx.cmd'
+        );
+      },
+      ['C:\\Program Files\\nodejs']
+    );
+
+    expect(resolved).toBe('C:\\Program Files\\nodejs\\npx.cmd');
+  });
 });

--- a/tests/mcp-npx-resolution.test.ts
+++ b/tests/mcp-npx-resolution.test.ts
@@ -61,4 +61,20 @@ describe('findPreferredWindowsNpxPath', () => {
 
     expect(resolved).toBe('C:\\Program Files\\nodejs\\npx.cmd');
   });
+
+  it('treats trusted PATH entries with a trailing slash as trusted', () => {
+    const bundled = 'C:\\open-cowork\\resources\\node\\npx.cmd';
+    const pathEnv = 'C:\\Program Files\\nodejs\\';
+
+    const resolved = findPreferredWindowsNpxPath(
+      pathEnv,
+      bundled,
+      (candidate) => {
+        return candidate === bundled || candidate === 'C:\\Program Files\\nodejs\\npx.cmd';
+      },
+      ['C:\\Program Files\\nodejs']
+    );
+
+    expect(resolved).toBe('C:\\Program Files\\nodejs\\npx.cmd');
+  });
 });

--- a/tests/mcp-npx-resolution.test.ts
+++ b/tests/mcp-npx-resolution.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { findPreferredWindowsNpxPath } from '../src/main/mcp/mcp-manager';
+
+describe('findPreferredWindowsNpxPath', () => {
+  it('prefers a system npx.cmd later in PATH over the bundled npx.cmd', () => {
+    const bundled = 'C:\\open-cowork\\resources\\node\\npx.cmd';
+    const pathEnv = [
+      'C:\\open-cowork\\resources\\node',
+      'C:\\Program Files\\nodejs',
+      'C:\\Windows\\System32',
+    ].join(';');
+
+    const resolved = findPreferredWindowsNpxPath(pathEnv, bundled, (candidate) => {
+      return candidate === bundled || candidate === 'C:\\Program Files\\nodejs\\npx.cmd';
+    });
+
+    expect(resolved).toBe('C:\\Program Files\\nodejs\\npx.cmd');
+  });
+
+  it('falls back to the bundled npx.cmd when no system npx.cmd is present', () => {
+    const bundled = 'C:\\open-cowork\\resources\\node\\npx.cmd';
+    const pathEnv = ['C:\\open-cowork\\resources\\node', 'C:\\Windows\\System32'].join(';');
+
+    const resolved = findPreferredWindowsNpxPath(pathEnv, bundled, (candidate) => {
+      return candidate === bundled;
+    });
+
+    expect(resolved).toBe(bundled);
+  });
+
+  it('ignores quoted PATH entries when resolving system npx.cmd', () => {
+    const bundled = 'C:\\open-cowork\\resources\\node\\npx.cmd';
+    const pathEnv = ['"C:\\open-cowork\\resources\\node"', '"C:\\Program Files\\nodejs"'].join(';');
+
+    const resolved = findPreferredWindowsNpxPath(pathEnv, bundled, (candidate) => {
+      return candidate === bundled || candidate === 'C:\\Program Files\\nodejs\\npx.cmd';
+    });
+
+    expect(resolved).toBe('C:\\Program Files\\nodejs\\npx.cmd');
+  });
+});


### PR DESCRIPTION
## Summary
- prefer a system `npx.cmd` on Windows when launching MCP connectors that use bare `npx`
- keep the bundled runtime as a fallback when no external `npx.cmd` exists
- add regression coverage for Windows PATH resolution so Chrome DevTools MCP does not get pinned to the bundled npx

## Testing
- npx vitest run tests/mcp-npx-resolution.test.ts tests/mcp-tool-name.test.ts tests/claude-sdk-one-shot.test.ts tests/api-diagnostics.test.ts
- npm run typecheck
- npx eslint src/main/mcp/mcp-manager.ts tests/mcp-npx-resolution.test.ts

Fixes #110