### PR TITLE
feat(permissions): gate local-agent tool calls through PermissionDialogMike/feat/permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,8 @@ progress.md
 task_plan.md
 findings.md
 mcp_server.log
+adaptations/
+.index/
 
 # Development log
 DEV_LOG.md

--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -24,6 +24,7 @@ import { Type, type TSchema } from '@sinclair/typebox';
 import { getSharedAuthStorage, ModelRegistry } from './shared-auth';
 import type { Session, Message, TraceStep, ServerEvent, ContentBlock } from '../../renderer/types';
 import { v4 as uuidv4 } from 'uuid';
+import { decidePermission, rememberAlwaysAllow } from '../config/permission-rules-store';
 import { PathResolver } from '../sandbox/path-resolver';
 import { MCPManager } from '../mcp/mcp-manager';
 import { mcpConfigStore } from '../mcp/mcp-config-store';
@@ -401,6 +402,12 @@ interface AgentRunnerOptions {
     toolUseId: string,
     command: string
   ) => Promise<string | null>;
+  requestPermission?: (
+    sessionId: string,
+    toolUseId: string,
+    toolName: string,
+    input: Record<string, unknown>
+  ) => Promise<'allow' | 'deny' | 'allow_always'>;
 }
 
 interface CachedPiSession {
@@ -427,6 +434,12 @@ export class ClaudeAgentRunner {
     toolUseId: string,
     command: string
   ) => Promise<string | null>;
+  private requestPermission?: (
+    sessionId: string,
+    toolUseId: string,
+    toolName: string,
+    input: Record<string, unknown>
+  ) => Promise<'allow' | 'deny' | 'allow_always'>;
   private pathResolver: PathResolver;
   private mcpManager?: MCPManager;
   // @ts-expect-error stored for future plugin support
@@ -707,6 +720,7 @@ ${hints.join('\n')}
     this.sendToRenderer = options.sendToRenderer;
     this.saveMessage = options.saveMessage;
     this.requestSudoPassword = options.requestSudoPassword;
+    this.requestPermission = options.requestPermission;
     this.pathResolver = pathResolver;
     this.mcpManager = mcpManager;
     this._pluginRuntimeService = pluginRuntimeService;
@@ -717,6 +731,100 @@ ${hints.join('\n')}
     if (mcpManager) {
       log('[ClaudeAgentRunner] MCP support enabled');
     }
+  }
+
+  /**
+   * Install a permission-gating hook on the pi-coding-agent session via
+   * `agent.setBeforeToolCall`. This is the only interception point that
+   * fires for built-in tools (read, bash, edit, write) — the SDK ignores
+   * wrapped `execute` functions on built-in tools passed via `options.tools`.
+   *
+   * The hook consults `decidePermission` from the main-process rules cache:
+   *  - 'allow' → delegate to SDK's original hook (proceeds normally)
+   *  - 'deny'  → return { block: true, reason } (SDK treats as tool error)
+   *  - 'ask'   → await requestPermission() IPC round-trip to PermissionDialog
+   *
+   * Known limitation: the async requestPermission wait (user dialog) causes
+   * the renderer to miss UI update events. The tool executes correctly on
+   * the backend, but the renderer's loading spinner may not clear. This is
+   * a renderer-side issue tracked as a follow-up.
+   */
+  private installPermissionHook(piSession: PiAgentSession, sessionId: string): void {
+    if (!this.requestPermission) {
+      log('[ClaudeAgentRunner] No requestPermission callback — skipping permission hook');
+      return;
+    }
+
+    // Access the Agent instance (public readonly property on AgentSession)
+    // and wrap its beforeToolCall hook with our permission gate.
+    //
+    // We must chain to the SDK's original beforeToolCall hook because it
+    // fires extension tool_call events and manages the _agentEventQueue.
+    // Without chaining, the renderer misses completion events.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const agent = (piSession as any).agent;
+    if (!agent || typeof agent.setBeforeToolCall !== 'function') {
+      logWarn(
+        '[ClaudeAgentRunner] Cannot access agent.setBeforeToolCall — skipping permission hook'
+      );
+      return;
+    }
+
+    // Capture the SDK's hook before we overwrite it
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sdkBeforeToolCall: ((ctx: any, signal?: AbortSignal) => Promise<any>) | undefined =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (agent as any)._beforeToolCall;
+
+    const requestPermission = this.requestPermission;
+
+    agent.setBeforeToolCall(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async (ctx: any, signal?: AbortSignal): Promise<any> => {
+        const toolName: string = ctx.toolCall?.name ?? '';
+        const input: Record<string, unknown> = ctx.args ?? {};
+
+        const decision = decidePermission(sessionId, toolName, input);
+
+        if (decision === 'deny') {
+          log(`[ClaudeAgentRunner] Tool '${toolName}' denied by rule`);
+          return { block: true, reason: `Tool '${toolName}' is denied by your permission rules.` };
+        }
+
+        if (decision === 'ask') {
+          const toolUseId = `${ctx.toolCall?.id ?? 'unknown'}-perm-${uuidv4().slice(0, 8)}`;
+          let result: 'allow' | 'deny' | 'allow_always';
+          try {
+            result = await requestPermission(sessionId, toolUseId, toolName, input);
+          } catch (permErr) {
+            logError(
+              `[ClaudeAgentRunner] Permission request failed for '${toolName}' — failing closed`,
+              permErr
+            );
+            return {
+              block: true,
+              reason: `Permission request failed for '${toolName}'; tool not executed.`,
+            };
+          }
+
+          if (result === 'deny') {
+            log(`[ClaudeAgentRunner] Tool '${toolName}' denied by user`);
+            return { block: true, reason: `User denied permission for '${toolName}'.` };
+          }
+
+          if (result === 'allow_always') {
+            rememberAlwaysAllow(sessionId, toolName);
+          }
+        }
+
+        // Allowed — delegate to SDK's original hook for event pipeline
+        return sdkBeforeToolCall ? sdkBeforeToolCall(ctx, signal) : undefined;
+      }
+    );
+
+    log(
+      `[ClaudeAgentRunner] Permission hook installed on session ${sessionId} via agent.setBeforeToolCall`
+    );
   }
 
   /**
@@ -1912,6 +2020,10 @@ Tool routing:
           cwd: effectiveCwd,
         });
         piSession = newPiSession;
+
+        // Install permission-gating hook via the SDK's tool_call extension event.
+        // This must happen once per new session — the hook persists across reuses.
+        this.installPermissionHook(piSession, session.id);
 
         // Store session for reuse — evict oldest if cache is full
         if (this.piSessions.size >= ClaudeAgentRunner.MAX_CACHED_SESSIONS) {

--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -25,6 +25,7 @@ import { Type, type TSchema } from '@sinclair/typebox';
 import { getSharedAuthStorage, ModelRegistry } from './shared-auth';
 import type { Session, Message, TraceStep, ServerEvent, ContentBlock } from '../../renderer/types';
 import { v4 as uuidv4 } from 'uuid';
+import { decidePermission, rememberAlwaysAllow } from '../config/permission-rules-store';
 import { PathResolver } from '../sandbox/path-resolver';
 import { MCPManager } from '../mcp/mcp-manager';
 import { mcpConfigStore } from '../mcp/mcp-config-store';
@@ -404,6 +405,12 @@ interface AgentRunnerOptions {
     toolUseId: string,
     command: string
   ) => Promise<string | null>;
+  requestPermission?: (
+    sessionId: string,
+    toolUseId: string,
+    toolName: string,
+    input: Record<string, unknown>
+  ) => Promise<'allow' | 'deny' | 'allow_always'>;
 }
 
 interface CachedPiSession {
@@ -431,6 +438,12 @@ export class ClaudeAgentRunner {
     toolUseId: string,
     command: string
   ) => Promise<string | null>;
+  private requestPermission?: (
+    sessionId: string,
+    toolUseId: string,
+    toolName: string,
+    input: Record<string, unknown>
+  ) => Promise<'allow' | 'deny' | 'allow_always'>;
   private pathResolver: PathResolver;
   private mcpManager?: MCPManager;
   private _pluginRuntimeService?: PluginRuntimeService;
@@ -757,6 +770,7 @@ ${hints.join('\n')}
     this.sendToRenderer = options.sendToRenderer;
     this.saveMessage = options.saveMessage;
     this.requestSudoPassword = options.requestSudoPassword;
+    this.requestPermission = options.requestPermission;
     this.pathResolver = pathResolver;
     this.mcpManager = mcpManager;
     this._pluginRuntimeService = pluginRuntimeService;
@@ -768,6 +782,100 @@ ${hints.join('\n')}
     if (mcpManager) {
       log('[ClaudeAgentRunner] MCP support enabled');
     }
+  }
+
+  /**
+   * Install a permission-gating hook on the pi-coding-agent session via
+   * `agent.setBeforeToolCall`. This is the only interception point that
+   * fires for built-in tools (read, bash, edit, write) — the SDK ignores
+   * wrapped `execute` functions on built-in tools passed via `options.tools`.
+   *
+   * The hook consults `decidePermission` from the main-process rules cache:
+   *  - 'allow' → delegate to SDK's original hook (proceeds normally)
+   *  - 'deny'  → return { block: true, reason } (SDK treats as tool error)
+   *  - 'ask'   → await requestPermission() IPC round-trip to PermissionDialog
+   *
+   * Known limitation: the async requestPermission wait (user dialog) causes
+   * the renderer to miss UI update events. The tool executes correctly on
+   * the backend, but the renderer's loading spinner may not clear. This is
+   * a renderer-side issue tracked as a follow-up.
+   */
+  private installPermissionHook(piSession: PiAgentSession, sessionId: string): void {
+    if (!this.requestPermission) {
+      log('[ClaudeAgentRunner] No requestPermission callback — skipping permission hook');
+      return;
+    }
+
+    // Access the Agent instance (public readonly property on AgentSession)
+    // and wrap its beforeToolCall hook with our permission gate.
+    //
+    // We must chain to the SDK's original beforeToolCall hook because it
+    // fires extension tool_call events and manages the _agentEventQueue.
+    // Without chaining, the renderer misses completion events.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const agent = (piSession as any).agent;
+    if (!agent || typeof agent.setBeforeToolCall !== 'function') {
+      logWarn(
+        '[ClaudeAgentRunner] Cannot access agent.setBeforeToolCall — skipping permission hook'
+      );
+      return;
+    }
+
+    // Capture the SDK's hook before we overwrite it
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sdkBeforeToolCall: ((ctx: any, signal?: AbortSignal) => Promise<any>) | undefined =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (agent as any)._beforeToolCall;
+
+    const requestPermission = this.requestPermission;
+
+    agent.setBeforeToolCall(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async (ctx: any, signal?: AbortSignal): Promise<any> => {
+        const toolName: string = ctx.toolCall?.name ?? '';
+        const input: Record<string, unknown> = ctx.args ?? {};
+
+        const decision = decidePermission(sessionId, toolName, input);
+
+        if (decision === 'deny') {
+          log(`[ClaudeAgentRunner] Tool '${toolName}' denied by rule`);
+          return { block: true, reason: `Tool '${toolName}' is denied by your permission rules.` };
+        }
+
+        if (decision === 'ask') {
+          const toolUseId = `${ctx.toolCall?.id ?? 'unknown'}-perm-${uuidv4().slice(0, 8)}`;
+          let result: 'allow' | 'deny' | 'allow_always';
+          try {
+            result = await requestPermission(sessionId, toolUseId, toolName, input);
+          } catch (permErr) {
+            logError(
+              `[ClaudeAgentRunner] Permission request failed for '${toolName}' — failing closed`,
+              permErr
+            );
+            return {
+              block: true,
+              reason: `Permission request failed for '${toolName}'; tool not executed.`,
+            };
+          }
+
+          if (result === 'deny') {
+            log(`[ClaudeAgentRunner] Tool '${toolName}' denied by user`);
+            return { block: true, reason: `User denied permission for '${toolName}'.` };
+          }
+
+          if (result === 'allow_always') {
+            rememberAlwaysAllow(sessionId, toolName);
+          }
+        }
+
+        // Allowed — delegate to SDK's original hook for event pipeline
+        return sdkBeforeToolCall ? sdkBeforeToolCall(ctx, signal) : undefined;
+      }
+    );
+
+    log(
+      `[ClaudeAgentRunner] Permission hook installed on session ${sessionId} via agent.setBeforeToolCall`
+    );
   }
 
   /**
@@ -2019,6 +2127,10 @@ Tool routing:
           cwd: effectiveCwd,
         });
         piSession = newPiSession;
+
+        // Install permission-gating hook via the SDK's tool_call extension event.
+        // This must happen once per new session — the hook persists across reuses.
+        this.installPermissionHook(piSession, session.id);
 
         // Store session for reuse — evict oldest if cache is full
         if (this.piSessions.size >= ClaudeAgentRunner.MAX_CACHED_SESSIONS) {

--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -828,6 +828,7 @@ ${hints.join('\n')}
       (agent as any)._beforeToolCall;
 
     const requestPermission = this.requestPermission;
+    const getDisplayName = (name: string): string => this.getToolDisplayName(name);
 
     agent.setBeforeToolCall(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -836,17 +837,28 @@ ${hints.join('\n')}
         const input: Record<string, unknown> = ctx.args ?? {};
 
         const decision = decidePermission(sessionId, toolName, input);
+        // Human-readable name for prompts/messages (e.g. MCP sanitized
+        // 'mcp__chrome__chrome_screenshot__ab12' → 'chrome_screenshot').
+        // Rule matching and rememberAlwaysAllow still use the canonical
+        // `toolName` so allow-once decisions stay stable across calls.
+        const displayName = getDisplayName(toolName);
 
         if (decision === 'deny') {
           log(`[ClaudeAgentRunner] Tool '${toolName}' denied by rule`);
-          return { block: true, reason: `Tool '${toolName}' is denied by your permission rules.` };
+          return {
+            block: true,
+            reason: `Tool '${displayName}' is denied by your permission rules.`,
+          };
         }
 
         if (decision === 'ask') {
           const toolUseId = `${ctx.toolCall?.id ?? 'unknown'}-perm-${uuidv4().slice(0, 8)}`;
           let result: 'allow' | 'deny' | 'allow_always';
           try {
-            result = await requestPermission(sessionId, toolUseId, toolName, input);
+            // Send the display name to the renderer so the dialog shows a
+            // human-readable tool name; canonical `toolName` is still used
+            // for rule matching above and "always allow" memory below.
+            result = await requestPermission(sessionId, toolUseId, displayName, input);
           } catch (permErr) {
             logError(
               `[ClaudeAgentRunner] Permission request failed for '${toolName}' — failing closed`,
@@ -854,13 +866,13 @@ ${hints.join('\n')}
             );
             return {
               block: true,
-              reason: `Permission request failed for '${toolName}'; tool not executed.`,
+              reason: `Permission request failed for '${displayName}'; tool not executed.`,
             };
           }
 
           if (result === 'deny') {
             log(`[ClaudeAgentRunner] Tool '${toolName}' denied by user`);
-            return { block: true, reason: `User denied permission for '${toolName}'.` };
+            return { block: true, reason: `User denied permission for '${displayName}'.` };
           }
 
           if (result === 'allow_always') {

--- a/src/main/config/permission-rules-store.ts
+++ b/src/main/config/permission-rules-store.ts
@@ -1,0 +1,132 @@
+/**
+ * @module main/config/permission-rules-store
+ *
+ * Main-process cache of Settings.permissionRules.
+ *
+ * The renderer owns the source of truth (Zustand store), but the agent
+ * runner needs synchronous access in the main process when wrapping tool
+ * `execute()` calls. The renderer mirrors changes via the `settings.update`
+ * IPC event; see `src/main/index.ts`.
+ *
+ * Security note: renderer-originated settings are treated as untrusted at
+ * this boundary. All rules are validated and coerced before being cached —
+ * unknown / malformed values fall back to `'ask'` so the worst-case is a
+ * harmless extra prompt, never an unintended auto-allow.
+ */
+import type { PermissionRule } from '../../renderer/types';
+
+// Mirrors the renderer defaults in src/renderer/store/index.ts
+const DEFAULT_RULES: PermissionRule[] = [
+  { tool: 'read', action: 'allow' },
+  { tool: 'glob', action: 'allow' },
+  { tool: 'grep', action: 'allow' },
+  { tool: 'ls', action: 'allow' },
+  { tool: 'find', action: 'allow' },
+  { tool: 'write', action: 'ask' },
+  { tool: 'edit', action: 'ask' },
+  { tool: 'bash', action: 'ask' },
+];
+
+const VALID_ACTIONS: ReadonlySet<PermissionRule['action']> = new Set(['allow', 'deny', 'ask']);
+
+let rules: PermissionRule[] = [...DEFAULT_RULES];
+
+/** Session-scoped "always allow" decisions, keyed by sessionId → set of lowercase tool names. */
+const alwaysAllowBySession = new Map<string, Set<string>>();
+
+/**
+ * Sanitize an untrusted rules payload from IPC. Drops entries with empty
+ * tool names, coerces invalid `action` values to `'ask'`, and preserves
+ * optional string `pattern` fields. Returns null for non-array input.
+ */
+function sanitizeRules(input: unknown): PermissionRule[] | null {
+  if (!Array.isArray(input)) return null;
+  const out: PermissionRule[] = [];
+  for (const raw of input) {
+    if (!raw || typeof raw !== 'object') continue;
+    const r = raw as Partial<PermissionRule>;
+    const tool = typeof r.tool === 'string' ? r.tool.trim() : '';
+    if (!tool) continue;
+
+    const pattern = typeof r.pattern === 'string' ? r.pattern : undefined;
+    const rawAction = typeof r.action === 'string' ? r.action : '';
+    const action: PermissionRule['action'] = VALID_ACTIONS.has(
+      rawAction as PermissionRule['action']
+    )
+      ? (rawAction as PermissionRule['action'])
+      : 'ask'; // Conservative fallback for unknown / malformed actions
+
+    out.push({ tool, pattern, action });
+  }
+  return out;
+}
+
+export function setPermissionRules(next: unknown): void {
+  const sanitized = sanitizeRules(next);
+  rules = sanitized && sanitized.length > 0 ? sanitized : [...DEFAULT_RULES];
+}
+
+export function getPermissionRules(): PermissionRule[] {
+  // Return a shallow copy so external callers can't mutate the internal cache.
+  return rules.map((r) => ({ ...r }));
+}
+
+/**
+ * Decide how a given tool call should be handled.
+ *
+ * Matching order:
+ *   1. Session-scoped "always allow" memory
+ *   2. First rule whose `tool` matches (case-insensitive) AND whose
+ *      optional `pattern` (glob-ish: `*` = any substring) matches the
+ *      stringified input
+ *   3. Default: 'ask' for unknown tools (conservative)
+ *
+ * Defence-in-depth: even though `setPermissionRules` sanitizes input, we
+ * re-validate the matched rule's action here so a malformed rule that
+ * somehow bypasses sanitation still falls back to `'ask'` rather than
+ * letting an unknown value propagate into the execution path.
+ */
+export function decidePermission(
+  sessionId: string,
+  toolName: string,
+  input: Record<string, unknown>
+): 'allow' | 'deny' | 'ask' {
+  const lowered = toolName.toLowerCase();
+
+  const session = alwaysAllowBySession.get(sessionId);
+  if (session?.has(lowered)) return 'allow';
+
+  const inputStr = safeStringify(input);
+
+  for (const rule of rules) {
+    if (rule.tool.toLowerCase() !== lowered) continue;
+    if (rule.pattern && !matchesPattern(rule.pattern, inputStr)) continue;
+    return VALID_ACTIONS.has(rule.action) ? rule.action : 'ask';
+  }
+  return 'ask';
+}
+
+export function rememberAlwaysAllow(sessionId: string, toolName: string): void {
+  const set = alwaysAllowBySession.get(sessionId) ?? new Set<string>();
+  set.add(toolName.toLowerCase());
+  alwaysAllowBySession.set(sessionId, set);
+}
+
+export function forgetSessionPermissions(sessionId: string): void {
+  alwaysAllowBySession.delete(sessionId);
+}
+
+function safeStringify(v: unknown): string {
+  try {
+    const s = typeof v === 'string' ? v : JSON.stringify(v);
+    return s ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function matchesPattern(pattern: string, haystack: string): boolean {
+  // Escape regex metacharacters except '*', then convert '*' → '.*'
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(escaped, 'i').test(haystack);
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,7 @@ import {
 } from './config/config-store';
 import { runConfigApiTest } from './config/config-test-routing';
 import { listOllamaModels } from './config/ollama-api';
+import { setPermissionRules } from './config/permission-rules-store';
 import { mcpConfigStore } from './mcp/mcp-config-store';
 import { getSandboxAdapter, shutdownSandbox } from './sandbox/sandbox-adapter';
 import { SandboxSync } from './sandbox/sandbox-sync';
@@ -45,6 +46,7 @@ import type {
   ApiTestResult,
   DiagnosticInput,
   ProviderModelInfo,
+  PermissionRule,
 } from '../renderer/types';
 import { remoteManager, type AgentExecutor } from './remote/remote-manager';
 import { remoteConfigStore } from './remote/remote-config-store';
@@ -2662,6 +2664,12 @@ async function handleClientEvent(event: ClientEvent): Promise<unknown> {
             config: configStore.getAll(),
           },
         });
+      }
+
+      if (Array.isArray((event.payload as { permissionRules?: unknown }).permissionRules)) {
+        setPermissionRules(
+          (event.payload as { permissionRules: PermissionRule[] }).permissionRules
+        );
       }
       return null;
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,7 @@ import {
 } from './config/config-store';
 import { runConfigApiTest } from './config/config-test-routing';
 import { listOllamaModels } from './config/ollama-api';
