### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/.claude/skills/docx/scripts/ooxml/scripts/unpack.py
+++ b/.claude/skills/docx/scripts/ooxml/scripts/unpack.py
@@ -14,7 +14,15 @@ input_file, output_dir = sys.argv[1], sys.argv[2]
 # Extract and format
 output_path = Path(output_dir)
 output_path.mkdir(parents=True, exist_ok=True)
-zipfile.ZipFile(input_file).extractall(output_path)
+with zipfile.ZipFile(input_file) as zf:
+    for member in zf.namelist():
+        member_path = output_path / member
+        try:
+            member_path.resolve().relative_to(output_path.resolve())
+        except ValueError:
+            print(f"Skipping malicious entry: {member}")
+            continue
+        zf.extract(member, output_path)
 
 # Pretty print all XML files
 xml_files = list(output_path.rglob("*.xml")) + list(output_path.rglob("*.rels"))

--- a/.claude/skills/pptx/ooxml/scripts/unpack.py
+++ b/.claude/skills/pptx/ooxml/scripts/unpack.py
@@ -14,7 +14,11 @@ input_file, output_dir = sys.argv[1], sys.argv[2]
 # Extract and format
 output_path = Path(output_dir)
 output_path.mkdir(parents=True, exist_ok=True)
-zipfile.ZipFile(input_file).extractall(output_path)
+with zipfile.ZipFile(input_file) as zf:
+    for member in zf.infolist():
+        if member.filename.startswith('/') or '..' in member.filename.split('/'):
+            continue
+        zf.extract(member, output_path)
 
 # Pretty print all XML files
 xml_files = list(output_path.rglob("*.xml")) + list(output_path.rglob("*.rels"))


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `.claude/skills/docx/scripts/ooxml/scripts/unpack.py:L18`

The unpack.py script extracts ZIP archives using extractall() without validating entry paths. Malicious Office documents containing entries with '../' sequences or absolute paths can write files outside the intended output directory, leading to arbitrary file write vulnerabilities.

## Solution

Validate each ZipInfo entry name before extraction using os.path.commonpath() or similar checks to ensure extracted files remain within the target directory. Consider using zipfile.Path or explicitly checking entry.filename for path traversal sequences.

## Changes

- `.claude/skills/docx/scripts/ooxml/scripts/unpack.py` (modified)
- `.claude/skills/pptx/ooxml/scripts/unpack.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*