### PR TITLE
fix: resolve #80 — Feature Request: 支持自定义默认工作目录

### DIFF
--- a/src/components/Settings/WorkspaceSettings.tsx
+++ b/src/components/Settings/WorkspaceSettings.tsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from 'react';
+
+declare global {
+  interface Window {
+    electron?: {
+      selectDirectory?: () => Promise<string | null>;
+      getWorkspacePath?: () => Promise<string | null>;
+      setWorkspacePath?: (path: string | null) => Promise<void>;
+    };
+  }
+}
+
+const WorkspaceSettings: React.FC = () => {
+  const [workspacePath, setWorkspacePath] = useState<string>('');
+  const [isSelecting, setIsSelecting] = useState(false);
+
+  useEffect(() => {
+    const loadPath = async () => {
+      const savedPath = await window.electron?.getWorkspacePath?.();
+      if (savedPath) {
+        setWorkspacePath(savedPath);
+      }
+    };
+    loadPath();
+  }, []);
+
+  const handleBrowse = async () => {
+    setIsSelecting(true);
+    try {
+      const selectedPath = await window.electron?.selectDirectory?.();
+      if (selectedPath) {
+        setWorkspacePath(selectedPath);
+        await window.electron?.setWorkspacePath?.(selectedPath);
+      }
+    } finally {
+      setIsSelecting(false);
+    }
+  };
+
+  const handleReset = async () => {
+    setWorkspacePath('');
+    await window.electron?.setWorkspacePath?.(null);
+  };
+
+  return (
+    <div className="workspace-settings">
+      <label className="workspace-settings-label">
+        Default Workspace Directory
+      </label>
+      <div className="workspace-settings-input-group">
+        <input
+          type="text"
+          value={workspacePath}
+          readOnly
+          placeholder="Using default location"
+          className="workspace-settings-input"
+        />
+        <button
+          type="button"
+          onClick={handleBrowse}
+          disabled={isSelecting}
+          className="workspace-settings-button workspace-settings-browse"
+        >
+          Browse
+        </button>
+        <button
+          type="button"
+          onClick={handleReset}
+          disabled={!workspacePath}
+          className="workspace-settings-button workspace-settings-reset"
+        >
+          Reset to Default
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default WorkspaceSettings;

--- a/src/main/ipc/settings-handlers.ts
+++ b/src/main/ipc/settings-handlers.ts
@@ -1,0 +1,18 @@
+import { ipcMain, dialog, BrowserWindow } from 'electron';
+
+export function registerSettingsHandlers(): void {
+  ipcMain.handle('settings:select-default-directory', async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win) return null;
+    
+    const { canceled, filePaths } = await dialog.showOpenDialog(win, {
+      properties: ['openDirectory']
+    });
+    
+    if (canceled || filePaths.length === 0) {
+      return null;
+    }
+    
+    return filePaths[0];
+  });
+}

--- a/src/main/services/project-service.ts
+++ b/src/main/services/project-service.ts
@@ -1,0 +1,38 @@
+import { dialog, app } from 'electron';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { settingsStore } from '../stores/settings-store';
+
+export class ProjectService {
+  async createProject(): Promise<string | null> {
+    const defaultWorkspace = settingsStore.get('defaultWorkspace') as string | undefined;
+    const defaultPath = defaultWorkspace || app.getPath('documents');
+
+    const result = await dialog.showOpenDialog({
+      title: 'Create New Project',
+      defaultPath: defaultPath,
+      properties: ['openDirectory', 'createDirectory'],
+      buttonLabel: 'Select Folder'
+    });
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return null;
+    }
+
+    return result.filePaths[0];
+  }
+
+  async createProjectWithName(projectName: string): Promise<string | null> {
+    const defaultWorkspace = settingsStore.get('defaultWorkspace') as string | undefined;
+    
+    if (!defaultWorkspace) {
+      return this.createProject();
+    }
+
+    const projectPath = path.join(defaultWorkspace, projectName);
+    await fs.mkdir(projectPath, { recursive: true });
+    return projectPath;
+  }
+}
+
+export const projectService = new ProjectService();

--- a/src/stores/opencowork-settings.state.ts
+++ b/src/stores/opencowork-settings.state.ts
@@ -1,0 +1,34 @@
+export interface OpencoworkSettingsState {
+  defaultWorkspace: string | null;
+}
+
+const DEFAULT_WORKSPACE_PATH = '~/Documents/NewProject';
+const STORAGE_KEY = 'opencowork-settings';
+
+export const defaultSettings: OpencoworkSettingsState = {
+  defaultWorkspace: null,
+};
+
+export function loadSettings(): OpencoworkSettingsState {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch {
+    // Ignore storage errors
+  }
+  return defaultSettings;
+}
+
+export function saveSettings(settings: OpencoworkSettingsState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export function getDefaultWorkspacePath(settings: OpencoworkSettingsState): string {
+  return settings.defaultWorkspace ?? DEFAULT_WORKSPACE_PATH;
+}

--- a/src/types/settings.types.ts
+++ b/src/types/settings.types.ts
@@ -1,0 +1,9 @@
+export interface AppSettings {
+  theme: 'light' | 'dark' | 'system';
+  language: string;
+  defaultWorkspace: string | null;
+  notificationsEnabled: boolean;
+  autoUpdate: boolean;
+}
+
+export type SettingsKey = keyof AppSettings;


### PR DESCRIPTION
## Summary

fix: resolve #80 — Feature Request: 支持自定义默认工作目录

## Problem

**Severity**: `High` | **File**: `src/stores/opencowork-settings.state.ts`

Extend the settings state interface and persistence logic to include the new `defaultWorkspace` field. This field should store the absolute path to the user's preferred default working directory. The state should initialize with a null/undefined value and fallback to the current hardcoded default (`~/Documents/NewProject`) when not set.

## Solution



## Changes

- `src/stores/opencowork-settings.state.ts` (new)
- `src/components/Settings/WorkspaceSettings.tsx` (new)
- `src/main/services/project-service.ts` (new)
- `src/types/settings.types.ts` (new)
- `src/main/ipc/settings-handlers.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*