### PR TITLE
fix(agent-runner): forward pasted image content to vision-capable models

### DIFF
--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -1257,8 +1257,39 @@ ${hints.join('\n')}
 
       const hasImages =
         lastUserMessage?.content.some((c) => (c as { type?: string }).type === 'image') || false;
+      // Extract image blocks from current user message and convert frontend shape
+      // ({type:'image', source:{type:'base64', media_type, data}}) → pi-coding-agent shape
+      // ({type:'image', mimeType, data}). Stored separately and passed to prompt() so
+      // pi can route them as vision input alongside the text.
+      const currentTurnImages: Array<{ type: 'image'; mimeType: string; data: string }> = [];
+      if (lastUserMessage) {
+        for (const block of lastUserMessage.content) {
+          const b = block as {
+            type?: string;
+            source?: { type?: string; media_type?: string; data?: string };
+            mimeType?: string;
+            data?: string;
+          };
+          if (b.type !== 'image') continue;
+          let mimeType: string | undefined;
+          let data: string | undefined;
+          if (b.source && typeof b.source === 'object') {
+            mimeType = b.source.media_type;
+            data = b.source.data;
+          }
+          if (!mimeType && typeof b.mimeType === 'string') mimeType = b.mimeType;
+          if (!data && typeof b.data === 'string') data = b.data;
+          if (mimeType && data) {
+            currentTurnImages.push({ type: 'image', mimeType, data });
+          }
+        }
+      }
       if (hasImages) {
-        log('[ClaudeAgentRunner] User message contains images');
+        log(
+          '[ClaudeAgentRunner] User message contains images:',
+          currentTurnImages.length,
+          'extracted'
+        );
       }
 
       logTiming('before pi-ai model resolution', runStartTime);
@@ -2401,7 +2432,10 @@ Tool routing:
             })
           );
         }
-        const promptResult = await piSession.prompt(contextualPrompt);
+        const promptResult =
+          currentTurnImages.length > 0
+            ? await piSession.prompt(contextualPrompt, { images: currentTurnImages })
+            : await piSession.prompt(contextualPrompt);
         log(
           '[ClaudeAgentRunner] prompt() returned:',
           JSON.stringify(promptResult ?? 'void').substring(0, 1000)


### PR DESCRIPTION
## Summary

When a user pastes an image in `ChatView`, the renderer creates a content block in Anthropic Messages API shape:

```ts
{ type: 'image', source: { type: 'base64', media_type, data } }
```

`ClaudeAgentRunner` in `src/main/claude/agent-runner.ts` only forwarded the prompt text via `piSession.prompt(string)`, so the image bytes were silently dropped before reaching the model. The pre-existing `hasImages` flag was set but never acted on — vision-capable agents received only the text.

This patch:

1. Walks the current user message's content blocks and extracts any `type:'image'` entries.
2. Normalises the Anthropic shape (`source.media_type`, `source.data`) to the pi-coding-agent shape (`{type:'image', mimeType, data}`). Already-normalised blocks are accepted too for forward compat.
3. Passes the extracted images via `piSession.prompt(text, { images: currentTurnImages })`. The text-only path is preserved when the user didn't paste anything, so the wire format is unchanged in the common case.

Only the current user turn is processed — prior turns are untouched. The existing `hasImages` log line now also reports the extracted count for easier debugging.

## Test plan

- [ ] Paste an image (PNG/JPEG) into ChatView, send with a question like "what's in this image?", confirm the model describes it instead of saying it can't see it.
- [ ] Send a text-only message, confirm no behaviour change (no `images` key in the underlying request).
- [ ] Send a message with multiple pasted images, confirm all are forwarded.
- [ ] Confirm log line shows e.g. `User message contains images: 2 extracted`.