### PR TITLE
fix: show screenshot images directly in tool output

### DIFF
--- a/src/renderer/components/message/ToolResultBlock.tsx
+++ b/src/renderer/components/message/ToolResultBlock.tsx
@@ -2,7 +2,11 @@
 import { useState, memo, useMemo } from 'react';
 import { ChevronDown, ChevronRight, XCircle, CheckCircle2 } from 'lucide-react';
 import { useAppStore } from '../../store';
-import { shouldUseScreenshotSummary } from '../../utils/tool-result-summary';
+import {
+  shouldPreferToolResultImages,
+  shouldRenderToolResultText,
+  shouldUseScreenshotSummary,
+} from '../../utils/tool-result-summary';
 import type { ToolResultContent, ContentBlock, ToolUseContent, Message } from '../../types';
 
 // Only allow safe image MIME types for data: URI rendering
@@ -72,7 +76,23 @@ export const ToolResultBlock = memo(function ToolResultBlock({
     return `${lines.length} lines`;
   };
 
-  const hasImages = block.images && block.images.length > 0;
+  const validImages =
+    block.images?.filter(
+      (image) => image?.mimeType && image?.data && ALLOWED_IMAGE_TYPES.has(image.mimeType)
+    ) ?? [];
+  const hasImages = validImages.length > 0;
+  const preferImageOutput = shouldPreferToolResultImages(
+    toolName,
+    typeof block.content === 'string' ? block.content : '',
+    hasImages,
+    block.isError === true
+  );
+  const shouldShowOutputText = shouldRenderToolResultText(
+    toolName,
+    typeof block.content === 'string' ? block.content : '',
+    hasImages,
+    block.isError === true
+  );
 
   return (
     <div
@@ -109,27 +129,41 @@ export const ToolResultBlock = memo(function ToolResultBlock({
 
       {expanded && (
         <div className="border-t border-border/50 px-3 py-2 animate-fade-in">
-          <pre
-            className={`text-xs font-mono whitespace-pre-wrap break-all rounded-lg p-2.5 border border-border-subtle max-h-[300px] overflow-y-auto ${
-              block.isError ? 'text-error bg-error/5' : 'text-text-secondary bg-surface-muted'
-            }`}
-          >
-            {block.content}
-          </pre>
-          {block.images && block.images.length > 0 && (
+          {preferImageOutput && hasImages && (
+            <div className="space-y-2">
+              {validImages.map((image, index) => (
+                <div key={index} className="border border-border rounded-lg overflow-hidden">
+                  <img
+                    src={`data:${image.mimeType};base64,${image.data}`}
+                    alt={`Screenshot ${index + 1}`}
+                    className="w-full h-auto"
+                    style={{ maxHeight: '400px', objectFit: 'contain' }}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+          {shouldShowOutputText && (
+            <pre
+              className={`text-xs font-mono whitespace-pre-wrap break-all rounded-lg p-2.5 border border-border-subtle max-h-[300px] overflow-y-auto ${
+                block.isError ? 'text-error bg-error/5' : 'text-text-secondary bg-surface-muted'
+              } ${preferImageOutput ? 'mt-2' : ''}`}
+            >
+              {block.content}
+            </pre>
+          )}
+          {!preferImageOutput && hasImages && (
             <div className="mt-2 space-y-2">
-              {block.images.map((image, index) =>
-                ALLOWED_IMAGE_TYPES.has(image.mimeType) ? (
-                  <div key={index} className="border border-border rounded-lg overflow-hidden">
-                    <img
-                      src={`data:${image.mimeType};base64,${image.data}`}
-                      alt={`Screenshot ${index + 1}`}
-                      className="w-full h-auto"
-                      style={{ maxHeight: '400px', objectFit: 'contain' }}
-                    />
-                  </div>
-                ) : null
-              )}
+              {validImages.map((image, index) => (
+                <div key={index} className="border border-border rounded-lg overflow-hidden">
+                  <img
+                    src={`data:${image.mimeType};base64,${image.data}`}
+                    alt={`Screenshot ${index + 1}`}
+                    className="w-full h-auto"
+                    style={{ maxHeight: '400px', objectFit: 'contain' }}
+                  />
+                </div>
+              ))}
             </div>
           )}
         </div>

--- a/src/renderer/components/message/ToolUseBlock.tsx
+++ b/src/renderer/components/message/ToolUseBlock.tsx
@@ -2,7 +2,11 @@
 import { useState, memo } from 'react';
 import { ChevronDown, ChevronRight, Loader2, XCircle, CheckCircle2 } from 'lucide-react';
 import { useAppStore } from '../../store';
-import { shouldUseScreenshotSummary } from '../../utils/tool-result-summary';
+import {
+  shouldPreferToolResultImages,
+  shouldRenderToolResultText,
+  shouldUseScreenshotSummary,
+} from '../../utils/tool-result-summary';
 import type { ToolUseContent, ToolResultContent, ContentBlock, Message } from '../../types';
 import { AskUserQuestionBlock } from './AskUserQuestionBlock';
 import { TodoWriteBlock } from './TodoWriteBlock';
@@ -84,6 +88,26 @@ export const ToolUseBlock = memo(function ToolUseBlock({
   };
 
   const summary = getSummary();
+  const validImages =
+    toolResult?.images?.filter(
+      (image) => image?.mimeType && image?.data && ALLOWED_IMAGE_TYPES.has(image.mimeType)
+    ) ?? [];
+  const preferImageOutput = toolResult
+    ? shouldPreferToolResultImages(
+        block.name,
+        typeof toolResult.content === 'string' ? toolResult.content : '',
+        validImages.length > 0,
+        isError
+      )
+    : false;
+  const shouldShowOutputText = toolResult
+    ? shouldRenderToolResultText(
+        block.name,
+        typeof toolResult.content === 'string' ? toolResult.content : '',
+        validImages.length > 0,
+        isError
+      )
+    : false;
 
   // Duration from trace steps
   let duration: number | undefined;
@@ -143,6 +167,11 @@ export const ToolUseBlock = memo(function ToolUseBlock({
             {summary}
           </span>
         )}
+        {validImages.length > 0 && (
+          <span className="text-[11px] text-text-muted flex-shrink-0">
+            +{validImages.length} img
+          </span>
+        )}
         {duration !== undefined && (
           <span className="text-[10px] text-text-muted flex-shrink-0 tabular-nums">
             {duration < 1000 ? `${duration}ms` : `${(duration / 1000).toFixed(1)}s`}
@@ -176,31 +205,37 @@ export const ToolUseBlock = memo(function ToolUseBlock({
               <div className="text-[10px] uppercase tracking-wider text-text-muted font-medium mb-1">
                 Output
               </div>
-              <pre
-                className={`text-xs font-mono whitespace-pre-wrap break-all rounded-lg p-2.5 border border-border-subtle max-h-[300px] overflow-y-auto ${
-                  isError ? 'text-error bg-error/5' : 'text-text-secondary bg-surface-muted'
-                }`}
-              >
-                {toolResult.content}
-              </pre>
-
-              {/* Images */}
-              {Array.isArray(toolResult.images) &&
-                toolResult.images.map((image, index) =>
-                  image?.mimeType && image?.data && ALLOWED_IMAGE_TYPES.has(image.mimeType) ? (
-                    <div
-                      key={index}
-                      className="mt-2 border border-border rounded-lg overflow-hidden"
-                    >
-                      <img
-                        src={`data:${image.mimeType};base64,${image.data}`}
-                        alt={`Output ${index + 1}`}
-                        className="w-full h-auto"
-                        style={{ maxHeight: '400px', objectFit: 'contain' }}
-                      />
-                    </div>
-                  ) : null
-                )}
+              {preferImageOutput &&
+                validImages.map((image, index) => (
+                  <div key={index} className="mt-2 border border-border rounded-lg overflow-hidden">
+                    <img
+                      src={`data:${image.mimeType};base64,${image.data}`}
+                      alt={`Output ${index + 1}`}
+                      className="w-full h-auto"
+                      style={{ maxHeight: '400px', objectFit: 'contain' }}
+                    />
+                  </div>
+                ))}
+              {shouldShowOutputText && (
+                <pre
+                  className={`text-xs font-mono whitespace-pre-wrap break-all rounded-lg p-2.5 border border-border-subtle max-h-[300px] overflow-y-auto ${
+                    isError ? 'text-error bg-error/5' : 'text-text-secondary bg-surface-muted'
+                  } ${preferImageOutput ? 'mt-2' : ''}`}
+                >
+                  {toolResult.content}
+                </pre>
+              )}
+              {!preferImageOutput &&
+                validImages.map((image, index) => (
+                  <div key={index} className="mt-2 border border-border rounded-lg overflow-hidden">
+                    <img
+                      src={`data:${image.mimeType};base64,${image.data}`}
+                      alt={`Output ${index + 1}`}
+                      className="w-full h-auto"
+                      style={{ maxHeight: '400px', objectFit: 'contain' }}
+                    />
+                  </div>
+                ))}
             </div>
           )}
         </div>

--- a/src/renderer/utils/tool-result-summary.ts
+++ b/src/renderer/utils/tool-result-summary.ts
@@ -1,4 +1,8 @@
-const screenshotSuccessPattern = /\b(?:screenshot\s+(?:saved|captured)|saved\s+screenshot|captured\s+screenshot)\b/i;
+const screenshotSuccessPattern =
+  /\b(?:screenshot\s+(?:saved|captured)|saved\s+screenshot|captured\s+screenshot)\b/i;
+const omittedImageOutputPattern =
+  /^\[(?:1 image output|\d+ image outputs) omitted from text context\]$/i;
+const emptyOutputPattern = /^\(no output\)$/i;
 
 function isScreenshotToolName(toolName?: string): boolean {
   if (!toolName) {
@@ -16,4 +20,35 @@ export function shouldUseScreenshotSummary(toolName: string | undefined, content
     return true;
   }
   return screenshotSuccessPattern.test(content);
+}
+
+export function shouldPreferToolResultImages(
+  toolName: string | undefined,
+  content: string,
+  hasImages: boolean,
+  isError = false
+): boolean {
+  if (isError || !hasImages) {
+    return false;
+  }
+
+  const normalized = content.trim();
+  if (shouldUseScreenshotSummary(toolName, normalized)) {
+    return true;
+  }
+
+  return omittedImageOutputPattern.test(normalized) || emptyOutputPattern.test(normalized);
+}
+
+export function shouldRenderToolResultText(
+  toolName: string | undefined,
+  content: string,
+  hasImages: boolean,
+  isError = false
+): boolean {
+  if (!content.trim()) {
+    return false;
+  }
+
+  return !shouldPreferToolResultImages(toolName, content, hasImages, isError);
 }

--- a/tests/tool-result-summary.test.ts
+++ b/tests/tool-result-summary.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { shouldUseScreenshotSummary } from '../src/renderer/utils/tool-result-summary';
+import {
+  shouldPreferToolResultImages,
+  shouldRenderToolResultText,
+  shouldUseScreenshotSummary,
+} from '../src/renderer/utils/tool-result-summary';
 
 describe('shouldUseScreenshotSummary', () => {
   it('does not classify generic command output as screenshot by keyword alone', () => {
@@ -21,5 +25,36 @@ describe('shouldUseScreenshotSummary', () => {
   it('classifies explicit screenshot success phrases', () => {
     expect(shouldUseScreenshotSummary('Bash', 'Screenshot saved to /tmp/a.png')).toBe(true);
     expect(shouldUseScreenshotSummary(undefined, 'captured screenshot successfully')).toBe(true);
+  });
+
+  it('prefers image-first output for screenshot tool results with images', () => {
+    expect(
+      shouldPreferToolResultImages(
+        'mcp__gui__screenshot_for_display',
+        '{\n  "path": "/tmp/screenshot.png"\n}',
+        true
+      )
+    ).toBe(true);
+    expect(
+      shouldRenderToolResultText(
+        'mcp__gui__screenshot_for_display',
+        '{\n  "path": "/tmp/screenshot.png"\n}',
+        true
+      )
+    ).toBe(false);
+  });
+
+  it('hides placeholder text when image payload is already available', () => {
+    expect(
+      shouldPreferToolResultImages(undefined, '[1 image output omitted from text context]', true)
+    ).toBe(true);
+    expect(
+      shouldRenderToolResultText(undefined, '[1 image output omitted from text context]', true)
+    ).toBe(false);
+  });
+
+  it('keeps text output for non-screenshot tools with meaningful text', () => {
+    expect(shouldPreferToolResultImages('read', 'OCR extracted text', true)).toBe(false);
+    expect(shouldRenderToolResultText('read', 'OCR extracted text', true)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary\n- render screenshot-style tool results with image-first output instead of showing screenshot metadata text first\n- keep generic tool results unchanged unless the text is just an omitted-image placeholder\n- add renderer summary tests for the new image-first output rules\n\n## Testing\n- npm exec vitest -- run tests/tool-result-summary.test.ts tests/tool-result-utils.test.ts tests/agent-runner-pi.test.ts\n- npm run typecheck\n\nFollow-up for #123. This PR intentionally does not auto-close the issue yet because the maintainer asked to confirm the output rendering behavior first.