### PR TITLE
Security: Path containment check can be bypassed via `..` segments

### DIFF
--- a/src/main/tools/path-containment.ts
+++ b/src/main/tools/path-containment.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 export function normalizePathForContainment(pathValue: string, caseInsensitive = false): string {
   const normalized = pathValue
     .replace(/[\\/]+/g, '/')
@@ -15,13 +17,16 @@ export function isPathWithinRoot(
   rootPath: string,
   caseInsensitive = false
 ): boolean {
-  const normalizedTarget = normalizePathForContainment(targetPath, caseInsensitive);
-  const normalizedRoot = normalizePathForContainment(rootPath, caseInsensitive);
+  const resolvedTarget = path.resolve(targetPath);
+  const resolvedRoot = path.resolve(rootPath);
+
+  const normalizedTarget = normalizePathForContainment(resolvedTarget, caseInsensitive);
+  const normalizedRoot = normalizePathForContainment(resolvedRoot, caseInsensitive);
 
   if (!normalizedTarget || !normalizedRoot) {
     return false;
   }
 
-  const prefix = normalizedRoot === '/' ? '/' : `${normalizedRoot}/`;
-  return normalizedTarget === normalizedRoot || normalizedTarget.startsWith(prefix);
+  const relativePath = path.relative(normalizedRoot, normalizedTarget);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
 }

--- a/src/main/tools/path-containment.ts
+++ b/src/main/tools/path-containment.ts
@@ -1,9 +1,15 @@
-import path from 'node:path';
+import { isUncPath, isWindowsDrivePath } from '../../shared/local-file-path';
+
+type CanonicalPathKind = 'posix' | 'windows' | 'unc';
+
+interface CanonicalPath {
+  kind: CanonicalPathKind;
+  root: string;
+  segments: string[];
+}
 
 export function normalizePathForContainment(pathValue: string, caseInsensitive = false): string {
-  const normalized = pathValue
-    .replace(/[\\/]+/g, '/')
-    .replace(/\/+$/, '');
+  const normalized = pathValue.replace(/[\\/]+/g, '/').replace(/\/+$/, '');
 
   if (!normalized) {
     return pathValue.includes('/') || pathValue.includes('\\') ? '/' : '';
@@ -12,21 +18,96 @@ export function normalizePathForContainment(pathValue: string, caseInsensitive =
   return caseInsensitive ? normalized.toLowerCase() : normalized;
 }
 
+function normalizeSegment(segment: string, caseInsensitive: boolean): string {
+  return caseInsensitive ? segment.toLowerCase() : segment;
+}
+
+function resolveSegments(pathValue: string, caseInsensitive: boolean): string[] {
+  const segments = pathValue.split(/[\\/]+/).filter(Boolean);
+  const resolved: string[] = [];
+
+  for (const segment of segments) {
+    if (segment === '.') {
+      continue;
+    }
+
+    if (segment === '..') {
+      if (resolved.length > 0) {
+        resolved.pop();
+      }
+      continue;
+    }
+
+    resolved.push(normalizeSegment(segment, caseInsensitive));
+  }
+
+  return resolved;
+}
+
+function canonicalizePath(pathValue: string, caseInsensitive: boolean): CanonicalPath | null {
+  if (!pathValue) {
+    return null;
+  }
+
+  if (isWindowsDrivePath(pathValue)) {
+    const drive = normalizeSegment(pathValue.slice(0, 2), caseInsensitive);
+    return {
+      kind: 'windows',
+      root: drive,
+      segments: resolveSegments(pathValue.slice(2), caseInsensitive),
+    };
+  }
+
+  if (isUncPath(pathValue) || /^\/\/[^/]+\/+[^/]+/.test(pathValue)) {
+    const normalized = pathValue.replace(/\\/g, '/');
+    const uncMatch = normalized.match(/^\/\/([^/]+)\/+([^/]+)(.*)$/);
+    if (!uncMatch) {
+      return null;
+    }
+
+    const [, host, share, rest = ''] = uncMatch;
+    return {
+      kind: 'unc',
+      root: `//${normalizeSegment(host, caseInsensitive)}/${normalizeSegment(share, caseInsensitive)}`,
+      segments: resolveSegments(rest, caseInsensitive),
+    };
+  }
+
+  if (pathValue.startsWith('/') || pathValue.startsWith('\\')) {
+    return {
+      kind: 'posix',
+      root: '/',
+      segments: resolveSegments(pathValue, caseInsensitive),
+    };
+  }
+
+  return null;
+}
+
 export function isPathWithinRoot(
   targetPath: string,
   rootPath: string,
   caseInsensitive = false
 ): boolean {
-  const resolvedTarget = path.resolve(targetPath);
-  const resolvedRoot = path.resolve(rootPath);
-
-  const normalizedTarget = normalizePathForContainment(resolvedTarget, caseInsensitive);
-  const normalizedRoot = normalizePathForContainment(resolvedRoot, caseInsensitive);
+  const normalizedTarget = canonicalizePath(targetPath, caseInsensitive);
+  const normalizedRoot = canonicalizePath(rootPath, caseInsensitive);
 
   if (!normalizedTarget || !normalizedRoot) {
     return false;
   }
 
-  const relativePath = path.relative(normalizedRoot, normalizedTarget);
-  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+  if (
+    normalizedTarget.kind !== normalizedRoot.kind ||
+    normalizedTarget.root !== normalizedRoot.root
+  ) {
+    return false;
+  }
+
+  if (normalizedRoot.segments.length > normalizedTarget.segments.length) {
+    return false;
+  }
+
+  return normalizedRoot.segments.every(
+    (segment, index) => normalizedTarget.segments[index] === segment
+  );
 }

--- a/tests/path-containment.test.ts
+++ b/tests/path-containment.test.ts
@@ -12,19 +12,55 @@ describe('isPathWithinRoot', () => {
     expect(isPathWithinRoot('/tmp/project', '/tmp/project')).toBe(true);
   });
 
+  it('allows descendants with dot segments that stay inside the root', () => {
+    expect(isPathWithinRoot('/tmp/project/src/../index.ts', '/tmp/project')).toBe(true);
+  });
+
   it('allows descendants inside the root', () => {
     expect(isPathWithinRoot('/tmp/project/src/index.ts', '/tmp/project')).toBe(true);
+  });
+
+  it('rejects paths that traverse outside the root with dot segments', () => {
+    expect(isPathWithinRoot('/tmp/project/../secret.txt', '/tmp/project')).toBe(false);
   });
 
   it('rejects sibling paths that merely share a prefix', () => {
     expect(isPathWithinRoot('/tmp/project-evil/file.txt', '/tmp/project')).toBe(false);
   });
 
+  it('rejects empty target inputs', () => {
+    expect(isPathWithinRoot('', '/tmp/project')).toBe(false);
+  });
+
+  it('rejects relative target inputs', () => {
+    expect(isPathWithinRoot('src/index.ts', '/tmp/project')).toBe(false);
+  });
+
+  it('rejects relative root inputs', () => {
+    expect(isPathWithinRoot('/tmp/project/src/index.ts', 'tmp/project')).toBe(false);
+  });
+
   it('supports case-insensitive Windows containment checks', () => {
     expect(isPathWithinRoot('C:/Workspace/Reports/out.txt', 'c:/workspace', true)).toBe(true);
   });
 
+  it('supports rooted backslash paths produced by Windows normalization', () => {
+    expect(isPathWithinRoot('\\tmp\\project\\notes..final.md', '\\tmp\\project')).toBe(true);
+  });
+
+  it('rejects Windows paths that traverse outside the root', () => {
+    expect(
+      isPathWithinRoot('C:/Workspace/Reports/../../Secrets/out.txt', 'c:/workspace/reports', true)
+    ).toBe(false);
+  });
+
   it('rejects UNC siblings that share the same prefix', () => {
     expect(isPathWithinRoot('//server/share-evil/out.txt', '//server/share', true)).toBe(false);
+  });
+
+  it('rejects UNC paths that traverse outside the root', () => {
+    expect(
+      isPathWithinRoot('//server/share/workspace/../secret.txt', '//server/share/workspace', true)
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Security: Path containment check can be bypassed via `..` segments

## Problem

**Severity**: `High` | **File**: `src/main/tools/path-containment.ts:L1`

`isPathWithinRoot()` only normalizes slashes/trailing separators and then performs a prefix check. It does not canonicalize dot segments (e.g., `..`), so a path like `/workspace/../etc/passwd` is treated as inside `/workspace` even though it escapes the root after real path resolution. If this function is used as a security boundary for file operations, it enables directory traversal.

## Solution

Canonicalize both paths before comparison (e.g., `path.resolve` / `path.normalize`) and, where possible, resolve symlinks with `fs.realpath`. Then enforce containment using `path.relative(root, target)` and reject if it starts with `..` or is absolute.

## Changes

- `src/main/tools/path-containment.ts` (modified)