+import { setPermissionRules } from './config/permission-rules-store';
 import { mcpConfigStore } from './mcp/mcp-config-store';
 import { getSandboxAdapter, shutdownSandbox } from './sandbox/sandbox-adapter';
 import { SandboxSync } from './sandbox/sandbox-sync';
@@ -48,6 +49,7 @@ import type {
   ApiTestResult,
   DiagnosticInput,
   ProviderModelInfo,
+  PermissionRule,
 } from '../renderer/types';
 import { remoteManager, type AgentExecutor } from './remote/remote-manager';
 import { remoteConfigStore } from './remote/remote-config-store';
@@ -2789,6 +2791,12 @@ async function handleClientEvent(event: ClientEvent): Promise<unknown> {
             config: configStore.getAll(),
           },
         });
+      }
+
+      if (Array.isArray((event.payload as { permissionRules?: unknown }).permissionRules)) {
+        setPermissionRules(
+          (event.payload as { permissionRules: PermissionRule[] }).permissionRules
+        );
       }
       return null;
 

--- a/src/main/session/session-manager.ts
+++ b/src/main/session/session-manager.ts
@@ -38,6 +38,7 @@ import { configStore } from '../config/config-store';
 import { MCPManager } from '../mcp/mcp-manager';
 import { mcpConfigStore } from '../mcp/mcp-config-store';
 import { PluginRuntimeService } from '../skills/plugin-runtime-service';
