### PR TITLE
fix: resolve #83 — DeepSeek & Qwen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,23 @@
 # Optional: Custom Claude Code CLI path 
 # IMPORTANT: Use forward slashes (/) on Windows, not backslashes (\) 
 # CLAUDE_CODE_PATH=C:/Users/yourname/AppData/Roaming/npm/node_modules/@anthropic-ai/claude-code/cli.js
+
+# DeepSeek API Configuration
+# Required: Set your DeepSeek API key
+# DEEPSEEK_API_KEY=your_deepseek_api_key_here
+
+# # Optional: Custom DeepSeek API endpoint
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
+
+# # Optional: DeepSeek model selection
+# DEEPSEEK_MODEL=deepseek-chat
+
+# Qwen API Configuration
+# Required: Set your Qwen API key
+# QWEN_API_KEY=your_qwen_api_key_here
+
+# # Optional: Custom Qwen API endpoint
+# QWEN_BASE_URL=https://dashscope.aliyuncs.com/api/v1
+
+# # Optional: Qwen model selection
+# QWEN_MODEL=qwen-max

--- a/src/agents/system-agent.ts
+++ b/src/agents/system-agent.ts
@@ -1,0 +1,162 @@
+import { BaseAgent } from './base-agent';
+import { AgentConfig, Message } from '../types';
+
+export type LLMProvider = 'deepseek' | 'qwen';
+
+interface ProviderConfig {
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
+  temperature?: number;
+}
+
+export interface SystemAgentConfig extends AgentConfig {
+  provider: LLMProvider;
+  providerConfig: ProviderConfig;
+}
+
+interface LLMClient {
+  chat(messages: Message[]): Promise<string>;
+  formatPrompt(template: string, variables: Record<string, string>): string;
+}
+
+class DeepSeekClient implements LLMClient {
+  private apiKey: string;
+  private baseUrl: string;
+  private model: string;
+  private temperature: number;
+
+  constructor(config: ProviderConfig) {
+    this.apiKey = config.apiKey;
+    this.baseUrl = config.baseUrl || 'https://api.deepseek.com';
+    this.model = config.model || 'deepseek-chat';
+    this.temperature = config.temperature ?? 0.7;
+  }
+
+  async chat(messages: Message[]): Promise<string> {
+    const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`
+      },
+      body: JSON.stringify({
+        model: this.model,
+        messages,
+        temperature: this.temperature
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`DeepSeek API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return data.choices[0]?.message?.content || '';
+  }
+
+  formatPrompt(template: string, variables: Record<string, string>): string {
+    return template.replace(/\{\{(\w+)\}\}/g, (_, key) => {
+      const value = variables[key];
+      return value !== undefined ? `<${key}>${value}</${key}>` : '';
+    });
+  }
+}
+
+class QwenClient implements LLMClient {
+  private apiKey: string;
+  private baseUrl: string;
+  private model: string;
+  private temperature: number;
+
+  constructor(config: ProviderConfig) {
+    this.apiKey = config.apiKey;
+    this.baseUrl = config.baseUrl || 'https://dashscope.aliyuncs.com/api/v1';
+    this.model = config.model || 'qwen-turbo';
+    this.temperature = config.temperature ?? 0.7;
+  }
+
+  async chat(messages: Message[]): Promise<string> {
+    const response = await fetch(`${this.baseUrl}/services/aigc/text-generation/generation`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`
+      },
+      body: JSON.stringify({
+        model: this.model,
+        input: { messages },
+        parameters: {
+          temperature: this.temperature
+        }
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`Qwen API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return data.output?.text || '';
+  }
+
+  formatPrompt(template: string, variables: Record<string, string>): string {
+    return template.replace(/\{\{(\w+)\}\}/g, (_, key) => variables[key] || '');
+  }
+}
+
+export class SystemAgent extends BaseAgent {
+  private client: LLMClient | null = null;
+  private config: SystemAgentConfig;
+
+  constructor(config: SystemAgentConfig) {
+    super(config);
+    this.config = config;
+  }
+
+  async initialize(): Promise<void> {
+    switch (this.config.provider) {
+      case 'deepseek':
+        this.client = new DeepSeekClient(this.config.providerConfig);
+        break;
+      case 'qwen':
+        this.client = new QwenClient(this.config.providerConfig);
+        break;
+      default:
+        throw new Error(`Unsupported LLM provider: ${this.config.provider}`);
+    }
+  }
+
+  async execute(prompt: string, context?: Message[]): Promise<string> {
+    if (!this.client) {
+      await this.initialize();
+    }
+
+    if (!this.client) {
+      throw new Error('Failed to initialize LLM client');
+    }
+
+    const messages: Message[] = context ? [...context] : [];
+    messages.push({ role: 'user', content: prompt });
+
+    try {
+      return await this.client.chat(messages);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`SystemAgent execution failed: ${error.message}`);
+      }
+      throw new Error('SystemAgent execution failed: Unknown error');
+    }
+  }
+
+  formatPrompt(template: string, variables: Record<string, string>): string {
+    if (!this.client) {
+      throw new Error('Agent not initialized');
+    }
+    return this.client.formatPrompt(template, variables);
+  }
+
+  getProvider(): LLMProvider {
+    return this.config.provider;
+  }
+}

