### PR TITLE
feat(ui): show last-turn input + cache hit % in context panel (instead of cumulative)

### DIFF
--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -381,6 +381,15 @@ function normalizeTokenUsage(usage: unknown): Message['tokenUsage'] | undefined 
     output_tokens?: unknown;
     inputTokens?: unknown;
     outputTokens?: unknown;
+    // Cache fields — provider-dependent names:
+    //   Anthropic: cache_read_input_tokens / cache_creation_input_tokens
+    //   OpenAI Responses: prompt_tokens_details.cached_tokens
+    //   pi-ai-core normalized: cacheRead / cacheWrite
+    cacheRead?: unknown;
+    cacheWrite?: unknown;
+    cache_read_input_tokens?: unknown;
+    cache_creation_input_tokens?: unknown;
+    prompt_tokens_details?: { cached_tokens?: unknown };
   };
 
   const input = raw.input ?? raw.input_tokens ?? raw.inputTokens;
@@ -390,7 +399,23 @@ function normalizeTokenUsage(usage: unknown): Message['tokenUsage'] | undefined 
     return undefined;
   }
 
-  return { input, output };
+  const cacheReadCandidate =
+    raw.cacheRead ??
+    raw.cache_read_input_tokens ??
+    (typeof raw.prompt_tokens_details === 'object' && raw.prompt_tokens_details
+      ? raw.prompt_tokens_details.cached_tokens
+      : undefined);
+  const cacheWriteCandidate = raw.cacheWrite ?? raw.cache_creation_input_tokens;
+
+  const cacheRead = typeof cacheReadCandidate === 'number' ? cacheReadCandidate : undefined;
+  const cacheWrite = typeof cacheWriteCandidate === 'number' ? cacheWriteCandidate : undefined;
+
+  return {
+    input,
+    output,
+    ...(cacheRead !== undefined ? { cacheRead } : {}),
+    ...(cacheWrite !== undefined ? { cacheWrite } : {}),
+  };
 }
 
 interface AgentRunnerOptions {

--- a/src/renderer/components/ContextPanel.tsx
+++ b/src/renderer/components/ContextPanel.tsx
@@ -88,35 +88,66 @@ export function ContextPanel() {
   const toolCallCount = steps.filter((s) => s.type === 'tool_call').length;
   const modelName = activeSession?.model || appConfig?.model || '—';
 
-  // Token usage aggregation
+  // Token usage: show LAST turn (current prompt size + last response) — not cumulative.
+  // Cumulative numbers across many turns scare users into thinking each turn is full-billed,
+  // when in reality the cached prefix is reused at deep discount. Also surface total output
+  // sum and overall cache hit % so the cost picture stays honest.
   const tokenUsage = useMemo(() => {
-    let input = 0;
-    let output = 0;
+    let totalOutput = 0;
+    let totalInputUncached = 0;
+    let totalCacheRead = 0;
+    let lastInput = 0;
+    let lastCacheRead = 0;
+    let lastOutput = 0;
     for (const msg of messages) {
-      if (msg.tokenUsage) {
-        input += msg.tokenUsage.input || 0;
-        output += msg.tokenUsage.output || 0;
+      const u = msg.tokenUsage;
+      if (!u) continue;
+      const inp = u.input || 0;
+      const out = u.output || 0;
+      const cr = u.cacheRead || 0;
+      totalOutput += out;
+      totalInputUncached += inp;
+      totalCacheRead += cr;
+      if (inp || cr || out) {
+        lastInput = inp;
+        lastCacheRead = cr;
+        lastOutput = out;
       }
     }
-    return { input, output, total: input + output };
+    const lastPrompt = lastInput + lastCacheRead;
+    const totalPromptCum = totalInputUncached + totalCacheRead;
+    const cacheHitRate = totalPromptCum > 0 ? totalCacheRead / totalPromptCum : 0;
+    return {
+      // Current-turn (what header reads as input/output)
+      input: lastPrompt,
+      output: lastOutput,
+      // Aggregates kept for tooltip/debug if needed
+      totalOutput,
+      totalInputUncached,
+      totalCacheRead,
+      cacheHitRate,
+      total: lastPrompt + lastOutput,
+    };
   }, [messages]);
 
-  // Context usage: last message's input tokens ≈ current context occupation
+  // Context usage: last message's TRUE prompt size (input + cacheRead) = current context.
+  // Without cacheRead the bar shrinks when cache hits — counterintuitive.
   const contextUsage = useMemo(() => {
     const contextWindow = activeSessionId ? sessionStates[activeSessionId]?.contextWindow : undefined;
     if (!contextWindow) return null;
 
-    let lastInput = 0;
+    let lastTotalPrompt = 0;
     for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].tokenUsage?.input) {
-        lastInput = messages[i].tokenUsage!.input;
+      const u = messages[i].tokenUsage;
+      if (u && (u.input || u.cacheRead)) {
+        lastTotalPrompt = (u.input || 0) + (u.cacheRead || 0);
         break;
       }
     }
-    if (lastInput === 0) return null;
+    if (lastTotalPrompt === 0) return null;
 
-    const percentage = Math.min((lastInput / contextWindow) * 100, 100);
-    return { used: lastInput, total: contextWindow, percentage };
+    const percentage = Math.min((lastTotalPrompt / contextWindow) * 100, 100);
+    return { used: lastTotalPrompt, total: contextWindow, percentage };
   }, [activeSessionId, sessionStates, messages]);
 
   const completedStepCount = useMemo(
@@ -276,7 +307,11 @@ export function ContextPanel() {
             </span>
             {tokenUsage.total > 0 && (
               <span className="ml-auto text-text-muted/70">
-                {t('context.inputTokens')} {formatTokenCount(tokenUsage.input)} · {t('context.outputTokens')} {formatTokenCount(tokenUsage.output)}
+                {t('context.inputTokens')} {formatTokenCount(tokenUsage.input)}
+                {tokenUsage.totalCacheRead > 0 && (
+                  <> (cache {Math.round(tokenUsage.cacheHitRate * 100)}%)</>
+                )}
+                {' '}· {t('context.outputTokens')} {formatTokenCount(tokenUsage.output)}
               </span>
             )}
           </div>

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -92,6 +92,10 @@ export interface ThinkingContent {
 export interface TokenUsage {
   input: number;
   output: number;
+  /** Tokens served from prompt cache on this turn (subset of effective input). */
+  cacheRead?: number;
+  /** Tokens written to prompt cache on this turn (charged at cache-write rate). */
+  cacheWrite?: number;
 }
 
 // Trace types for visualization


### PR DESCRIPTION
## Problem

The context panel currently displays input/output token counts as cumulative sums across the entire session. After ~10 turns of normal usage, the input number reads "hundreds of thousands of tokens" — even though the cached prefix is being reused at deep discount on each turn. Users panic and assume they're being billed full rate every turn.

The context-usage bar has the inverse problem: it uses only `tokenUsage.input` (uncached portion), so the bar visually *shrinks* when a cache hit lands. But the prompt is still that big — the model still has to attend to all of it. Users see a session that feels "lighter" right when it gets fuller.

## Fix

Switch the display to last-turn input + last-turn output + overall cache-hit percentage. That honestly reflects what the user is paying for.

Three changes:

1. **`types/index.ts`** — `TokenUsage` gains optional `cacheRead` / `cacheWrite` fields. The provider/SDK already produces these; the UI was discarding them.

2. **`agent-runner.ts` `normalizeTokenUsage`** — extract `cacheRead` / `cacheWrite` from common provider field-name variants:
   - Anthropic: `cache_read_input_tokens` / `cache_creation_input_tokens`
   - OpenAI Responses: `prompt_tokens_details.cached_tokens`
   - pi-ai-core normalized: `cacheRead` / `cacheWrite`

3. **`ContextPanel.tsx`** —
   - `tokenUsage` now exposes `lastInput + lastOutput` as `input`/`output`, plus aggregates (`totalCacheRead`, `cacheHitRate`) for the header.
   - `contextUsage` bar uses `lastInput + lastCacheRead` (true prompt size), so the bar doesn't shrink when a cache hit lands.
   - Header shows `cache N%` inline next to input when `totalCacheRead > 0`; absent for non-cache providers (existing behavior preserved).

## Files

- `src/renderer/types/index.ts` (+4)
- `src/renderer/components/ContextPanel.tsx` (+47/-18)
- `src/main/claude/agent-runner.ts` (`normalizeTokenUsage` only, +24/-3)

## Test plan

- [x] `tsc --noEmit` passes
- [x] First message: input/output reflect that single turn (no aggregation)
- [x] After 10 turns with high cache hit rate: input shows current-turn prompt + 'cache 90%' style label, NOT 1.5M
- [x] Context bar % grows with chat length (no shrink on cache hit)
- [x] Provider with no cache info (e.g. Ollama, OpenAI Chat-Completions w/o caching): no 'cache N%' label, behavior identical to before