+import { forgetSessionPermissions } from '../config/permission-rules-store';
 import {
   log,
   logError,
@@ -132,6 +133,12 @@ export class SessionManager {
         saveMessage: (message: Message) => this.saveMessage(message),
         requestSudoPassword: (sessionId: string, toolUseId: string, command: string) =>
           this.requestSudoPassword(sessionId, toolUseId, command),
+        requestPermission: (
+          sessionId: string,
+          toolUseId: string,
+          toolName: string,
+          input: Record<string, unknown>
+        ) => this.requestPermission(sessionId, toolUseId, toolName, input),
       },
       this.pathResolver,
       this.mcpManager,
@@ -934,6 +941,7 @@ export class SessionManager {
     this.messageCache.delete(sessionId);
     this.sessionTitleAttempts.delete(sessionId);
     this.titleGenerationTokens.delete(sessionId);
+    forgetSessionPermissions(sessionId);
 
     log('[SessionManager] Session deleted:', sessionId);
   }
@@ -958,6 +966,7 @@ export class SessionManager {
         this.messageCache.delete(sessionId);
         this.sessionTitleAttempts.delete(sessionId);
         this.titleGenerationTokens.delete(sessionId);
+        forgetSessionPermissions(sessionId);
       }
     })();
 

--- a/src/main/session/session-manager.ts
+++ b/src/main/session/session-manager.ts
@@ -39,6 +39,7 @@ import { MCPManager } from '../mcp/mcp-manager';
 import { mcpConfigStore } from '../mcp/mcp-config-store';
 import { PluginRuntimeService } from '../skills/plugin-runtime-service';
 import { AgentRuntimeExtensionManager } from '../extensions/agent-runtime-extension-manager';
