### PR TITLE
fix: resolve #89 — 阿里云coding plan接入报错

### DIFF
--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -1,0 +1,3 @@
+export const ALIBABA_CLOUD_BASE_URL = 'https://dashscope.aliyuncs.com/compatible-mode/v1';
+export const ALIBABA_CLOUD_API_VERSION = 'v1';
+export const ALIBABA_CLOUD_CODING_PLAN_ENDPOINT = '/chat/completions';

--- a/src/providers/alibaba/config.ts
+++ b/src/providers/alibaba/config.ts
@@ -1,0 +1,5 @@
+export const ALIBABA_CLOUD_CONFIG = {
+  baseURL: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+} as const;
+
+export type AlibabaCloudConfig = typeof ALIBABA_CLOUD_CONFIG;

--- a/src/providers/alibaba/index.ts
+++ b/src/providers/alibaba/index.ts
@@ -1,0 +1,105 @@
+import { Provider, Message, RequestOptions } from '../../types';
+
+export class AlibabaProvider implements Provider {
+  private apiKey: string;
+  private baseURL: string;
+
+  constructor(apiKey: string, baseURL: string = 'https://dashscope.aliyuncs.com') {
+    this.apiKey = apiKey;
+    this.baseURL = baseURL.replace(/\/$/, '');
+  }
+
+  private getEndpoint(model: string): string {
+    if (model.includes('coding') || model.includes('code')) {
+      return '/api/v1/services/aigc/text-generation/generation';
+    }
+    return '/compatible-mode/v1/chat/completions';
+  }
+
+  private getHeaders(model: string): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${this.apiKey}`,
+    };
+
+    if (model.includes('coding') || model.includes('code')) {
+      headers['X-DashScope-Code'] = 'true';
+    }
+
+    return headers;
+  }
+
+  async chat(messages: Message[], options?: RequestOptions): Promise<any> {
+    const model = options?.model || 'qwen-turbo';
+    const endpoint = this.getEndpoint(model);
+    const url = `${this.baseURL}${endpoint}`;
+    const headers = this.getHeaders(model);
+
+    const body = {
+      model,
+      messages: messages.map(msg => ({
+        role: msg.role,
+        content: msg.content,
+      })),
+      stream: false,
+    };
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error('Alibaba API request failed:', { url, status: response.status, model });
+        throw new Error(`Alibaba API error: ${response.status} ${errorText}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error('Request URL:', url);
+      throw error;
+    }
+  }
+
+  async streamChat(messages: Message[], options?: RequestOptions): Promise<ReadableStream> {
+    const model = options?.model || 'qwen-turbo';
+    const endpoint = this.getEndpoint(model);
+    const url = `${this.baseURL}${endpoint}`;
+    const headers = this.getHeaders(model);
+
+    const body = {
+      model,
+      messages: messages.map(msg => ({
+        role: msg.role,
+        content: msg.content,
+      })),
+      stream: true,
+    };
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error('Alibaba API request failed:', { url, status: response.status, model });
+        throw new Error(`Alibaba API error: ${response.status} ${errorText}`);
+      }
+
+      if (!response.body) {
+        throw new Error('Response body is null');
+      }
+
+      return response.body;
+    } catch (error) {
+      console.error('Request URL:', url);
+      throw error;
+    }
+  }
+}

--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -1,0 +1,45 @@
+import axios, { AxiosInstance, AxiosError } from 'axios';
+
+export class ApiClient {
+  private client: AxiosInstance;
+  private baseUrl: string;
+  private provider: string;
+
+  constructor(baseUrl: string, apiKey: string, provider: string = 'default') {
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
+    this.provider = provider;
+    
+    this.client = axios.create({
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    this.client.interceptors.response.use(
+      (response) => response,
+      (error: AxiosError) => {
+        if (error.response?.status === 404) {
+          console.error(`404 Error: Request URL was ${error.config?.url}`);
+        }
+        return Promise.reject(error);
+      }
+    );
+  }
+
+  async post<T>(path: string, data: unknown): Promise<T> {
+    const url = this.buildUrl(path);
+    const response = await this.client.post<T>(url, data);
+    return response.data;
+  }
+
+  private buildUrl(path: string): string {
+    let normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    
+    if (this.provider === 'alibaba' && !normalizedPath.startsWith('/v1/')) {
+      normalizedPath = `/v1${normalizedPath}`;
+    }
+    
+    return new URL(normalizedPath, this.baseUrl).toString();
+  }
+}


### PR DESCRIPTION
## Summary

fix: resolve #89 — 阿里云coding plan接入报错

## Problem

**Severity**: `High` | **File**: `src/providers/alibaba/config.ts`

The 404 error indicates the API endpoint URL is incorrectly constructed for Alibaba Cloud Coding Plan integration. The base URL likely needs to include the correct API version path (e.g., `/compatible-mode/v1` or `/api/v1`) or the endpoint construction logic is appending an incorrect path. Other providers work because they use standard OpenAI-compatible endpoints, but Alibaba Cloud may require specific URL formatting.

## Solution

Verify and update the base URL configuration for Alibaba Cloud provider to ensure it matches the official Alibaba Cloud (DashScope) API documentation. For Coding Plan models, the base URL should typically be `https://dashscope.aliyuncs.com/compatible-mode/v1` (for OpenAI-compatible mode) or `https://dashscope.aliyuncs.com/api/v1`. Ensure the endpoint construction doesn't double-append `/v1/chat/completions` or similar paths. Add validation to log the full constructed URL in debug mode to help diagnose 404 errors.

## Changes

- `src/providers/alibaba/config.ts` (new)
- `src/services/api-client.ts` (new)
- `src/constants/providers.ts` (new)
- `src/providers/alibaba/index.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*