### PR TITLE
feat(skills): auto-discover ~/.claude/skills (Claude Code convention)

### DIFF
--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -515,6 +515,13 @@ ${hints.join('\n')}
     if (builtin && fs.existsSync(builtin)) paths.push(builtin);
     const global = this.getConfiguredGlobalSkillsDir();
     if (global && fs.existsSync(global)) paths.push(global);
+    // Claude Code convention: auto-discover user-level skills under ~/.claude/skills
+    // so skills installed via `claude plugin` / `~/.claude/plugins/*` are picked up
+    // without requiring the user to set globalSkillsDir explicitly.
+    const homeClaudeSkills = path.join(os.homedir(), '.claude', 'skills');
+    if (fs.existsSync(homeClaudeSkills) && !paths.includes(homeClaudeSkills)) {
+      paths.push(homeClaudeSkills);
+    }
     return paths;
   }
 


### PR DESCRIPTION
## Problem

Claude Code installs user-level skills under `~/.claude/skills` (and via `claude plugin` into `~/.claude/plugins/*/skills`). When users install skills the standard way, this fork's legacy skill-path fallback doesn't see them — it only scans the built-in directory plus an explicit `globalSkillsDir` setting. So users following Claude Code's convention have to manually point `globalSkillsDir` at `~/.claude/skills` to get their skills picked up.

## Fix

Add `~/.claude/skills` to the `legacySkillPaths()` list when it exists. Deduped against any existing entries (e.g. when the user has explicitly configured the same dir as their global skills dir).

`fs.existsSync` gate keeps fresh-install machines (no `~/.claude` dir yet) clean — no ENOENT, no log spam.

## Files

- `src/main/claude/agent-runner.ts` — `legacySkillPaths()` (+7 lines)

## Test plan

- [x] Skills under `~/.claude/skills/<name>/SKILL.md` get scanned without explicit `globalSkillsDir` config
- [x] Fresh machine without `~/.claude` doesn't error or log warnings
- [x] Already-configured `globalSkillsDir == ~/.claude/skills` not added twice