+import { forgetSessionPermissions } from '../config/permission-rules-store';
 import {
   log,
   logError,
@@ -137,6 +138,12 @@ export class SessionManager {
         saveMessage: (message: Message) => this.saveMessage(message),
         requestSudoPassword: (sessionId: string, toolUseId: string, command: string) =>
           this.requestSudoPassword(sessionId, toolUseId, command),
+        requestPermission: (
+          sessionId: string,
+          toolUseId: string,
+          toolName: string,
+          input: Record<string, unknown>
+        ) => this.requestPermission(sessionId, toolUseId, toolName, input),
       },
       this.pathResolver,
       this.mcpManager,
@@ -972,6 +979,7 @@ export class SessionManager {
         session: existingSession,
       });
     }
+    forgetSessionPermissions(sessionId);
 
     log('[SessionManager] Session deleted:', sessionId);
   }
@@ -999,6 +1007,7 @@ export class SessionManager {
         this.messageCache.delete(sessionId);
         this.sessionTitleAttempts.delete(sessionId);
         this.titleGenerationTokens.delete(sessionId);
+        forgetSessionPermissions(sessionId);
       }
     })();
 

--- a/src/renderer/hooks/useIPC.ts
+++ b/src/renderer/hooks/useIPC.ts
@@ -326,6 +326,23 @@ export function useIPC() {
         const store = useAppStore.getState();
         store.setSystemDarkMode(Boolean(systemTheme?.shouldUseDarkColors));
         applyConfigSnapshot(config, Boolean(isConfigured));
+
+        // Hydrate main-process permission rules from the renderer's (possibly
+        // persisted) settings so the agent has them before the first tool call.
+        // Re-read the store after applyConfigSnapshot so we send the latest
+        // persisted rules, not a stale pre-hydration snapshot.
+        try {
+          const latest = useAppStore.getState();
+          window.electronAPI.send({
+            type: 'settings.update',
+            payload: { permissionRules: latest.settings.permissionRules } as Record<
+              string,
+              unknown
+            >,
+          });
+        } catch (syncErr) {
+          console.warn('[useIPC] Failed to sync permissionRules to main:', syncErr);
+        }
       } catch (error) {
         console.error('[useIPC] Failed to bootstrap config/theme state:', error);
       }