--- a/src/config/llm-providers.ts
+++ b/src/config/llm-providers.ts
@@ -1,0 +1,40 @@
+export interface LLMProviderConfig {
+  name: string;
+  baseUrl: string;
+  authType: 'bearer' | 'api-key';
+  authHeader: string;
+  models: Record<string, string>;
+  defaultModel: string;
+}
+
+export const deepseekConfig: LLMProviderConfig = {
+  name: 'DeepSeek',
+  baseUrl: 'https://api.deepseek.com/v1',
+  authType: 'bearer',
+  authHeader: 'Authorization',
+  models: {
+    'deepseek-chat': 'deepseek-chat',
+    'deepseek-coder': 'deepseek-coder',
+    'deepseek-reasoner': 'deepseek-reasoner'
+  },
+  defaultModel: 'deepseek-chat'
+};
+
+export const qwenConfig: LLMProviderConfig = {
+  name: 'Qwen',
+  baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+  authType: 'bearer',
+  authHeader: 'Authorization',
+  models: {
+    'qwen-turbo': 'qwen-turbo',
+    'qwen-plus': 'qwen-plus',
+    'qwen-max': 'qwen-max',
+    'qwen-coder-plus': 'qwen-coder-plus'
+  },
+  defaultModel: 'qwen-turbo'
+};
+
+export const llmProviders: Record<string, LLMProviderConfig> = {
+  deepseek: deepseekConfig,
+  qwen: qwenConfig
+};

