### PR TITLE
feat(skills): progressive disclosure (replace full-body load, ~9k tokens/turn savings)

### DIFF
--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -66,6 +66,11 @@ import {
   normalizeToolExecutionResultForUi,
 } from './tool-result-utils';
 import { fetchOllamaModelInfo } from '../config/ollama-api';
+import {
+  scanSkillFrontmatter,
+  buildSkillListing,
+  buildSkillTool,
+} from '../skills/skill-progressive-loader';
 
 // Virtual workspace path shown to the model (hides real sandbox path)
 const VIRTUAL_WORKSPACE_PATH = '/workspace';
@@ -409,6 +414,8 @@ interface CachedPiSession {
   thinkingLevel: string;
   runtimeSignature: string;
   ollamaNumCtx?: { value: number };
+  /** Names of skills whose SKILL.md body was loaded into chat history this session. */
+  loadedSkills?: Set<string>;
 }
 
 /**
@@ -1745,6 +1752,27 @@ This is an isolated sandbox environment. Use ${VIRTUAL_WORKSPACE_PATH} as the ro
             ? `<workspace_info>Your current workspace is: ${workingDir}</workspace_info>`
             : '';
 
+      // Skill loading — progressive disclosure (Claude Code-style):
+      //   - Scan SKILL.md frontmatter only (name + description, ≤250 chars each)
+      //   - Append a compact <available_skills> listing to the system prompt
+      //   - Expose a "Skill" function tool that loads SKILL.md body on demand
+      //   - Pass [] to DefaultResourceLoader's additionalSkillPaths so it does NOT
+      //     embed full SKILL.md bodies in the system prompt (≈9k input tokens/turn
+      //     for 5 bundled skills, repeated every turn).
+      const skillPaths = this._skillsAdapter
+        ? this._skillsAdapter.getSkillPaths()
+        : this.legacySkillPaths();
+      log('[ClaudeAgentRunner] Skill paths (scanning frontmatter only):', skillPaths);
+      // Tag bundled vs user — bundled skills get budget priority in buildSkillListing.
+      const builtinPath = this.getBuiltinSkillsPath();
+      const skillEntries = scanSkillFrontmatter(
+        skillPaths.map((p) => ({ rootDir: p, bundled: !builtinPath || p === builtinPath }))
+      );
+      const skillListing = buildSkillListing(skillEntries, piModel.contextWindow || 128_000);
+      log(
+        `[ClaudeAgentRunner] Discovered ${skillEntries.length} skills, listing ${skillListing.length} chars`
+      );
+
       const coworkAppendPrompt = [
         'You are an Open Cowork assistant. Be concise, accurate, and tool-capable.',
         `CRITICAL BEHAVIORAL RULES:
@@ -1752,7 +1780,11 @@ This is an isolated sandbox environment. Use ${VIRTUAL_WORKSPACE_PATH} as the ro
 2. When a request is actionable, proceed immediately with reasonable assumptions. If you need clarification, ask briefly in plain text.
 3. For relative time windows like "within two days" in browsing or research tasks, assume the most recent two relevant publication days unless the user explicitly defines another date range.
 4. For bracketed placeholders like [Agent], [Topic], etc., treat the word inside brackets as the literal search keyword unless the user says otherwise.
-5. When given a task, START DOING IT. Do not restate the task, do not list what you will do, do not ask for confirmation. Just execute.`,
+5. When given a task, START DOING IT. Do not restate the task, do not list what you will do, do not ask for confirmation. Just execute.
+6. SKILLS — eager load policy:
+   a. When the user asks "do you have skill X / can you use X / is X available", consult the <available_skills> block below and answer based on its contents. Never list a hardcoded subset or hallucinate skills.
+   b. If skill X is in the listing AND the user has shown ANY intent (asked about it, mentioned its name, or implied a task in its domain), IMMEDIATELY call the Skill tool to load X's full instructions in the same turn — do NOT say "I can load it if you want" and stop. Loading is cheap and the user shouldn't have to confirm twice.
+   c. After loading, give a brief confirmation in the SAME reply (e.g. "Loaded the xlsx skill — what would you like to do?") then act on the user's request.`,
         workspaceInfoPrompt,
         `<citation_requirements>
 If your answer uses linkable content from MCP tools, include a "Sources:" section and otherwise use standard Markdown links: [Title](https://claude.ai/chat/URL).
@@ -1763,6 +1795,7 @@ Tool routing:
 - Use WebSearch/WebFetch only when Chrome MCP is unavailable or the user explicitly asks for generic web search.
 </tool_behavior>`,
         this.getBundledPathHints(),
+        skillListing,
       ]
         .filter((section): section is string => Boolean(section && section.trim()))
         .join('\n\n');
@@ -1771,14 +1804,6 @@ Tool routing:
 
       // Create or reuse pi-coding-agent session
 
-      // Collect skill directories for pi's native skill discovery.
-      // SkillsAdapter handles path resolution, disabled skill filtering,
-      // and compatibility with Claude Code / OpenClaw ecosystems.
-      const skillPaths = this._skillsAdapter
-        ? this._skillsAdapter.getSkillPaths()
-        : this.legacySkillPaths();
-      log('[ClaudeAgentRunner] Skill paths for pi ResourceLoader:', skillPaths);
-
       // Bridge MCP tools as customTools for pi-coding-agent.
       // Re-read every query so newly added/removed MCP servers take effect immediately.
       const mcpCustomTools = this.mcpManager ? buildMcpCustomTools(this.mcpManager) : [];
@@ -1786,6 +1811,20 @@ Tool routing:
         log(
           `[ClaudeAgentRunner] Registered ${mcpCustomTools.length} MCP tools as customTools:`,
           mcpCustomTools.map((t) => t.name).join(', ')
+        );
+      }
+
+      // Skill tool — progressive disclosure (load SKILL.md body on demand).
+      // Re-use the loadedSkills Set across cached session reuse so we keep track of
+      // what was already loaded into chat history (the SDK retains the messages,
+      // we just remember which names we've returned bodies for).
+      const cachedForSkills = this.piSessions.get(session.id);
+      const sessionLoadedSkills =
+        cachedForSkills?.loadedSkills ?? new Set<string>();
+      if (skillEntries.length > 0) {
+        mcpCustomTools.push(buildSkillTool(skillEntries, sessionLoadedSkills));
+        log(
+          `[ClaudeAgentRunner] Skill tool injected (progressive disclosure, ${skillEntries.length} skills available)`
         );
       }
 
@@ -1857,9 +1896,13 @@ Tool routing:
         // First query in this session — create new pi-coding-agent session
         // ResourceLoader + ModelRegistry only needed for session creation — skip on reuse
         const { DefaultResourceLoader } = await import('@mariozechner/pi-coding-agent');
+        // additionalSkillPaths: [] — we handle skills via progressive disclosure
+        // (frontmatter listing + on-demand Skill tool). Passing skillPaths here would
+        // make DefaultResourceLoader inject every SKILL.md body into the system
+        // prompt every turn, which is the cost-bug we are fixing.
         const resourceLoader = new DefaultResourceLoader({
           cwd: effectiveCwd,
-          additionalSkillPaths: skillPaths,
+          additionalSkillPaths: [],
           appendSystemPrompt: coworkAppendPrompt,
         });
         await resourceLoader.reload();
@@ -1934,6 +1977,7 @@ Tool routing:
           modelId: piModel.id,
           thinkingLevel,
           runtimeSignature: sessionRuntimeSignature,
+          loadedSkills: sessionLoadedSkills,
         });
 
         // Ollama: wrap _onPayload to inject num_ctx into every request

--- a/src/main/skills/skill-progressive-loader.ts
+++ b/src/main/skills/skill-progressive-loader.ts
@@ -1,0 +1,252 @@
+/**
+ * @module main/skills/skill-progressive-loader
+ *
+ * Progressive disclosure for SKILL.md (mirrors Claude Code's pattern):
+ *   - Startup: scan only frontmatter (name + description), NOT full content
+ *   - Build a "Skill" function tool listing skills (≤250 chars per entry)
+ *   - SKILL.md body only loaded when model invokes the tool
+ *
+ * vs. pi-coding-agent's DefaultResourceLoader which embeds full SKILL.md text in
+ * the system prompt every turn (cost ≈ 9k input tokens for 5 bundled skills).
+ *
+ * Budget: cap total listing at min(20k chars, 1% × contextWindow); bundled skills
+ * have priority; custom skills truncated first if over budget.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { Type, type TSchema } from '@sinclair/typebox';
+import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import { log, logWarn } from '../utils/logger';
+
+const MAX_LISTING_DESC_CHARS = 250;
+const MIN_BUDGET_CHARS = 2000;
+// 1M-context models can spare 20k chars (~5k tokens) for skill listings without
+// hurting cost. Smaller models still get capped at 1% × ctx_window.
+const MAX_BUDGET_CHARS = 20000;
+
+export interface SkillEntry {
+  name: string;
+  description: string;
+  filePath: string;
+  bundled: boolean;
+  rootDir: string;
+}
+
+interface FrontmatterFields {
+  name?: string;
+  description?: string;
+}
+
+/**
+ * Parse YAML frontmatter (lightweight — only extracts top-level scalar `name` and
+ * `description`). Returns null if no `---` block at file start.
+ */
+function parseFrontmatter(text: string): FrontmatterFields | null {
+  if (!text.startsWith('---')) return null;
+  const end = text.indexOf('\n---', 3);
+  if (end === -1) return null;
+  const body = text.slice(3, end);
+  const fields: FrontmatterFields = {};
+  // very small YAML subset — handle quoted/unquoted scalars on single lines
+  const lines = body.split('\n');
+  let inMultiline: 'name' | 'description' | null = null;
+  let multilineBuf = '';
+  for (const raw of lines) {
+    const line = raw.replace(/\r$/, '');
+    if (inMultiline) {
+      if (/^\S/.test(line)) {
+        // dedent end
+        fields[inMultiline] = multilineBuf.trim();
+        inMultiline = null;
+        multilineBuf = '';
+      } else {
+        multilineBuf += line.trim() + ' ';
+        continue;
+      }
+    }
+    const m = /^(name|description)\s*:\s*(.*)$/.exec(line);
+    if (!m) continue;
+    const key = m[1] as 'name' | 'description';
+    let val = m[2].trim();
+    if (val === '|' || val === '>') {
+      inMultiline = key;
+      multilineBuf = '';
+      continue;
+    }
+    // strip optional matching quotes
+    if (
+      (val.startsWith('"') && val.endsWith('"')) ||
+      (val.startsWith("'") && val.endsWith("'"))
+    ) {
+      val = val.slice(1, -1);
+    }
+    fields[key] = val;
+  }
+  if (inMultiline && multilineBuf) {
+    fields[inMultiline] = multilineBuf.trim();
+  }
+  return fields;
+}
+
+function truncateToChars(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + '…';
+}
+
+/**
+ * Scan a list of skill root directories. Each root is expected to contain
+ * <root>/<skill-name>/SKILL.md. Returns one entry per skill, with truncated
+ * description.
+ */
+export function scanSkillFrontmatter(
+  paths: Array<{ rootDir: string; bundled: boolean }>
+): SkillEntry[] {
+  const seen = new Map<string, SkillEntry>();
+  for (const { rootDir, bundled } of paths) {
+    if (!rootDir || !fs.existsSync(rootDir)) continue;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(rootDir, { withFileTypes: true });
+    } catch (err) {
+      logWarn('[SkillLoader] readdir failed:', rootDir, err);
+      continue;
+    }
+    for (const ent of entries) {
+      if (!ent.isDirectory()) continue;
+      const skillName = ent.name;
+      if (skillName.startsWith('.')) continue;
+      const filePath = path.join(rootDir, skillName, 'SKILL.md');
+      if (!fs.existsSync(filePath)) continue;
+      // bundled wins over user when same name appears
+      if (seen.has(skillName) && !bundled) continue;
+      try {
+        const text = fs.readFileSync(filePath, 'utf-8');
+        const fm = parseFrontmatter(text);
+        const description = fm?.description?.trim() || '';
+        const name = (fm?.name?.trim() || skillName).trim();
+        seen.set(name, {
+          name,
+          description: truncateToChars(description, MAX_LISTING_DESC_CHARS),
+          filePath,
+          bundled,
+          rootDir,
+        });
+      } catch (err) {
+        logWarn('[SkillLoader] read failed:', filePath, err);
+      }
+    }
+  }
+  return Array.from(seen.values());
+}
+
+/**
+ * Build the system-prompt listing string for skills. Returns empty string when no
+ * skills available. Total length capped at min(MAX_BUDGET_CHARS, contextWindow * 1%);
+ * bundled skills protected, custom skills truncated first.
+ */
+export function buildSkillListing(
+  entries: SkillEntry[],
+  contextWindow: number = 128_000
+): string {
+  if (entries.length === 0) return '';
+  const totalBudget = Math.min(
+    Math.max(MIN_BUDGET_CHARS, Math.floor(contextWindow / 100)),
+    MAX_BUDGET_CHARS
+  );
+
+  // Bundled first, custom last
+  const sorted = [...entries].sort((a, b) => {
+    if (a.bundled !== b.bundled) return a.bundled ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  const lines: string[] = [];
+  let usedChars = 0;
+  for (const entry of sorted) {
+    const lineFull = `- ${entry.name}: ${entry.description}`;
+    const overhead = lineFull.length + 1; // +1 newline
+    if (usedChars + overhead <= totalBudget) {
+      lines.push(lineFull);
+      usedChars += overhead;
+      continue;
+    }
+    // Over budget — bundled stays even if it busts, custom gets truncated to name only
+    if (entry.bundled) {
+      lines.push(lineFull);
+      usedChars += overhead;
+    } else {
+      const lineMin = `- ${entry.name}`;
+      if (usedChars + lineMin.length + 1 <= totalBudget) {
+        lines.push(lineMin);
+        usedChars += lineMin.length + 1;
+      }
+    }
+  }
+
+  return [
+    '<available_skills>',
+    `Below is the COMPLETE list of skills installed locally (${lines.length} total). When the user asks "do you have skill X" or "can you use X", you MUST scan this list and answer based on it — do not hallucinate or list a hardcoded subset. To load a skill's full instructions, call the Skill tool with the skill_name argument. Loaded content stays in history; no need to reload.`,
+    ...lines,
+    '</available_skills>',
+  ].join('\n');
+}
+
+/**
+ * Build the "Skill" function tool. The model calls Skill(skill_name=...) and the
+ * SKILL.md body is read once and returned as text. The agent caches loaded skills
+ * per-session via the provided `loadedSkills` Set so we can warn (not block) on
+ * re-loads.
+ */
+export function buildSkillTool(
+  entries: SkillEntry[],
+  loadedSkills: Set<string>
+): ToolDefinition<TSchema, unknown> {
+  const byName = new Map(entries.map((e) => [e.name, e]));
+  return {
+    name: 'Skill',
+    label: 'Skill',
+    description:
+      'Load a skill from the available_skills listing. Provides detailed instructions for tasks like spreadsheet/PDF/Word/PowerPoint manipulation. Call this once per skill per conversation; loaded content stays in chat history.',
+    parameters: Type.Object({
+      skill_name: Type.String({
+        description: 'Exact skill name from the available_skills listing (e.g. "xlsx", "pdf").',
+      }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+      const skillName = (params as { skill_name?: string })?.skill_name?.trim() || '';
+      if (!skillName) {
+        return {
+          content: [{ type: 'text' as const, text: 'Skill error: missing skill_name' }],
+          details: undefined,
+        };
+      }
+      const entry = byName.get(skillName);
+      if (!entry) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Skill "${skillName}" not found. Available: ${Array.from(byName.keys()).join(', ')}`,
+            },
+          ],
+          details: undefined,
+        };
+      }
+      try {
+        const text = fs.readFileSync(entry.filePath, 'utf-8');
+        loadedSkills.add(entry.name);
+        log(`[SkillLoader] Loaded skill "${entry.name}" (${text.length} chars)`);
+        return {
+          content: [{ type: 'text' as const, text }],
+          details: undefined,
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: 'text' as const, text: `Skill load failed: ${msg}` }],
+          details: undefined,
+        };
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Problem

`DefaultResourceLoader` embeds every `SKILL.md` body into the system prompt on every turn via `additionalSkillPaths`. With the 5 bundled skills (xlsx/pdf/docx/pptx/skill-creator), each turn carries an extra ~9k input tokens — even when the user is just asking a plain text question. The cost compounds for long sessions, and the user pays for content the model rarely needs.

## Fix — Claude Code-style progressive disclosure

1. **New module** `src/main/skills/skill-progressive-loader.ts`:
   - `scanSkillFrontmatter` — reads only the YAML frontmatter at the top of each `SKILL.md` (~250 chars/skill instead of full body).
   - `buildSkillListing` — emits a compact `<available_skills>` block (bundled first, custom truncated first when over budget). Total budget capped at `min(20k chars, 1% × contextWindow)`.
   - `buildSkillTool` — exposes a `Skill` function tool. Model calls `Skill(skill_name='xlsx')` and the `SKILL.md` body is read on demand and returned as the tool result. Loaded names tracked in a per-session `Set` so the cost is paid once per skill per session.

2. **`agent-runner.ts` integration**:
   - Scan `skillPaths` frontmatter once, append `<available_skills>` to the `appendSystemPrompt` block.
   - Pass `additionalSkillPaths: []` to `DefaultResourceLoader` so it no longer embeds bodies.
   - Push `buildSkillTool` into `mcpCustomTools` when at least one skill is discovered.
   - Persist `sessionLoadedSkills` in `CachedPiSession` so reused sessions keep tracking what's already been loaded into history.

3. **System prompt rule 6 — eager-load policy**: when the user mentions a skill name or implies its domain, the model loads it in the same turn instead of asking 'should I load it?'. Loading is cheap; the user shouldn't have to confirm twice.

## Cost impact

`gpt-5.5` / `claude-sonnet-4` typical pricing (~$3/Mtok input):
- 9k tokens × $3/Mtok × 20-turn session ≈ **$0.54 saved per session** when no skill is needed.
- ~**$0.40 saved per session** when one skill is loaded (amortized over remaining turns).

## Files

- `src/main/skills/skill-progressive-loader.ts` (new, 250 lines)
- `src/main/claude/agent-runner.ts` (+54/-10)

## Test plan

- [x] `tsc --noEmit` passes
- [x] First turn: `<available_skills>` block visible in system prompt, full SKILL.md bodies are NOT
- [x] User asks 'do you have the xlsx skill?' → model loads it in same turn (rule 6.b)
- [x] Same skill loaded twice in one session → second call still returns content (no false-block)
- [x] No skills installed → no `<available_skills>` block emitted, no `Skill` tool registered
- [x] Custom skills work the same as bundled (just no priority in budget gate)