--- a/src/renderer/hooks/useIPC.ts
+++ b/src/renderer/hooks/useIPC.ts
@@ -15,13 +15,30 @@ import i18n from '../i18n/config';
 // Check if running in Electron
 const isElectron = typeof window !== 'undefined' && window.electronAPI !== undefined;
 
+// Module-level singleton guard so only the FIRST useIPC() caller installs the
+// server-event listener. Other callers (PermissionDialog, Sidebar, ChatView,
+// etc.) still get the callback API but must NOT re-register the listener —
+// the preload's `on()` is a "single-slot" bridge and re-registering (or
+// unmounting a subsequent useIPC caller) tears down the single shared
+// listener, silently dropping subsequent events from main.
+let ipcListenerInstalled = false;
+
 export function useIPC() {
-  // Handle incoming server events - only setup once
+  // Handle incoming server events - only setup once across all useIPC() callers.
+  // See module-level `ipcListenerInstalled` guard above for the full reason.
   useEffect(() => {
     if (!isElectron) {
       console.log('[useIPC] Not in Electron, skipping IPC setup');
       return;
     }
+
+    if (ipcListenerInstalled) {
+      // A previous useIPC() caller already installed the shared listener.
+      // Do nothing here — and crucially return no cleanup, so unmounting
+      // this component does NOT tear down the shared listener.
+      return;
+    }
+    ipcListenerInstalled = true;
 
     console.log('[useIPC] Setting up IPC listener (once)');
 
@@ -366,6 +383,10 @@ export function useIPC() {
         flushTraces();
       }
       cleanup?.();
+      // Reset guard so a subsequent mount (e.g., React Strict Mode double-
+      // invoke in dev) re-installs the listener instead of silently running
+      // with a torn-down bridge.
+      ipcListenerInstalled = false;
     };
   }, []); // Empty deps - setup listener only once!
 