--- a/src/services/llm/deepseek-client.ts
+++ b/src/services/llm/deepseek-client.ts
@@ -1,0 +1,195 @@
+interface DeepSeekMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+interface DeepSeekUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+interface DeepSeekChoice {
+  index: number;
+  message: DeepSeekMessage;
+  finish_reason: string;
+}
+
+interface DeepSeekResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: DeepSeekChoice[];
+  usage: DeepSeekUsage;
+}
+
+interface DeepSeekStreamChoice {
+  index: number;
+  delta: Partial<DeepSeekMessage>;
+  finish_reason: string | null;
+}
+
+interface DeepSeekStreamChunk {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: DeepSeekStreamChoice[];
+  usage?: DeepSeekUsage;
+}
+
+export interface DeepSeekClientConfig {
+  apiKey: string;
+  baseUrl?: string;
+  model?: string;
+}
+
+export interface ChatCompletionMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatCompletionOptions {
+  messages: ChatCompletionMessage[];
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export interface ChatCompletionResponse {
+  content: string;
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+}
+
+export interface StreamChunk {
+  content: string;
+  done: boolean;
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+}
+
+export class DeepSeekClient {
+  private apiKey: string;
+  private baseUrl: string;
+  private defaultModel: string;
+
+  constructor(config: DeepSeekClientConfig) {
+    this.apiKey = config.apiKey;
+    this.baseUrl = config.baseUrl || 'https://api.deepseek.com';
+    this.defaultModel = config.model || 'deepseek-chat';
+  }
+
+  async chatComplete(options: ChatCompletionOptions): Promise<ChatCompletionResponse> {
+    const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: options.model || this.defaultModel,
+        messages: options.messages,
+        temperature: options.temperature,
+        max_tokens: options.maxTokens,
+        stream: false,
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`DeepSeek API error ${response.status}: ${error}`);
+    }
+
+    const data: DeepSeekResponse = await response.json();
+
+    return {
+      content: data.choices[0]?.message?.content ?? '',
+      usage: {
+        promptTokens: data.usage?.prompt_tokens ?? 0,
+        completionTokens: data.usage?.completion_tokens ?? 0,
+        totalTokens: data.usage?.total_tokens ?? 0,
+      },
+    };
+  }
+
+  async *streamChatComplete(options: ChatCompletionOptions): AsyncGenerator<StreamChunk> {
+    const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: options.model || this.defaultModel,
+        messages: options.messages,
+        temperature: options.temperature,
+        max_tokens: options.maxTokens,
+        stream: true,
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`DeepSeek API error ${response.status}: ${error}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Response body is null');
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith('data: ')) continue;
+
+          const data = trimmed.slice(6);
+          if (data === '[DONE]') {
+            yield { content: '', done: true };
+            return;
+          }
+
+          try {
+            const chunk: DeepSeekStreamChunk = JSON.parse(data);
+            const content = chunk.choices[0]?.delta?.content ?? '';
+            
+            yield {
+              content,
+              done: false,
+              usage: chunk.usage ? {
+                promptTokens: chunk.usage.prompt_tokens,
+                completionTokens: chunk.usage.completion_tokens,
+                totalTokens: chunk.usage.total_tokens,
+              } : undefined,
+            };
+          } catch {
+            continue;
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    yield { content: '', done: true };
+  }
+}

--- a/src/services/llm/qwen-client.ts
+++ b/src/services/llm/qwen-client.ts
@@ -1,0 +1,236 @@
+import { logger } from '../../utils/logger';
+
+export interface QwenClientConfig {
+  apiKey: string;
+  baseUrl?: string;
+  model?: string;
+}
+
+export interface QwenMessage {
+  role: 'system' | 'user' | 'assistant' | 'function';
+  content: string | QwenContentItem[];
+  name?: string;
+  function_call?: {
+    name: string;
+    arguments: string;
+  };
+}
+
+export interface QwenContentItem {
+  type: 'text' | 'image_url';
+  text?: string;
+  image_url?: {
+    url: string;
+  };
+}
+
+export interface QwenFunction {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+export interface QwenTool {
+  type: 'function';
+  function: QwenFunction;
+}
+
+export interface QwenChatCompletionRequest {
+  model: string;
+  messages: QwenMessage[];
+  stream?: boolean;
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  tools?: QwenTool[];
+}
+
+export interface QwenChatCompletionResponse {
+  output: {
+    text?: string;
+    choices?: Array<{
+      message: QwenMessage;
+      finish_reason: string;
+    }>;
+  };
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+  request_id: string;
+}
+
+export interface QwenStreamChunk {
+  output: {
+    text?: string;
+    choices?: Array<{
+      delta: Partial<QwenMessage>;
+      finish_reason?: string;
+    }>;
+  };
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}
+
+export class QwenClient {
+  private apiKey: string;
+  private baseUrl: string;
+  private defaultModel: string;
+
+  constructor(config: QwenClientConfig) {
+    if (!config.apiKey) {
+      throw new Error('Qwen API key is required');
+    }
+    this.apiKey = config.apiKey;
+    this.baseUrl = config.baseUrl || 'https://dashscope.aliyuncs.com/api/v1';
+    this.defaultModel = config.model || 'qwen-turbo';
+  }
+
+  async chatCompletion(
+    request: Omit<QwenChatCompletionRequest, 'model' | 'stream'> & {
+      model?: string;
+    }
+  ): Promise<QwenChatCompletionResponse> {
+    const url = `${this.baseUrl}/services/aigc/text-generation/generation`;
+    
+    const body: QwenChatCompletionRequest = {
+      model: request.model || this.defaultModel,
+      messages: request.messages,
+      temperature: request.temperature,
+      top_p: request.top_p,
+      max_tokens: request.max_tokens,
+      tools: request.tools,
+      stream: false,
+    };
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Qwen API error: ${response.status} ${errorText}`);
+      }
+
+      const data = await response.json() as QwenChatCompletionResponse;
+      return data;
+    } catch (error) {
+      logger.error('Qwen chat completion failed', { error });
+      throw error;
+    }
+  }
+
+  async *streamChatCompletion(
+    request: Omit<QwenChatCompletionRequest, 'model' | 'stream'> & {
+      model?: string;
+    }
+  ): AsyncGenerator<QwenStreamChunk, void, unknown> {
+    const url = `${this.baseUrl}/services/aigc/text-generation/generation`;
+    
+    const body: QwenChatCompletionRequest = {
+      model: request.model || this.defaultModel,
+      messages: request.messages,
+      temperature: request.temperature,
+      top_p: request.top_p,
+      max_tokens: request.max_tokens,
+      tools: request.tools,
+      stream: true,
+    };
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Qwen API error: ${response.status} ${errorText}`);
+      }
+
+      if (!response.body) {
+        throw new Error('Response body is null');
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || !trimmed.startsWith('data:')) continue;
+          
+          const data = trimmed.slice(5).trim();
+          if (data === '[DONE]') return;
+
+          try {
+            const chunk = JSON.parse(data) as QwenStreamChunk;
+            yield chunk;
+          } catch (parseError) {
+            logger.warn('Failed to parse Qwen stream chunk', { data, error: parseError });
+          }
+        }
+      }
+    } catch (error) {
+      logger.error('Qwen stream chat completion failed', { error });
+      throw error;
+    }
+  }
+
+  async multimodalChat(
+    messages: QwenMessage[],
+    options?: {
+      model?: string;
+      temperature?: number;
+      max_tokens?: number;
+    }
+  ): Promise<QwenChatCompletionResponse> {
+    const model = options?.model || 'qwen-vl-plus';
+    return this.chatCompletion({
+      model,
+      messages,
+      ...options,
+    });
+  }
+
+  async functionCall(
+    messages: QwenMessage[],
+    functions: QwenFunction[],
+    options?: {
+      model?: string;
+      temperature?: number;
+    }
+  ): Promise<QwenChatCompletionResponse> {
+    const tools: QwenTool[] = functions.map(fn => ({
+      type: 'function',
+      function: fn,
+    }));
+
+    return this.chatCompletion({
+      model: options?.model || this.defaultModel,
+      messages,
+      tools,
+      temperature: options?.temperature,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

fix: resolve #83 — DeepSeek & Qwen

## Problem

**Severity**: `High` | **File**: `.env.example`

Add environment variables for DeepSeek and Qwen API keys, endpoints, and model configurations to support the new AI providers in the system.

## Solution

Add the following variables:

## Changes

- `.env.example` (modified)
- `src/config/llm-providers.ts` (new)
- `src/services/llm/deepseek-client.ts` (new)
- `src/services/llm/qwen-client.ts` (new)
- `src/agents/system-agent.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*