### PR TITLE
fix(gui): keep screenshot images out of tool text context

### DIFF
--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -61,6 +61,10 @@ import {
 } from './pi-model-resolution';
 import { buildPiSessionRuntimeSignature } from './pi-session-runtime';
 import { ThinkTagStreamParser } from './think-tag-parser';
+import {
+  normalizeMcpToolResultForModel,
+  normalizeToolExecutionResultForUi,
+} from './tool-result-utils';
 import { fetchOllamaModelInfo } from '../config/ollama-api';
 
 // Virtual workspace path shown to the model (hides real sandbox path)
@@ -284,21 +288,13 @@ function buildMcpCustomTools(mcpManager: MCPManager): ToolDefinition[] {
       async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
         try {
           const result = await mcpManager.callTool(mcpTool.name, params as Record<string, unknown>);
-          // MCP callTool returns { content: [...] } — extract text
-          const textParts: string[] = [];
-          const resultObj = result as Record<string, unknown>;
-          if (resultObj?.content) {
-            const contentArr = resultObj.content as Array<Record<string, unknown>>;
-            for (const part of contentArr) {
-              if (part.type === 'text') textParts.push(String(part.text));
-              else textParts.push(JSON.stringify(part));
-            }
-          } else {
-            textParts.push(typeof result === 'string' ? result : JSON.stringify(result));
-          }
+          const normalizedResult = normalizeMcpToolResultForModel(result);
           return {
-            content: [{ type: 'text' as const, text: textParts.join('\n') }],
-            details: undefined as unknown,
+            content: [{ type: 'text' as const, text: normalizedResult.text }],
+            details:
+              normalizedResult.images.length > 0
+                ? { openCoworkImages: normalizedResult.images }
+                : undefined,
           };
         } catch (err: unknown) {
           logError(`[ClaudeAgentRunner] MCP tool ${mcpTool.name} failed:`, err);
@@ -2288,10 +2284,8 @@ Tool routing:
               if (controller.signal.aborted) break;
               const toolCallId = event.toolCallId;
               const isError = event.isError;
-              const outputText =
-                typeof event.result === 'string'
-                  ? event.result
-                  : JSON.stringify(event.result || '');
+              const normalizedToolResult = normalizeToolExecutionResultForUi(event.result);
+              const outputText = normalizedToolResult.content;
               this.sendTraceUpdate(session.id, toolCallId, {
                 status: isError ? 'error' : 'completed',
                 toolName: event.toolName,
@@ -2309,6 +2303,9 @@ Tool routing:
                     toolUseId: toolCallId,
                     content: sanitizeOutputPaths(outputText),
                     isError,
+                    ...(normalizedToolResult.images.length > 0
+                      ? { images: normalizedToolResult.images }
+                      : {}),
                   },
                 ],
                 timestamp: Date.now(),

--- a/src/main/claude/tool-result-utils.ts
+++ b/src/main/claude/tool-result-utils.ts
@@ -1,0 +1,185 @@
+type ToolResultImage = {
+  data: string;
+  mimeType: string;
+};
+
+type NormalizedToolTextResult = {
+  text: string;
+  images: ToolResultImage[];
+};
+
+type NormalizedToolExecutionResult = {
+  content: string;
+  images: ToolResultImage[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isToolResultImage(value: unknown): value is ToolResultImage {
+  return (
+    isRecord(value) &&
+    typeof value.data === 'string' &&
+    typeof value.mimeType === 'string' &&
+    value.data.length > 0 &&
+    value.mimeType.length > 0
+  );
+}
+
+function redactLargeBinaryData(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactLargeBinaryData(item));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const objectType = typeof value.type === 'string' ? value.type : undefined;
+  const redacted: Record<string, unknown> = {};
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (typeof nestedValue === 'string') {
+      if (objectType === 'image' && key === 'data') {
+        redacted[key] = `[image base64 omitted: ${nestedValue.length} chars]`;
+        continue;
+      }
+
+      if ((key === 'base64' || key === 'inlineDataBase64') && nestedValue.length > 128) {
+        redacted[key] = `[base64 omitted: ${nestedValue.length} chars]`;
+        continue;
+      }
+
+      if (key === 'url' && /^data:image\//i.test(nestedValue)) {
+        redacted[key] = `[image data URL omitted: ${nestedValue.length} chars]`;
+        continue;
+      }
+    }
+
+    redacted[key] = redactLargeBinaryData(nestedValue);
+  }
+
+  return redacted;
+}
+
+function safeStringifyToolResult(value: unknown): string {
+  try {
+    return JSON.stringify(redactLargeBinaryData(value));
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    return `[Unserializable tool result: ${details}]`;
+  }
+}
+
+function summarizeStructuredToolPart(part: unknown): string | null {
+  if (!isRecord(part)) {
+    return typeof part === 'string' ? part : safeStringifyToolResult(part);
+  }
+
+  if (part.type === 'text') {
+    return typeof part.text === 'string' ? part.text : '';
+  }
+
+  if (part.type === 'image' && isToolResultImage(part)) {
+    return null;
+  }
+
+  return safeStringifyToolResult(part);
+}
+
+function extractImagesFromDetails(details: unknown): ToolResultImage[] {
+  if (!isRecord(details) || !Array.isArray(details.openCoworkImages)) {
+    return [];
+  }
+
+  return details.openCoworkImages.flatMap((image) =>
+    isToolResultImage(image) ? [{ data: image.data, mimeType: image.mimeType }] : []
+  );
+}
+
+function extractTextAndImagesFromContent(content: unknown): {
+  textParts: string[];
+  images: ToolResultImage[];
+} {
+  if (!Array.isArray(content)) {
+    return { textParts: [], images: [] };
+  }
+
+  const textParts: string[] = [];
+  const images: ToolResultImage[] = [];
+
+  for (const part of content) {
+    if (isRecord(part) && part.type === 'image' && isToolResultImage(part)) {
+      images.push({ data: part.data, mimeType: part.mimeType });
+      continue;
+    }
+
+    const summary = summarizeStructuredToolPart(part);
+    if (summary && summary.trim()) {
+      textParts.push(summary.trim());
+    }
+  }
+
+  return { textParts, images };
+}
+
+function dedupeImages(images: ToolResultImage[]): ToolResultImage[] {
+  const seen = new Set<string>();
+  return images.filter((image) => {
+    const key = `${image.mimeType}:${image.data.length}:${image.data.slice(0, 48)}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function finalizeText(textParts: string[], imageCount: number): string {
+  const normalized = textParts.map((part) => part.trim()).filter(Boolean);
+  if (normalized.length > 0) {
+    return normalized.join('\n\n');
+  }
+  if (imageCount > 0) {
+    return imageCount === 1
+      ? '[1 image output omitted from text context]'
+      : `[${imageCount} image outputs omitted from text context]`;
+  }
+  return '(no output)';
+}
+
+export function normalizeMcpToolResultForModel(result: unknown): NormalizedToolTextResult {
+  const resultObj = isRecord(result) ? result : null;
+  if (resultObj?.content) {
+    const { textParts, images } = extractTextAndImagesFromContent(resultObj.content);
+    return {
+      text: finalizeText(textParts, images.length),
+      images,
+    };
+  }
+
+  return {
+    text: typeof result === 'string' ? result : safeStringifyToolResult(result),
+    images: [],
+  };
+}
+
+export function normalizeToolExecutionResultForUi(result: unknown): NormalizedToolExecutionResult {
+  const resultObj = isRecord(result) ? result : null;
+  const detailImages = extractImagesFromDetails(resultObj?.details);
+
+  if (resultObj?.content) {
+    const { textParts, images: inlineImages } = extractTextAndImagesFromContent(resultObj.content);
+    const images = dedupeImages([...inlineImages, ...detailImages]);
+    return {
+      content: finalizeText(textParts, images.length),
+      images,
+    };
+  }
+
+  return {
+    content: typeof result === 'string' ? result : safeStringifyToolResult(result),
+    images: dedupeImages(detailImages),
+  };
+}

--- a/src/main/claude/tool-result-utils.ts
+++ b/src/main/claude/tool-result-utils.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 type ToolResultImage = {
   data: string;
   mimeType: string;
@@ -127,7 +129,8 @@ function extractTextAndImagesFromContent(content: unknown): {
 function dedupeImages(images: ToolResultImage[]): ToolResultImage[] {
   const seen = new Set<string>();
   return images.filter((image) => {
-    const key = `${image.mimeType}:${image.data.length}:${image.data.slice(0, 48)}`;
+    const hash = createHash('sha256').update(image.data).digest('hex');
+    const key = `${image.mimeType}:${hash}`;
     if (seen.has(key)) {
       return false;
     }

--- a/tests/agent-runner-pi.test.ts
+++ b/tests/agent-runner-pi.test.ts
@@ -97,6 +97,20 @@ describe('ClaudeAgentRunner pi-coding-agent integration', () => {
     expect(agentRunnerContent).toContain('most recent two relevant publication days');
   });
 
+  it('routes MCP image results through structured helpers instead of stringifying base64 into text', () => {
+    expect(agentRunnerContent).toContain(
+      "import {\n  normalizeMcpToolResultForModel,\n  normalizeToolExecutionResultForUi,\n} from './tool-result-utils'"
+    );
+    expect(agentRunnerContent).toContain(
+      'const normalizedResult = normalizeMcpToolResultForModel(result);'
+    );
+    expect(agentRunnerContent).toContain(
+      'const normalizedToolResult = normalizeToolExecutionResultForUi(event.result);'
+    );
+    expect(agentRunnerContent).not.toContain('else textParts.push(JSON.stringify(part));');
+    expect(agentRunnerContent).not.toContain(": JSON.stringify(event.result || '');");
+  });
+
   it('does not reference removed AskUserQuestion or TodoWrite tools', () => {
     expect(agentRunnerContent).not.toContain('AskUserQuestion');
     expect(agentRunnerContent).not.toContain('TodoWrite');

--- a/tests/tool-result-utils.test.ts
+++ b/tests/tool-result-utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeMcpToolResultForModel,
+  normalizeToolExecutionResultForUi,
+} from '../src/main/claude/tool-result-utils';
+
+describe('tool result utils', () => {
+  it('keeps screenshot metadata text while omitting image base64 from model context', () => {
+    const base64Image = 'A'.repeat(2048);
+    const result = {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ success: true, path: '/tmp/screenshot.png' }, null, 2),
+        },
+        {
+          type: 'image',
+          data: base64Image,
+          mimeType: 'image/png',
+        },
+      ],
+    };
+
+    const normalized = normalizeMcpToolResultForModel(result);
+
+    expect(normalized.text).toContain('"success": true');
+    expect(normalized.text).toContain('/tmp/screenshot.png');
+    expect(normalized.text).not.toContain(base64Image);
+    expect(normalized.images).toEqual([{ data: base64Image, mimeType: 'image/png' }]);
+  });
+
+  it('extracts tool result images into the dedicated ui field', () => {
+    const base64Image = 'B'.repeat(1024);
+    const result = {
+      content: [{ type: 'text', text: 'Screenshot captured successfully' }],
+      details: {
+        openCoworkImages: [
+          {
+            data: base64Image,
+            mimeType: 'image/png',
+          },
+        ],
+      },
+    };
+
+    const normalized = normalizeToolExecutionResultForUi(result);
+
+    expect(normalized.content).toBe('Screenshot captured successfully');
+    expect(normalized.images).toEqual([{ data: base64Image, mimeType: 'image/png' }]);
+  });
+
+  it('redacts data urls and image payloads when stringifying fallback tool results', () => {
+    const dataUrl = `data:image/png;base64,${'C'.repeat(512)}`;
+    const result = {
+      content: [
+        {
+          type: 'image_url',
+          image_url: {
+            url: dataUrl,
+          },
+        },
+      ],
+    };
+
+    const normalized = normalizeToolExecutionResultForUi(result);
+
+    expect(normalized.content).toContain('[image data URL omitted');
+    expect(normalized.content).not.toContain(dataUrl);
+  });
+});

--- a/tests/tool-result-utils.test.ts
+++ b/tests/tool-result-utils.test.ts
@@ -49,6 +49,28 @@ describe('tool result utils', () => {
     expect(normalized.images).toEqual([{ data: base64Image, mimeType: 'image/png' }]);
   });
 
+  it('keeps different images that share the same prefix and length', () => {
+    const sharedPrefix = 'PREFIX'.repeat(20);
+    const firstImage = `${sharedPrefix}${'X'.repeat(64)}`;
+    const secondImage = `${sharedPrefix}${'Y'.repeat(64)}`;
+    const result = {
+      content: [{ type: 'text', text: 'Captured two screenshots' }],
+      details: {
+        openCoworkImages: [
+          { data: firstImage, mimeType: 'image/png' },
+          { data: secondImage, mimeType: 'image/png' },
+        ],
+      },
+    };
+
+    const normalized = normalizeToolExecutionResultForUi(result);
+
+    expect(normalized.images).toEqual([
+      { data: firstImage, mimeType: 'image/png' },
+      { data: secondImage, mimeType: 'image/png' },
+    ]);
+  });
+
   it('redacts data urls and image payloads when stringifying fallback tool results', () => {
     const dataUrl = `data:image/png;base64,${'C'.repeat(512)}`;
     const result = {


### PR DESCRIPTION
## Summary\n- keep MCP screenshot image payloads out of the text returned to the agent\n- store screenshot images in structured tool-result images instead of serializing base64 into content\n- add regression tests for model-context formatting and UI tool-result extraction\n\n## Testing\n- npx vitest run tests/tool-result-utils.test.ts tests/agent-runner-pi.test.ts\n- npm run typecheck\n\nFixes #123