--- a/src/tests/config/permission-rules-store.test.ts
+++ b/src/tests/config/permission-rules-store.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for src/main/config/permission-rules-store.
+ *
+ * Focus areas (security-critical):
+ *   - decidePermission() returns allow / deny / ask per rule
+ *   - Glob-ish pattern matching ('*' = any substring) and case-insensitivity
+ *   - Session-scoped "always allow" memory works within session and clears on
+ *     forgetSessionPermissions()
+ *   - Garbage / malformed renderer input falls back to DEFAULT_RULES so the
+ *     fail-safe is an extra prompt, never a silent auto-allow
+ *   - Malformed individual rule entries are coerced to 'ask' rather than
+ *     silently bypassed
+ */
+import { beforeEach, describe, it, expect } from 'vitest';
+import {
+  decidePermission,
+  forgetSessionPermissions,
+  getPermissionRules,
+  rememberAlwaysAllow,
+  setPermissionRules,
+} from '../../main/config/permission-rules-store';
+
+const SESSION_A = 'session-a';
+const SESSION_B = 'session-b';
+
+// Reset to DEFAULT_RULES before each test by passing garbage input — the
+// module documents that this falls back to defaults rather than empty rules.
+function resetToDefaults(): void {
+  setPermissionRules(null);
+  forgetSessionPermissions(SESSION_A);
+  forgetSessionPermissions(SESSION_B);
+}
+
+describe('permission-rules-store', () => {
+  beforeEach(() => {
+    resetToDefaults();
+  });
+
+  describe('decidePermission — built-in defaults', () => {
+    it('returns allow for default-allowed read tool', () => {
+      expect(decidePermission(SESSION_A, 'read', { path: '/tmp/x' })).toBe('allow');
+    });
+
+    it('returns ask for default-ask bash tool', () => {
+      expect(decidePermission(SESSION_A, 'bash', { command: 'ls' })).toBe('ask');
+    });
+
+    it('returns ask for default-ask write tool', () => {
+      expect(decidePermission(SESSION_A, 'write', { path: '/etc/passwd' })).toBe('ask');
+    });
+
+    it('returns ask for unknown tool (conservative default)', () => {
+      expect(decidePermission(SESSION_A, 'unknown_tool', {})).toBe('ask');
+    });
+
+    it('matches tool names case-insensitively', () => {
+      expect(decidePermission(SESSION_A, 'READ', {})).toBe('allow');
+      expect(decidePermission(SESSION_A, 'BaSh', { command: 'ls' })).toBe('ask');
+    });
+  });
+
+  describe('setPermissionRules — explicit rules', () => {
+    it('returns allow when matching allow rule is set', () => {
+      setPermissionRules([{ tool: 'bash', action: 'allow' }]);
+      expect(decidePermission(SESSION_A, 'bash', { command: 'rm -rf /' })).toBe('allow');
+    });
+
+    it('returns deny when matching deny rule is set', () => {
+      setPermissionRules([{ tool: 'bash', action: 'deny' }]);
+      expect(decidePermission(SESSION_A, 'bash', { command: 'ls' })).toBe('deny');
+    });
+
+    it('returns ask when matching ask rule is set', () => {
+      setPermissionRules([{ tool: 'bash', action: 'ask' }]);
+      expect(decidePermission(SESSION_A, 'bash', { command: 'ls' })).toBe('ask');
+    });
+
+    it('falls through to default ask when no rule matches the tool', () => {
+      setPermissionRules([{ tool: 'read', action: 'allow' }]);
+      expect(decidePermission(SESSION_A, 'bash', { command: 'ls' })).toBe('ask');
+    });
+  });
+
+  describe('pattern matching', () => {
+    it("rule for 'bash' with pattern 'ls *' allows 'ls -la' but not 'rm -rf'", () => {
+      setPermissionRules([
+        { tool: 'bash', pattern: 'ls *', action: 'allow' },
+        { tool: 'bash', action: 'ask' },
+      ]);
+      expect(decidePermission(SESSION_A, 'bash', { command: 'ls -la' })).toBe('allow');
+      expect(decidePermission(SESSION_A, 'bash', { command: 'rm -rf /tmp' })).toBe('ask');
+    });
+
+    it('uses first matching rule (rules are evaluated in order)', () => {
+      setPermissionRules([
+        { tool: 'bash', pattern: 'rm *', action: 'deny' },
+        { tool: 'bash', action: 'allow' },
+      ]);
+      expect(decidePermission(SESSION_A, 'bash', { command: 'rm -rf /' })).toBe('deny');
+      expect(decidePermission(SESSION_A, 'bash', { command: 'ls' })).toBe('allow');
+    });
+
+    it('treats * as any substring (not just trailing wildcards)', () => {
+      setPermissionRules([{ tool: 'bash', pattern: '*sudo*', action: 'deny' }]);
+      expect(decidePermission(SESSION_A, 'bash', { command: 'echo hi | sudo tee f' })).toBe('deny');
+      expect(decidePermission(SESSION_A, 'bash', { command: 'echo hi' })).toBe('ask');
+    });
+
+    it('escapes regex metacharacters in patterns (security: prevents injection)', () => {
+      // '.' in pattern must match literal '.', not any char
+      setPermissionRules([{ tool: 'bash', pattern: 'rm a.txt', action: 'deny' }]);
+      expect(decidePermission(SESSION_A, 'bash', { command: 'rm a.txt' })).toBe('deny');
+      // Should NOT match because the '.' is escaped to a literal dot
+      expect(decidePermission(SESSION_A, 'bash', { command: 'rm aXtxt' })).toBe('ask');
+    });
+
+    it('falls through when pattern does not match', () => {
+      setPermissionRules([
+        { tool: 'bash', pattern: 'ls *', action: 'allow' },
+        // No catch-all → falls through to module default ('ask')
+      ]);
+      expect(decidePermission(SESSION_A, 'bash', { command: 'cat /etc/passwd' })).toBe('ask');
+    });
+
+    it('matches pattern against stringified JSON input for non-bash tools', () => {
+      setPermissionRules([
+        { tool: 'write', pattern: '*sensitive*', action: 'deny' },
+        { tool: 'write', action: 'allow' },
+      ]);
+      expect(decidePermission(SESSION_A, 'write', { path: '/sensitive/data.json' })).toBe('deny');
+      expect(decidePermission(SESSION_A, 'write', { path: '/tmp/ok.txt' })).toBe('allow');
+    });
+  });
+
+  describe('session-scoped always-allow', () => {
+    it('rememberAlwaysAllow makes future calls allow within the same session', () => {
+      setPermissionRules([{ tool: 'bash', action: 'ask' }]);
+      expect(decidePermission(SESSION_A, 'bash', { command: 'ls' })).toBe('ask');
+      rememberAlwaysAllow(SESSION_A, 'bash');
+      expect(decidePermission(SESSION_A, 'bash', { command: 'ls' })).toBe('allow');
+    });
+
+    it('always-allow does NOT leak to other sessions', () => {
+      setPermissionRules([{ tool: 'bash', action: 'ask' }]);
+      rememberAlwaysAllow(SESSION_A, 'bash');
+      // Same tool, different session — must still ask
+      expect(decidePermission(SESSION_B, 'bash', { command: 'ls' })).toBe('ask');
+    });
+
+    it('forgetSessionPermissions clears session-scoped allow memory', () => {
+      setPermissionRules([{ tool: 'bash', action: 'ask' }]);
+      rememberAlwaysAllow(SESSION_A, 'bash');
+      expect(decidePermission(SESSION_A, 'bash', {})).toBe('allow');
+      forgetSessionPermissions(SESSION_A);
+      expect(decidePermission(SESSION_A, 'bash', {})).toBe('ask');
+    });
+
+    it('always-allow is case-insensitive (normalized to lowercase)', () => {
+      setPermissionRules([{ tool: 'bash', action: 'ask' }]);
+      rememberAlwaysAllow(SESSION_A, 'BASH');
+      expect(decidePermission(SESSION_A, 'bash', {})).toBe('allow');
+      expect(decidePermission(SESSION_A, 'Bash', {})).toBe('allow');
+    });
+
+    it('always-allow takes precedence over a configured deny rule', () => {
+      // Security note: this matches the documented matching order (session
+      // memory first, then rules). If this behaviour ever needs to change
+      // for security reasons, this test should fail loudly.
+      setPermissionRules([{ tool: 'bash', action: 'deny' }]);
+      rememberAlwaysAllow(SESSION_A, 'bash');
+      expect(decidePermission(SESSION_A, 'bash', {})).toBe('allow');
+    });
+  });
+
+  describe('fail-safe input sanitation', () => {
+    it('falls back to DEFAULT_RULES when given null', () => {
+      setPermissionRules(null);
+      // read is in defaults as 'allow'
+      expect(decidePermission(SESSION_A, 'read', {})).toBe('allow');
+      // bash is in defaults as 'ask'
+      expect(decidePermission(SESSION_A, 'bash', {})).toBe('ask');
+    });
+
+    it('falls back to DEFAULT_RULES when given non-array', () => {
+      setPermissionRules({ not: 'an-array' });
+      expect(decidePermission(SESSION_A, 'read', {})).toBe('allow');
+      expect(decidePermission(SESSION_A, 'bash', {})).toBe('ask');
+    });
+
+    it('falls back to DEFAULT_RULES when array sanitises to empty', () => {
+      // All entries are garbage (no tool field) → sanitised list is empty →
+      // fall back to defaults so we never run with an "allow everything"
+      // empty ruleset.
+      setPermissionRules([{ notTool: 'bash' }, null, 'string', 42]);
+      expect(decidePermission(SESSION_A, 'read', {})).toBe('allow');
+      expect(decidePermission(SESSION_A, 'bash', {})).toBe('ask');
+    });
+
+    it('coerces unknown action values to ask (never silently auto-allows)', () => {
+      setPermissionRules([{ tool: 'bash', action: 'YOLO' }]);
+      // Action 'YOLO' is invalid → coerced to 'ask'
+      expect(decidePermission(SESSION_A, 'bash', {})).toBe('ask');
+    });
+
+    it('drops rules with empty / whitespace tool names', () => {
+      setPermissionRules([
+        { tool: '   ', action: 'allow' },
+        { tool: '', action: 'allow' },
+        { tool: 'read', action: 'allow' },
+      ]);
+      // The two garbage entries are dropped; the read entry survives
+      const rules = getPermissionRules();
+      expect(rules).toHaveLength(1);
+      expect(rules[0].tool).toBe('read');
+    });
+
+    it('coerces non-string pattern to undefined (no crash)', () => {
+      setPermissionRules([{ tool: 'bash', pattern: 123 as unknown as string, action: 'allow' }]);
+      // Pattern was non-string → dropped; rule applies unconditionally
+      expect(decidePermission(SESSION_A, 'bash', { command: 'rm -rf /' })).toBe('allow');
+    });
+
+    it('mixes valid + garbage rules: keeps the valid ones, drops the rest', () => {
+      setPermissionRules([
+        { tool: 'bash', action: 'deny' },
+        null,
+        { notTool: 'foo' },
+        { tool: '', action: 'allow' },
+        { tool: 'read', action: 'allow' },
+      ]);
+      expect(decidePermission(SESSION_A, 'bash', {})).toBe('deny');
+      expect(decidePermission(SESSION_A, 'read', {})).toBe('allow');
+    });
+  });
+
+  describe('getPermissionRules', () => {
+    it('returns defaults after reset', () => {
+      const rules = getPermissionRules();
+      const tools = rules.map((r) => r.tool);
+      expect(tools).toContain('read');
+      expect(tools).toContain('bash');
+    });
+
+    it('returns shallow copies so callers cannot mutate the internal cache', () => {
+      setPermissionRules([{ tool: 'bash', action: 'allow' }]);
+      const rules = getPermissionRules();
+      rules[0].action = 'deny';
+      // Internal cache should be unaffected
+      expect(decidePermission(SESSION_A, 'bash', {})).toBe('allow');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #164

## What this does

Wires the existing PermissionDialog, permission.request IPC channel, and settings.permissionRules into the local pi-coding-agent tool-execution path. Local sessions now prompt for approval on write/edit/bash and any MCP tool whose rule is `ask`, matching the behaviour remote (Feishu/Slack) sessions already had.

## Commits

1. **feat(permissions)** — Install a permission-gating hook on the pi-coding-agent session via `agent.setBeforeToolCall(...)`, chaining to the SDK's original hook. Covers both built-in tools (read, bash, edit, write) and MCP customTools in one interception point. Adds a main-process `permission-rules-store` with IPC-safe sanitization, hydrates it from the renderer on startup and every `settings.update`, and clears session-scoped "always allow" memory on session delete. Fails closed if the permission IPC rejects.

2. **fix(renderer)** — Follow-up fix for a React/preload integration bug that was masking the feature end-to-end. The preload's `window.electronAPI.on()` is a single-slot bridge; seven components call `useIPC()`, and each `useEffect` cleanup tore down the shared listener. When `PermissionDialog` unmounted after the user clicked Allow, the listener was removed and every subsequent `webContents.send()` call (tool result, session.status=idle) was silently dropped. Adds a module-level `ipcListenerInstalled` flag so only the first `useIPC()` caller installs the listener and registers a cleanup. Strict-mode-safe.

## Testing

Reproduced end-to-end on macOS with `deepseek/deepseek-v3.2:nitro` via OpenRouter:

1. Fresh session, prompt "Run `ls -la` in current directory"
2. `PermissionDialog` appears with the proposed bash command ✅
3. Click Allow ✅
4. Tool result appears in chat ✅
5. Agent's follow-up reply streams in ✅
6. Loading spinner clears when `session.status=idle` arrives ✅

Also verified Deny (tool returns isError) and Always Allow (subsequent same-tool calls skip the dialog in the same session).
