### PR TITLE
ci: add launch-level smoke test to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,25 @@ jobs:
           fi
           echo "All packaged resources verified."
 
+      - name: Smoke test - launch app
+        run: |
+          set -euo pipefail
+          APP_DIR="release/mac-arm64"
+          APP_NAME=$(ls "$APP_DIR" | grep '\.app$' | head -1)
+          if [ -z "$APP_NAME" ]; then
+            echo "::error::No .app bundle found"
+            exit 1
+          fi
+          EXECUTABLE="$APP_DIR/$APP_NAME/Contents/MacOS/$(echo "$APP_NAME" | sed 's/\.app$//')"
+          echo "Launching: $EXECUTABLE --smoke-test"
+          timeout 30 "$EXECUTABLE" --smoke-test 2>&1 || EXIT_CODE=$?
+          if [ "${EXIT_CODE:-0}" -eq 0 ]; then
+            echo "Launch smoke test passed"
+          else
+            echo "::error::Launch smoke test failed with exit code ${EXIT_CODE}"
+            exit 1
+          fi
+
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
         with:
@@ -205,6 +224,24 @@ jobs:
             exit 1
           }
           Write-Host "All packaged resources verified."
+
+      - name: Smoke test - launch app
+        shell: pwsh
+        run: |
+          $unpackedDir = "release\win-unpacked"
+          $exe = Get-ChildItem -Path $unpackedDir -Filter "*.exe" | Where-Object { $_.Name -notmatch 'Uninstall' } | Select-Object -First 1
+          if (-not $exe) {
+            Write-Host "::error::No exe found in win-unpacked"
+            exit 1
+          }
+          Write-Host "Launching: $($exe.FullName) --smoke-test"
+          $proc = Start-Process -FilePath $exe.FullName -ArgumentList "--smoke-test" -PassThru -Wait -NoNewWindow
+          if ($proc.ExitCode -eq 0) {
+            Write-Host "Launch smoke test passed"
+          } else {
+            Write-Host "::error::Launch smoke test failed with exit code $($proc.ExitCode)"
+            exit 1
+          }
 
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,22 @@ jobs:
           fi
           EXECUTABLE="$APP_DIR/$APP_NAME/Contents/MacOS/$(echo "$APP_NAME" | sed 's/\.app$//')"
           echo "Launching: $EXECUTABLE --smoke-test"
-          timeout 30 "$EXECUTABLE" --smoke-test 2>&1 || EXIT_CODE=$?
+          # macOS runners may not have coreutils timeout; fall back to no timeout
+          if command -v gtimeout >/dev/null 2>&1; then
+            gtimeout 30 "$EXECUTABLE" --smoke-test 2>&1 || EXIT_CODE=$?
+          elif command -v timeout >/dev/null 2>&1; then
+            timeout 30 "$EXECUTABLE" --smoke-test 2>&1 || EXIT_CODE=$?
+          else
+            "$EXECUTABLE" --smoke-test 2>&1 &
+            APP_PID=$!
+            sleep 30
+            if kill -0 "$APP_PID" 2>/dev/null; then
+              kill "$APP_PID"
+              echo "::error::Launch smoke test timed out after 30s"
+              exit 1
+            fi
+            wait "$APP_PID" || EXIT_CODE=$?
+          fi
           if [ "${EXIT_CODE:-0}" -eq 0 ]; then
             echo "Launch smoke test passed"
           else
@@ -235,7 +250,12 @@ jobs:
             exit 1
           }
           Write-Host "Launching: $($exe.FullName) --smoke-test"
-          $proc = Start-Process -FilePath $exe.FullName -ArgumentList "--smoke-test" -PassThru -Wait -NoNewWindow
+          $proc = Start-Process -FilePath $exe.FullName -ArgumentList "--smoke-test" -PassThru
+          if (-not $proc.WaitForExit(30000)) {
+            $proc.Kill($true)
+            Write-Host "::error::Launch smoke test timed out after 30s"
+            exit 1
+          }
           if ($proc.ExitCode -eq 0) {
             Write-Host "Launch smoke test passed"
           } else {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -781,6 +781,23 @@ function sendToRenderer(event: ServerEvent) {
 app
   .whenReady()
   .then(async () => {
+    // Smoke test mode: verify the app can start, then exit cleanly
+    if (process.argv.includes('--smoke-test')) {
+      log('[SmokeTest] App launched successfully in smoke test mode');
+      log('[SmokeTest] Platform:', process.platform, 'Arch:', process.arch);
+      log('[SmokeTest] Electron:', process.versions.electron, 'Node:', process.versions.node);
+      try {
+        // Verify critical native modules load
+        require('better-sqlite3');
+        log('[SmokeTest] better-sqlite3: OK');
+      } catch (e) {
+        log('[SmokeTest] FAIL: better-sqlite3 failed to load:', e);
+        process.exit(1);
+      }
+      log('[SmokeTest] PASSED');
+      process.exit(0);
+    }
+
     // Apply dev logs setting from config
     const enableDevLogs = configStore.get('enableDevLogs');
     setDevLogsEnabled(enableDevLogs);


### PR DESCRIPTION
## Summary

- Add `--smoke-test` flag to app entry point — verifies native modules load, then exits cleanly
- Both macOS and Windows release jobs now **actually launch the built app** before uploading to GitHub Release
- Catches the "builds OK but won't start" class of bugs that static resource checks miss

## What it tests

1. Electron app can start (`app.whenReady()` fires)
2. `better-sqlite3` native module loads correctly on the target platform
3. Clean exit with code 0

## How it works

```
App startup → detect --smoke-test → verify native modules → log PASSED → exit 0
```

If any step fails, the release workflow stops before uploading artifacts.

## Test plan

- [ ] macOS release job: smoke test passes after build
- [ ] Windows release job: smoke test passes after build
- [ ] Normal app launch (without --smoke-test) is unaffected