### PR TITLE
fix: sanitize MCP tool names for OpenAI-compatible providers

### DIFF
--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -282,7 +282,7 @@ function buildMcpCustomTools(mcpManager: MCPManager): ToolDefinition[] {
 
     const toolDef: ToolDefinition<TSchema, unknown> = {
       name: mcpTool.name,
-      label: mcpTool.name.replace(/^mcp__/, '').replace(/__/g, ' → '),
+      label: `${mcpTool.serverName} → ${mcpTool.originalName || mcpTool.name}`,
       description: mcpTool.description || `MCP tool from ${mcpTool.serverName}`,
       parameters,
       async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {

--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -776,6 +776,20 @@ ${hints.join('\n')}
     return /\bsudo\b/.test(command);
   }
 
+  private getToolDisplayName(toolName: string): string {
+    if (!toolName.startsWith('mcp__')) {
+      return toolName;
+    }
+
+    const mcpTool = this.mcpManager?.getTool(toolName);
+    if (mcpTool?.originalName) {
+      return mcpTool.originalName;
+    }
+
+    const match = toolName.match(/^mcp__(.+?)__(.+)$/);
+    return match?.[2] || toolName;
+  }
+
   /**
    * Wrap the bash tool in the coding tools array to intercept sudo commands.
    * When a sudo command is detected, prompts the user for a password,
@@ -2197,11 +2211,12 @@ Tool routing:
                 const toolContent = partial?.content?.[ame.contentIndex];
                 const toolName = toolContent?.type === 'toolCall' ? toolContent.name : 'unknown';
                 const toolCallId = toolContent?.type === 'toolCall' ? toolContent.id : uuidv4();
+                const toolDisplayName = this.getToolDisplayName(toolName);
                 this.sendTraceStep(session.id, {
                   id: toolCallId,
                   type: 'tool_call',
                   status: 'running',
-                  title: toolName,
+                  title: toolDisplayName,
                   toolName,
                   toolInput:
                     toolContent?.type === 'toolCall'
@@ -2304,10 +2319,12 @@ Tool routing:
                       }
                     }
                   } else if (block.type === 'toolCall') {
+                    const displayName = this.getToolDisplayName(block.name);
                     contentBlocks.push({
                       type: 'tool_use',
                       id: block.id,
                       name: block.name,
+                      displayName,
                       input: block.arguments,
                     });
                   } else if (block.type === 'thinking') {
@@ -2372,8 +2389,10 @@ Tool routing:
               const isError = event.isError;
               const normalizedToolResult = normalizeToolExecutionResultForUi(event.result);
               const outputText = normalizedToolResult.content;
+              const toolDisplayName = this.getToolDisplayName(event.toolName);
               this.sendTraceUpdate(session.id, toolCallId, {
                 status: isError ? 'error' : 'completed',
+                title: toolDisplayName,
                 toolName: event.toolName,
                 toolOutput: sanitizeOutputPaths(outputText).slice(0, 800),
               });

--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -285,7 +285,7 @@ function buildMcpCustomTools(mcpManager: MCPManager): ToolDefinition[] {
 
     const toolDef: ToolDefinition<TSchema, unknown> = {
       name: mcpTool.name,
-      label: mcpTool.name.replace(/^mcp__/, '').replace(/__/g, ' → '),
+      label: `${mcpTool.serverName} → ${mcpTool.originalName || mcpTool.name}`,
       description: mcpTool.description || `MCP tool from ${mcpTool.serverName}`,
       parameters,
       async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {

--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -438,6 +438,7 @@ export class ClaudeAgentRunner {
   private extensionManager?: AgentRuntimeExtensionManager;
   private activeControllers: Map<string, AbortController> = new Map();
   private piSessions: Map<string, CachedPiSession> = new Map();
+  private toolDisplayNameCache: Map<string, string> = new Map();
   private static readonly MAX_CACHED_SESSIONS = 50;
 
   // Per-instance caches — invalidated when the underlying config changes.
@@ -777,17 +778,27 @@ ${hints.join('\n')}
   }
 
   private getToolDisplayName(toolName: string): string {
+    const cached = this.toolDisplayNameCache.get(toolName);
+    if (cached) {
+      return cached;
+    }
+
+    let displayName = toolName;
     if (!toolName.startsWith('mcp__')) {
-      return toolName;
+      this.toolDisplayNameCache.set(toolName, displayName);
+      return displayName;
     }
 
     const mcpTool = this.mcpManager?.getTool(toolName);
     if (mcpTool?.originalName) {
-      return mcpTool.originalName;
+      displayName = mcpTool.originalName;
+    } else {
+      const match = toolName.match(/^mcp__(.+?)__(.+)$/);
+      displayName = match?.[2] || toolName;
     }
 
-    const match = toolName.match(/^mcp__(.+?)__(.+)$/);
-    return match?.[2] || toolName;
+    this.toolDisplayNameCache.set(toolName, displayName);
+    return displayName;
   }
 
   /**

--- a/src/main/mcp/mcp-manager.ts
+++ b/src/main/mcp/mcp-manager.ts
@@ -42,6 +42,7 @@ export interface MCPServerConfig {
  */
 export interface MCPTool {
   name: string;
+  originalName?: string;
   description: string;
   inputSchema: {
     type: string;
@@ -58,6 +59,33 @@ function normalizeWindowsPathForComparison(candidate: string): string {
 
 function normalizeWindowsDirectoryForComparison(candidate: string): string {
   return normalizeWindowsPathForComparison(candidate).replace(/[\\/]+$/, '');
+}
+
+function sanitizeMcpToolSegment(segment: string, fallback: string): string {
+  const sanitized = segment
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/[^a-zA-Z0-9_-]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return sanitized || fallback;
+}
+
+function createUniqueMcpToolName(baseName: string, usedNames: Set<string>): string {
+  if (!usedNames.has(baseName)) {
+    usedNames.add(baseName);
+    return baseName;
+  }
+
+  let suffix = 2;
+  let candidate = `${baseName}_${suffix}`;
+  while (usedNames.has(candidate)) {
+    suffix += 1;
+    candidate = `${baseName}_${suffix}`;
+  }
+
+  usedNames.add(candidate);
+  return candidate;
 }
 
 function getTrustedWindowsNpxDirectories(
@@ -1323,6 +1351,7 @@ export class MCPManager {
   async refreshTools(): Promise<void> {
     log('[MCPManager] Refreshing tools from all servers');
     const newTools = new Map<string, MCPTool>();
+    const usedToolNames = new Set<string>();
 
     for (const [serverId, client] of this.clients.entries()) {
       try {
@@ -1351,14 +1380,21 @@ export class MCPManager {
         log(`[MCPManager] Raw tools from ${config.name}:`, listToolsResult);
 
         for (const tool of listToolsResult.tools) {
-          // Prefix tool name with server name to avoid conflicts
-          // Format: mcp__<ServerName>__<toolName> (double underscores, preserve case)
-          // Sanitize: collapse whitespace and collapse any accidental __ sequences
-          const serverKey = config.name.replace(/\s+/g, '_').replace(/__/g, '_');
-          const prefixedName = `mcp__${serverKey}__${tool.name}`;
+          // OpenAI-compatible providers reject tool names that contain punctuation
+          // like dots or colons, so we expose a sanitized model-facing name while
+          // preserving the original MCP tool name for the actual call.
+          const serverKey = sanitizeMcpToolSegment(config.name, 'server');
+          const originalToolName =
+            typeof tool.name === 'string' && tool.name.trim().length > 0 ? tool.name : 'tool';
+          const sanitizedToolName = sanitizeMcpToolSegment(originalToolName, 'tool');
+          const prefixedName = createUniqueMcpToolName(
+            `mcp__${serverKey}__${sanitizedToolName}`,
+            usedToolNames
+          );
 
           newTools.set(prefixedName, {
             name: prefixedName,
+            originalName: originalToolName,
             description: tool.description || '',
             inputSchema: {
               type: 'object',
@@ -1426,9 +1462,10 @@ export class MCPManager {
       throw new Error(`MCP tool not found: ${toolName}`);
     }
 
-    // 提取实际工具名（格式：mcp__<ServerName>__<toolName>）
-    let actualToolName = toolName;
-    if (toolName.startsWith('mcp__')) {
+    // Prefer the original MCP tool name when present so sanitized model-facing
+    // names can still map back to the true server tool.
+    let actualToolName = tool.originalName || toolName;
+    if (!tool.originalName && toolName.startsWith('mcp__')) {
       const remainder = toolName.slice('mcp__'.length);
       const separatorIndex = remainder.indexOf('__');
       if (separatorIndex !== -1) {

--- a/src/main/mcp/mcp-manager.ts
+++ b/src/main/mcp/mcp-manager.ts
@@ -15,6 +15,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { createHash } from 'crypto';
 import { app, BrowserWindow } from 'electron';
 
 import path from 'path';
@@ -53,6 +54,9 @@ export interface MCPTool {
   serverName: string;
 }
 
+const MAX_MODEL_TOOL_NAME_LENGTH = 64;
+const MCP_TOOL_NAME_HASH_LENGTH = 8;
+
 function normalizeWindowsPathForComparison(candidate: string): string {
   return path.win32.normalize(candidate).replace(/\//g, '\\').toLowerCase();
 }
@@ -71,17 +75,48 @@ function sanitizeMcpToolSegment(segment: string, fallback: string): string {
   return sanitized || fallback;
 }
 
-function createUniqueMcpToolName(baseName: string, usedNames: Set<string>): string {
-  if (!usedNames.has(baseName)) {
-    usedNames.add(baseName);
+function truncateMcpToolName(baseName: string, maxLength: number): string {
+  if (baseName.length <= maxLength) {
     return baseName;
   }
 
+  if (maxLength <= 0) {
+    return '';
+  }
+
+  if (maxLength <= MCP_TOOL_NAME_HASH_LENGTH) {
+    return createHash('sha256').update(baseName).digest('hex').slice(0, maxLength);
+  }
+
+  const hashLength = Math.min(MCP_TOOL_NAME_HASH_LENGTH, maxLength - 2);
+  const hash = createHash('sha256').update(baseName).digest('hex').slice(0, hashLength);
+  const prefixLength = Math.max(1, maxLength - hash.length - 1);
+
+  return `${baseName.slice(0, prefixLength)}_${hash}`;
+}
+
+function formatMcpToolName(baseName: string, suffix: number | null): string {
+  const suffixPart = suffix === null ? '' : `_${suffix}`;
+  const truncatedBase = truncateMcpToolName(
+    baseName,
+    MAX_MODEL_TOOL_NAME_LENGTH - suffixPart.length
+  );
+
+  return `${truncatedBase}${suffixPart}`;
+}
+
+function createUniqueMcpToolName(baseName: string, usedNames: Set<string>): string {
+  const firstCandidate = formatMcpToolName(baseName, null);
+  if (!usedNames.has(firstCandidate)) {
+    usedNames.add(firstCandidate);
+    return firstCandidate;
+  }
+
   let suffix = 2;
-  let candidate = `${baseName}_${suffix}`;
+  let candidate = formatMcpToolName(baseName, suffix);
   while (usedNames.has(candidate)) {
     suffix += 1;
-    candidate = `${baseName}_${suffix}`;
+    candidate = formatMcpToolName(baseName, suffix);
   }
 
   usedNames.add(candidate);
@@ -1379,7 +1414,19 @@ export class MCPManager {
 
         log(`[MCPManager] Raw tools from ${config.name}:`, listToolsResult);
 
-        for (const tool of listToolsResult.tools) {
+        const sortedTools = [...listToolsResult.tools].sort((left, right) => {
+          const leftName = left.name || '';
+          const rightName = right.name || '';
+          if (leftName < rightName) {
+            return -1;
+          }
+          if (leftName > rightName) {
+            return 1;
+          }
+          return 0;
+        });
+
+        for (const tool of sortedTools) {
           // OpenAI-compatible providers reject tool names that contain punctuation
           // like dots or colons, so we expose a sanitized model-facing name while
           // preserving the original MCP tool name for the actual call.

--- a/src/main/mcp/mcp-manager.ts
+++ b/src/main/mcp/mcp-manager.ts
@@ -95,12 +95,18 @@ function truncateMcpToolName(baseName: string, maxLength: number): string {
   return `${baseName.slice(0, prefixLength)}_${hash}`;
 }
 
-function formatMcpToolName(baseName: string, suffix: number | null): string {
+export function formatMcpToolName(baseName: string, suffix: string | null): string {
   const suffixPart = suffix === null ? '' : `_${suffix}`;
-  const truncatedBase = truncateMcpToolName(
-    baseName,
-    MAX_MODEL_TOOL_NAME_LENGTH - suffixPart.length
-  );
+  const availableBaseLength = MAX_MODEL_TOOL_NAME_LENGTH - suffixPart.length;
+
+  if (availableBaseLength <= 0) {
+    return truncateMcpToolName(
+      `tool_${createHash('sha256').update(`${baseName}${suffixPart}`).digest('hex')}`,
+      MAX_MODEL_TOOL_NAME_LENGTH
+    );
+  }
+
+  const truncatedBase = truncateMcpToolName(baseName, availableBaseLength);
 
   return `${truncatedBase}${suffixPart}`;
 }
@@ -113,10 +119,10 @@ function createUniqueMcpToolName(baseName: string, usedNames: Set<string>): stri
   }
 
   let suffix = 2;
-  let candidate = formatMcpToolName(baseName, suffix);
+  let candidate = formatMcpToolName(baseName, String(suffix));
   while (usedNames.has(candidate)) {
     suffix += 1;
-    candidate = formatMcpToolName(baseName, suffix);
+    candidate = formatMcpToolName(baseName, String(suffix));
   }
 
   usedNames.add(candidate);

--- a/src/renderer/components/ContextPanel.tsx
+++ b/src/renderer/components/ContextPanel.tsx
@@ -2,15 +2,8 @@ import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../store';
 import { resolveArtifactPath } from '../utils/artifact-path';
-import {
-  extractFilePathFromToolInput,
-  extractFilePathFromToolOutput,
-} from '../utils/tool-output-path';
-import {
-  getArtifactLabel,
-  getArtifactIconComponent,
-  getArtifactSteps,
-} from '../utils/artifact-steps';
+import { extractFilePathFromToolInput, extractFilePathFromToolOutput } from '../utils/tool-output-path';
+import { getArtifactLabel, getArtifactIconComponent, getArtifactSteps } from '../utils/artifact-steps';
 import { useIPC } from '../hooks/useIPC';
 import {
   ChevronDown,
@@ -58,13 +51,11 @@ export function ContextPanel() {
   const [mcpServers, setMcpServers] = useState<MCPServerInfo[]>([]);
   const [copiedPath, setCopiedPath] = useState(false);
   const [isChangingDir, setIsChangingDir] = useState(false);
-  const [recentWorkspaceFiles, setRecentWorkspaceFiles] = useState<
-    Array<{
-      path: string;
-      modifiedAt: number;
-      size: number;
-    }>
-  >([]);
+  const [recentWorkspaceFiles, setRecentWorkspaceFiles] = useState<Array<{
+    path: string;
+    modifiedAt: number;
+    size: number;
+  }>>([]);
 
   const handleCopyPath = async (path: string) => {
     try {
@@ -84,11 +75,10 @@ export function ContextPanel() {
 
   const ss = activeSessionId ? sessionStates[activeSessionId] : undefined;
   const steps = ss?.traceSteps ?? EMPTY_STEPS;
-  const activeSession = activeSessionId ? sessions.find((s) => s.id === activeSessionId) : null;
+  const activeSession = activeSessionId ? sessions.find(s => s.id === activeSessionId) : null;
   const currentWorkingDir = activeSession?.cwd || workingDir;
   const { displayArtifactSteps } = getArtifactSteps(steps);
-  const canShowItemInFolder =
-    typeof window !== 'undefined' && !!window.electronAPI?.showItemInFolder;
+  const canShowItemInFolder = typeof window !== 'undefined' && !!window.electronAPI?.showItemInFolder;
 
   // Session info computations
   const messages = useMemo(
@@ -114,9 +104,7 @@ export function ContextPanel() {
 
   // Context usage: last message's input tokens ≈ current context occupation
   const contextUsage = useMemo(() => {
-    const contextWindow = activeSessionId
-      ? sessionStates[activeSessionId]?.contextWindow
-      : undefined;
+    const contextWindow = activeSessionId ? sessionStates[activeSessionId]?.contextWindow : undefined;
     if (!contextWindow) return null;
 
     let lastInput = 0;
@@ -177,10 +165,10 @@ export function ContextPanel() {
       return;
     }
     if (
-      typeof window === 'undefined' ||
-      !window.electronAPI?.artifacts?.listRecentFiles ||
-      !currentWorkingDir ||
-      !activeSession?.createdAt
+      typeof window === 'undefined'
+      || !window.electronAPI?.artifacts?.listRecentFiles
+      || !currentWorkingDir
+      || !activeSession?.createdAt
     ) {
       setRecentWorkspaceFiles([]);
       return;
@@ -223,9 +211,8 @@ export function ContextPanel() {
     const items: Array<{ label: string; path: string }> = [];
 
     for (const step of displayArtifactSteps) {
-      const fallbackPath =
-        extractFilePathFromToolOutput(step.toolOutput) ||
-        extractFilePathFromToolInput(step.toolInput);
+      const fallbackPath = extractFilePathFromToolOutput(step.toolOutput)
+        || extractFilePathFromToolInput(step.toolInput);
       if (!fallbackPath) {
         continue;
       }
@@ -340,26 +327,20 @@ export function ContextPanel() {
             <span className="text-xs font-medium text-text-muted uppercase tracking-wider">
               {t('context.contextUsage')}
             </span>
-            <span
-              className={`text-xs font-medium ${
-                contextUsage.percentage > 95
-                  ? 'text-error'
-                  : contextUsage.percentage > 80
-                    ? 'text-warning'
-                    : 'text-text-primary'
-              }`}
-            >
+            <span className={`text-xs font-medium ${
+              contextUsage.percentage > 95 ? 'text-error' :
+              contextUsage.percentage > 80 ? 'text-warning' :
+              'text-text-primary'
+            }`}>
               {Math.round(contextUsage.percentage)}%
             </span>
           </div>
           <div className="h-1.5 bg-surface-muted rounded-full overflow-hidden">
             <div
               className={`h-full rounded-full transition-all duration-500 ease-out ${
-                contextUsage.percentage > 95
-                  ? 'bg-error'
-                  : contextUsage.percentage > 80
-                    ? 'bg-warning'
-                    : 'bg-gradient-to-r from-accent to-accent-hover'
+                contextUsage.percentage > 95 ? 'bg-error' :
+                contextUsage.percentage > 80 ? 'bg-warning' :
+                'bg-gradient-to-r from-accent to-accent-hover'
               }`}
               style={{ width: `${contextUsage.percentage}%` }}
             />
@@ -404,25 +385,16 @@ export function ContextPanel() {
                   const canClick = Boolean(artifactPath && canShowItemInFolder);
                   const iconComponent = getArtifactIconComponent(label);
                   const IconComponent =
-                    iconComponent === 'presentation'
-                      ? FilePieChart
-                      : iconComponent === 'table'
-                        ? FileSpreadsheet
-                        : iconComponent === 'document'
-                          ? FileText
-                          : iconComponent === 'code'
-                            ? FileCode2
-                            : iconComponent === 'image'
-                              ? ImageIcon
-                              : iconComponent === 'audio'
-                                ? FileAudio2
-                                : iconComponent === 'video'
-                                  ? FileVideo
-                                  : iconComponent === 'archive'
-                                    ? FileArchive
-                                    : iconComponent === 'text'
-                                      ? File
-                                      : File;
+                    iconComponent === 'presentation' ? FilePieChart
+                    : iconComponent === 'table' ? FileSpreadsheet
+                    : iconComponent === 'document' ? FileText
+                    : iconComponent === 'code' ? FileCode2
+                    : iconComponent === 'image' ? ImageIcon
+                    : iconComponent === 'audio' ? FileAudio2
+                    : iconComponent === 'video' ? FileVideo
+                    : iconComponent === 'archive' ? FileArchive
+                    : iconComponent === 'text' ? File
+                    : File;
 
                   return (
                     <div
@@ -430,10 +402,7 @@ export function ContextPanel() {
                       className={`flex items-center gap-2 px-4 py-1.5 transition-colors ${canClick ? 'cursor-pointer hover:bg-surface-hover' : ''}`}
                       onClick={async () => {
                         if (!canClick) return;
-                        const revealed = await window.electronAPI.showItemInFolder(
-                          artifactPath,
-                          currentWorkingDir ?? undefined
-                        );
+                        const revealed = await window.electronAPI.showItemInFolder(artifactPath, currentWorkingDir ?? undefined);
                         if (!revealed) {
                           setGlobalNotice({
                             id: `artifact-reveal-failed-${Date.now()}`,
@@ -466,9 +435,7 @@ export function ContextPanel() {
             <span
               className={`text-xs truncate flex-1 ${currentWorkingDir ? 'text-text-primary cursor-pointer hover:text-accent-primary transition-colors' : 'text-text-muted'}`}
               title={currentWorkingDir ? t('context.openInFileManager') : ''}
-              onClick={() =>
-                currentWorkingDir && window.electronAPI?.showItemInFolder(currentWorkingDir)
-              }
+              onClick={() => currentWorkingDir && window.electronAPI?.showItemInFolder(currentWorkingDir)}
             >
               {currentWorkingDir ? formatPath(currentWorkingDir) : t('context.noFolderSelected')}
             </span>
@@ -560,14 +527,14 @@ export function ContextPanel() {
   );
 }
 
-function ConnectorItem({
-  server,
-  steps,
+function ConnectorItem({ 
+  server, 
+  steps, 
   mcpToolDisplayNames,
-  expanded,
-  onToggle,
-}: {
-  server: MCPServerInfo;
+  expanded, 
+  onToggle 
+}: { 
+  server: MCPServerInfo; 
   steps: TraceStep[];
   mcpToolDisplayNames: Map<string, string>;
   expanded: boolean;
@@ -578,12 +545,12 @@ function ConnectorItem({
   // Tool names are in format: mcp__ServerName__toolname (with double underscores)
   // Server name preserves original case and spaces are replaced with underscores
   const serverNamePattern = server.name.replace(/\s+/g, '_');
-
+  
   const mcpToolsUsed = steps
-    .filter((s) => s.toolName?.startsWith('mcp__'))
-    .map((s) => s.toolName!)
+    .filter(s => s.toolName?.startsWith('mcp__'))
+    .map(s => s.toolName!)
     .filter((name, index, self) => self.indexOf(name) === index)
-    .filter((name) => {
+    .filter(name => {
       // Check if this tool belongs to this server
       // Format: mcp__ServerName__toolname
       const match = name.match(/^mcp__(.+?)__(.+)$/);
@@ -594,8 +561,8 @@ function ConnectorItem({
       return false;
     });
 
-  const usageCount = steps.filter(
-    (s) => s.toolName?.startsWith('mcp__') && mcpToolsUsed.includes(s.toolName)
+  const usageCount = steps.filter(s => 
+    s.toolName?.startsWith('mcp__') && mcpToolsUsed.includes(s.toolName)
   ).length;
 
   return (
@@ -603,19 +570,21 @@ function ConnectorItem({
       <button
         onClick={onToggle}
         className={`w-full px-3 py-2 flex items-center gap-2 transition-colors ${
-          server.connected ? 'bg-mcp/10 hover:bg-mcp/20' : 'bg-surface-muted hover:bg-surface-hover'
+          server.connected 
+            ? 'bg-mcp/10 hover:bg-mcp/20' 
+            : 'bg-surface-muted hover:bg-surface-hover'
         }`}
       >
-        <div
-          className={`w-6 h-6 rounded flex items-center justify-center ${
-            server.connected ? 'bg-mcp/20' : 'bg-surface-muted'
-          }`}
-        >
+        <div className={`w-6 h-6 rounded flex items-center justify-center ${
+          server.connected ? 'bg-mcp/20' : 'bg-surface-muted'
+        }`}>
           <Plug className={`w-3.5 h-3.5 ${server.connected ? 'text-mcp' : 'text-text-muted'}`} />
         </div>
         <div className="flex-1 text-left min-w-0">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-text-primary truncate">{server.name}</span>
+            <span className="text-sm font-medium text-text-primary truncate">
+              {server.name}
+            </span>
             {!server.connected && (
               <span className="text-xs text-text-muted">({t('mcp.notConnected')})</span>
             )}
@@ -627,12 +596,13 @@ function ConnectorItem({
             </p>
           )}
         </div>
-        {server.connected &&
-          (expanded ? (
+        {server.connected && (
+          expanded ? (
             <ChevronDown className="w-4 h-4 text-text-muted" />
           ) : (
             <ChevronRight className="w-4 h-4 text-text-muted" />
-          ))}
+          )
+        )}
       </button>
 
       {expanded && server.connected && (
@@ -641,10 +611,10 @@ function ConnectorItem({
             <>
               <p className="text-xs text-text-muted px-2 py-1">{t('context.toolsUsedLabel')}</p>
               {mcpToolsUsed.map((toolName, index) => {
-                const count = steps.filter((s) => s.toolName === toolName).length;
+                const count = steps.filter(s => s.toolName === toolName).length;
                 const readableName =
                   mcpToolDisplayNames.get(toolName) || getMcpToolDisplayName(toolName);
-
+                
                 return (
                   <div
                     key={index}
@@ -669,21 +639,21 @@ function ConnectorItem({
 // Format long paths to show abbreviated version
 function formatPath(path: string): string {
   if (!path) return '';
-
+  
   // Windows: Replace C:\Users\username with ~
   const winHome = /^[A-Z]:\\Users\\[^\\]+/i;
   const winMatch = path.match(winHome);
   if (winMatch) {
     return '~' + path.slice(winMatch[0].length).replace(/\\/g, '/');
   }
-
+  
   // macOS/Linux: Replace /Users/username or /home/username with ~
   const unixHome = /^\/(?:Users|home)\/[^/]+/;
   const unixMatch = path.match(unixHome);
   if (unixMatch) {
     return '~' + path.slice(unixMatch[0].length);
   }
-
+  
   return path;
 }
 

--- a/src/renderer/components/ContextPanel.tsx
+++ b/src/renderer/components/ContextPanel.tsx
@@ -2,8 +2,15 @@ import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../store';
 import { resolveArtifactPath } from '../utils/artifact-path';
-import { extractFilePathFromToolInput, extractFilePathFromToolOutput } from '../utils/tool-output-path';
-import { getArtifactLabel, getArtifactIconComponent, getArtifactSteps } from '../utils/artifact-steps';
+import {
+  extractFilePathFromToolInput,
+  extractFilePathFromToolOutput,
+} from '../utils/tool-output-path';
+import {
+  getArtifactLabel,
+  getArtifactIconComponent,
+  getArtifactSteps,
+} from '../utils/artifact-steps';
 import { useIPC } from '../hooks/useIPC';
 import {
   ChevronDown,
@@ -30,7 +37,8 @@ import {
   Copy,
   Layers,
 } from 'lucide-react';
-import type { TraceStep, MCPServerInfo } from '../types';
+import type { TraceStep, MCPServerInfo, ContentBlock, ToolUseContent } from '../types';
+import { getMcpToolDisplayName } from './message/toolHelpers';
 
 const EMPTY_STEPS: TraceStep[] = [];
 
@@ -50,11 +58,13 @@ export function ContextPanel() {
   const [mcpServers, setMcpServers] = useState<MCPServerInfo[]>([]);
   const [copiedPath, setCopiedPath] = useState(false);
   const [isChangingDir, setIsChangingDir] = useState(false);
-  const [recentWorkspaceFiles, setRecentWorkspaceFiles] = useState<Array<{
-    path: string;
-    modifiedAt: number;
-    size: number;
-  }>>([]);
+  const [recentWorkspaceFiles, setRecentWorkspaceFiles] = useState<
+    Array<{
+      path: string;
+      modifiedAt: number;
+      size: number;
+    }>
+  >([]);
 
   const handleCopyPath = async (path: string) => {
     try {
@@ -74,10 +84,11 @@ export function ContextPanel() {
 
   const ss = activeSessionId ? sessionStates[activeSessionId] : undefined;
   const steps = ss?.traceSteps ?? EMPTY_STEPS;
-  const activeSession = activeSessionId ? sessions.find(s => s.id === activeSessionId) : null;
+  const activeSession = activeSessionId ? sessions.find((s) => s.id === activeSessionId) : null;
   const currentWorkingDir = activeSession?.cwd || workingDir;
   const { displayArtifactSteps } = getArtifactSteps(steps);
-  const canShowItemInFolder = typeof window !== 'undefined' && !!window.electronAPI?.showItemInFolder;
+  const canShowItemInFolder =
+    typeof window !== 'undefined' && !!window.electronAPI?.showItemInFolder;
 
   // Session info computations
   const messages = useMemo(
@@ -103,7 +114,9 @@ export function ContextPanel() {
 
   // Context usage: last message's input tokens ≈ current context occupation
   const contextUsage = useMemo(() => {
-    const contextWindow = activeSessionId ? sessionStates[activeSessionId]?.contextWindow : undefined;
+    const contextWindow = activeSessionId
+      ? sessionStates[activeSessionId]?.contextWindow
+      : undefined;
     if (!contextWindow) return null;
 
     let lastInput = 0;
@@ -124,15 +137,50 @@ export function ContextPanel() {
     [steps]
   );
 
+  const mcpToolDisplayNames = useMemo(() => {
+    const displayNames = new Map<string, string>();
+
+    for (const msg of messages) {
+      if (!Array.isArray(msg.content)) {
+        continue;
+      }
+
+      for (const block of msg.content as ContentBlock[]) {
+        if (block.type !== 'tool_use') {
+          continue;
+        }
+
+        const toolUse = block as ToolUseContent;
+        if (!toolUse.name.startsWith('mcp__')) {
+          continue;
+        }
+
+        displayNames.set(toolUse.name, getMcpToolDisplayName(toolUse.name, toolUse.displayName));
+      }
+    }
+
+    for (const step of steps) {
+      if (step.type !== 'tool_call' || !step.toolName?.startsWith('mcp__')) {
+        continue;
+      }
+
+      if (!displayNames.has(step.toolName)) {
+        displayNames.set(step.toolName, getMcpToolDisplayName(step.toolName, step.title));
+      }
+    }
+
+    return displayNames;
+  }, [messages, steps]);
+
   useEffect(() => {
     if (contextPanelCollapsed) {
       return;
     }
     if (
-      typeof window === 'undefined'
-      || !window.electronAPI?.artifacts?.listRecentFiles
-      || !currentWorkingDir
-      || !activeSession?.createdAt
+      typeof window === 'undefined' ||
+      !window.electronAPI?.artifacts?.listRecentFiles ||
+      !currentWorkingDir ||
+      !activeSession?.createdAt
     ) {
       setRecentWorkspaceFiles([]);
       return;
@@ -175,8 +223,9 @@ export function ContextPanel() {
     const items: Array<{ label: string; path: string }> = [];
 
     for (const step of displayArtifactSteps) {
-      const fallbackPath = extractFilePathFromToolOutput(step.toolOutput)
-        || extractFilePathFromToolInput(step.toolInput);
+      const fallbackPath =
+        extractFilePathFromToolOutput(step.toolOutput) ||
+        extractFilePathFromToolInput(step.toolInput);
       if (!fallbackPath) {
         continue;
       }
@@ -276,7 +325,8 @@ export function ContextPanel() {
             </span>
             {tokenUsage.total > 0 && (
               <span className="ml-auto text-text-muted/70">
-                {t('context.inputTokens')} {formatTokenCount(tokenUsage.input)} · {t('context.outputTokens')} {formatTokenCount(tokenUsage.output)}
+                {t('context.inputTokens')} {formatTokenCount(tokenUsage.input)} ·{' '}
+                {t('context.outputTokens')} {formatTokenCount(tokenUsage.output)}
               </span>
             )}
           </div>
@@ -290,20 +340,26 @@ export function ContextPanel() {
             <span className="text-xs font-medium text-text-muted uppercase tracking-wider">
               {t('context.contextUsage')}
             </span>
-            <span className={`text-xs font-medium ${
-              contextUsage.percentage > 95 ? 'text-error' :
-              contextUsage.percentage > 80 ? 'text-warning' :
-              'text-text-primary'
-            }`}>
+            <span
+              className={`text-xs font-medium ${
+                contextUsage.percentage > 95
+                  ? 'text-error'
+                  : contextUsage.percentage > 80
+                    ? 'text-warning'
+                    : 'text-text-primary'
+              }`}
+            >
               {Math.round(contextUsage.percentage)}%
             </span>
           </div>
           <div className="h-1.5 bg-surface-muted rounded-full overflow-hidden">
             <div
               className={`h-full rounded-full transition-all duration-500 ease-out ${
-                contextUsage.percentage > 95 ? 'bg-error' :
-                contextUsage.percentage > 80 ? 'bg-warning' :
-                'bg-gradient-to-r from-accent to-accent-hover'
+                contextUsage.percentage > 95
+                  ? 'bg-error'
+                  : contextUsage.percentage > 80
+                    ? 'bg-warning'
+                    : 'bg-gradient-to-r from-accent to-accent-hover'
               }`}
               style={{ width: `${contextUsage.percentage}%` }}
             />
@@ -348,16 +404,25 @@ export function ContextPanel() {
                   const canClick = Boolean(artifactPath && canShowItemInFolder);
                   const iconComponent = getArtifactIconComponent(label);
                   const IconComponent =
-                    iconComponent === 'presentation' ? FilePieChart
-                    : iconComponent === 'table' ? FileSpreadsheet
-                    : iconComponent === 'document' ? FileText
-                    : iconComponent === 'code' ? FileCode2
-                    : iconComponent === 'image' ? ImageIcon
-                    : iconComponent === 'audio' ? FileAudio2
-                    : iconComponent === 'video' ? FileVideo
-                    : iconComponent === 'archive' ? FileArchive
-                    : iconComponent === 'text' ? File
-                    : File;
+                    iconComponent === 'presentation'
+                      ? FilePieChart
+                      : iconComponent === 'table'
+                        ? FileSpreadsheet
+                        : iconComponent === 'document'
+                          ? FileText
+                          : iconComponent === 'code'
+                            ? FileCode2
+                            : iconComponent === 'image'
+                              ? ImageIcon
+                              : iconComponent === 'audio'
+                                ? FileAudio2
+                                : iconComponent === 'video'
+                                  ? FileVideo
+                                  : iconComponent === 'archive'
+                                    ? FileArchive
+                                    : iconComponent === 'text'
+                                      ? File
+                                      : File;
 
                   return (
                     <div
@@ -365,7 +430,10 @@ export function ContextPanel() {
                       className={`flex items-center gap-2 px-4 py-1.5 transition-colors ${canClick ? 'cursor-pointer hover:bg-surface-hover' : ''}`}
                       onClick={async () => {
                         if (!canClick) return;
-                        const revealed = await window.electronAPI.showItemInFolder(artifactPath, currentWorkingDir ?? undefined);
+                        const revealed = await window.electronAPI.showItemInFolder(
+                          artifactPath,
+                          currentWorkingDir ?? undefined
+                        );
                         if (!revealed) {
                           setGlobalNotice({
                             id: `artifact-reveal-failed-${Date.now()}`,
@@ -398,7 +466,9 @@ export function ContextPanel() {
             <span
               className={`text-xs truncate flex-1 ${currentWorkingDir ? 'text-text-primary cursor-pointer hover:text-accent-primary transition-colors' : 'text-text-muted'}`}
               title={currentWorkingDir ? t('context.openInFileManager') : ''}
-              onClick={() => currentWorkingDir && window.electronAPI?.showItemInFolder(currentWorkingDir)}
+              onClick={() =>
+                currentWorkingDir && window.electronAPI?.showItemInFolder(currentWorkingDir)
+              }
             >
               {currentWorkingDir ? formatPath(currentWorkingDir) : t('context.noFolderSelected')}
             </span>
@@ -475,6 +545,7 @@ export function ContextPanel() {
                   key={server.id}
                   server={server}
                   steps={steps}
+                  mcpToolDisplayNames={mcpToolDisplayNames}
                   expanded={expandedConnector === server.id}
                   onToggle={() =>
                     setExpandedConnector(expandedConnector === server.id ? null : server.id)
@@ -489,14 +560,16 @@ export function ContextPanel() {
   );
 }
 
-function ConnectorItem({ 
-  server, 
-  steps, 
-  expanded, 
-  onToggle 
-}: { 
-  server: MCPServerInfo; 
+function ConnectorItem({
+  server,
+  steps,
+  mcpToolDisplayNames,
+  expanded,
+  onToggle,
+}: {
+  server: MCPServerInfo;
   steps: TraceStep[];
+  mcpToolDisplayNames: Map<string, string>;
   expanded: boolean;
   onToggle: () => void;
 }) {
@@ -505,12 +578,12 @@ function ConnectorItem({
   // Tool names are in format: mcp__ServerName__toolname (with double underscores)
   // Server name preserves original case and spaces are replaced with underscores
   const serverNamePattern = server.name.replace(/\s+/g, '_');
-  
+
   const mcpToolsUsed = steps
-    .filter(s => s.toolName?.startsWith('mcp__'))
-    .map(s => s.toolName!)
+    .filter((s) => s.toolName?.startsWith('mcp__'))
+    .map((s) => s.toolName!)
     .filter((name, index, self) => self.indexOf(name) === index)
-    .filter(name => {
+    .filter((name) => {
       // Check if this tool belongs to this server
       // Format: mcp__ServerName__toolname
       const match = name.match(/^mcp__(.+?)__(.+)$/);
@@ -521,8 +594,8 @@ function ConnectorItem({
       return false;
     });
 
-  const usageCount = steps.filter(s => 
-    s.toolName?.startsWith('mcp__') && mcpToolsUsed.includes(s.toolName)
+  const usageCount = steps.filter(
+    (s) => s.toolName?.startsWith('mcp__') && mcpToolsUsed.includes(s.toolName)
   ).length;
 
   return (
@@ -530,21 +603,19 @@ function ConnectorItem({
       <button
         onClick={onToggle}
         className={`w-full px-3 py-2 flex items-center gap-2 transition-colors ${
-          server.connected 
-            ? 'bg-mcp/10 hover:bg-mcp/20' 
-            : 'bg-surface-muted hover:bg-surface-hover'
+          server.connected ? 'bg-mcp/10 hover:bg-mcp/20' : 'bg-surface-muted hover:bg-surface-hover'
         }`}
       >
-        <div className={`w-6 h-6 rounded flex items-center justify-center ${
-          server.connected ? 'bg-mcp/20' : 'bg-surface-muted'
-        }`}>
+        <div
+          className={`w-6 h-6 rounded flex items-center justify-center ${
+            server.connected ? 'bg-mcp/20' : 'bg-surface-muted'
+          }`}
+        >
           <Plug className={`w-3.5 h-3.5 ${server.connected ? 'text-mcp' : 'text-text-muted'}`} />
         </div>
         <div className="flex-1 text-left min-w-0">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-text-primary truncate">
-              {server.name}
-            </span>
+            <span className="text-sm font-medium text-text-primary truncate">{server.name}</span>
             {!server.connected && (
               <span className="text-xs text-text-muted">({t('mcp.notConnected')})</span>
             )}
@@ -556,13 +627,12 @@ function ConnectorItem({
             </p>
           )}
         </div>
-        {server.connected && (
-          expanded ? (
+        {server.connected &&
+          (expanded ? (
             <ChevronDown className="w-4 h-4 text-text-muted" />
           ) : (
             <ChevronRight className="w-4 h-4 text-text-muted" />
-          )
-        )}
+          ))}
       </button>
 
       {expanded && server.connected && (
@@ -571,11 +641,10 @@ function ConnectorItem({
             <>
               <p className="text-xs text-text-muted px-2 py-1">{t('context.toolsUsedLabel')}</p>
               {mcpToolsUsed.map((toolName, index) => {
-                const count = steps.filter(s => s.toolName === toolName).length;
-                // Extract readable tool name - remove mcp__ServerName__ prefix
-                const match = toolName.match(/^mcp__(.+?)__(.+)$/);
-                const readableName = match ? match[2] : toolName;
-                
+                const count = steps.filter((s) => s.toolName === toolName).length;
+                const readableName =
+                  mcpToolDisplayNames.get(toolName) || getMcpToolDisplayName(toolName);
+
                 return (
                   <div
                     key={index}
@@ -600,21 +669,21 @@ function ConnectorItem({
 // Format long paths to show abbreviated version
 function formatPath(path: string): string {
   if (!path) return '';
-  
+
   // Windows: Replace C:\Users\username with ~
   const winHome = /^[A-Z]:\\Users\\[^\\]+/i;
   const winMatch = path.match(winHome);
   if (winMatch) {
     return '~' + path.slice(winMatch[0].length).replace(/\\/g, '/');
   }
-  
+
   // macOS/Linux: Replace /Users/username or /home/username with ~
   const unixHome = /^\/(?:Users|home)\/[^/]+/;
   const unixMatch = path.match(unixHome);
   if (unixMatch) {
     return '~' + path.slice(unixMatch[0].length);
   }
-  
+
   return path;
 }
 

--- a/src/renderer/components/message/ToolResultBlock.tsx
+++ b/src/renderer/components/message/ToolResultBlock.tsx
@@ -8,6 +8,7 @@ import {
   shouldUseScreenshotSummary,
 } from '../../utils/tool-result-summary';
 import type { ToolResultContent, ContentBlock, ToolUseContent, Message } from '../../types';
+import { getMcpToolDisplayName } from './toolHelpers';
 
 // Only allow safe image MIME types for data: URI rendering
 const ALLOWED_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
@@ -48,21 +49,25 @@ export const ToolResultBlock = memo(function ToolResultBlock({
 
   // Try to find the tool name from trace steps
   let toolName: string | undefined;
+  let toolDisplayName: string | undefined;
   if (message?.sessionId) {
     const toolCallStep = traceSteps.find((s) => s.id === block.toolUseId && s.type === 'tool_call');
-    if (toolCallStep) toolName = toolCallStep.toolName;
+    if (toolCallStep) {
+      toolName = toolCallStep.toolName;
+      toolDisplayName = toolCallStep.title;
+    }
   }
+  const toolUseBlock = allBlocks?.find(
+    (b) => b.type === 'tool_use' && (b as ToolUseContent).id === block.toolUseId
+  ) as ToolUseContent | undefined;
   if (!toolName) {
-    const toolUseBlock = allBlocks?.find(
-      (b) => b.type === 'tool_use' && (b as ToolUseContent).id === block.toolUseId
-    ) as ToolUseContent | undefined;
     toolName = toolUseBlock?.name;
   }
+  if (!toolDisplayName) {
+    toolDisplayName = toolUseBlock?.displayName;
+  }
 
-  const isMCPTool = toolName?.startsWith('mcp__') || false;
-  const displayName = isMCPTool
-    ? (toolName || '').match(/^mcp__(.+?)__(.+)$/)?.[2] || toolName || 'tool'
-    : toolName || 'tool';
+  const displayName = toolName ? getMcpToolDisplayName(toolName, toolDisplayName) : 'tool';
 
   const getSummary = (): string => {
     const content = typeof block.content === 'string' ? block.content : '';

--- a/src/renderer/components/message/ToolUseBlock.tsx
+++ b/src/renderer/components/message/ToolUseBlock.tsx
@@ -70,7 +70,7 @@ export const ToolUseBlock = memo(function ToolUseBlock({
   const isError = toolResult?.isError === true;
   const isSuccess = toolResult && !isError;
 
-  const label = getToolLabel(block.name, block.input);
+  const label = getToolLabel(block.name, block.input, block.displayName);
   const isMCPTool = block.name.startsWith('mcp__');
   const mcpServerName = isMCPTool ? block.name.match(/^mcp__(.+?)__/)?.[1] : null;
 

--- a/src/renderer/components/message/toolHelpers.tsx
+++ b/src/renderer/components/message/toolHelpers.tsx
@@ -23,13 +23,29 @@ export function shortenPath(p: string): string {
   return segments.slice(-2).join('/');
 }
 
-/** Get compact label: tool action + key argument */
-export function getToolLabel(name: string, input: Record<string, unknown>): string {
-  const inp = input || {};
-  // MCP tools
+export function getMcpToolDisplayName(name: string, displayName?: string): string {
+  if (typeof displayName === 'string' && displayName.trim().length > 0) {
+    return displayName;
+  }
+
   if (name.startsWith('mcp__')) {
     const match = name.match(/^mcp__(.+?)__(.+)$/);
     return match?.[2] || name;
+  }
+
+  return name;
+}
+
+/** Get compact label: tool action + key argument */
+export function getToolLabel(
+  name: string,
+  input: Record<string, unknown>,
+  displayName?: string
+): string {
+  const inp = input || {};
+  // MCP tools
+  if (name.startsWith('mcp__')) {
+    return getMcpToolDisplayName(name, displayName);
   }
 
   const nameLower = name.toLowerCase();

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -73,6 +73,7 @@ export interface ToolUseContent {
   type: 'tool_use';
   id: string;
   name: string;
+  displayName?: string;
   input: Record<string, unknown>;
 }
 

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -83,8 +83,8 @@ export interface ToolResultContent {
   content: string;
   isError?: boolean;
   images?: Array<{
-    data: string; // base64 encoded image data
-    mimeType: string; // e.g., 'image/png'
+    data: string;          // base64 encoded image data
+    mimeType: string;      // e.g., 'image/png'
   }>;
 }
 
@@ -479,17 +479,17 @@ export type ClientEvent =
   | { type: 'workdir.select'; payload: { sessionId?: string; currentPath?: string } };
 
 // Sandbox setup types (app startup)
-export type SandboxSetupPhase =
-  | 'checking' // Checking WSL/Lima availability
-  | 'creating' // Creating Lima instance (macOS only)
-  | 'starting' // Starting Lima instance (macOS only)
+export type SandboxSetupPhase = 
+  | 'checking'      // Checking WSL/Lima availability
+  | 'creating'      // Creating Lima instance (macOS only)
+  | 'starting'      // Starting Lima instance (macOS only)  
   | 'installing_node' // Installing Node.js
   | 'installing_python' // Installing Python
-  | 'installing_pip' // Installing pip
-  | 'installing_deps' // Installing skill dependencies (markitdown, pypdf, etc.)
-  | 'ready' // Ready to use
-  | 'skipped' // No sandbox needed (native mode)
-  | 'error'; // Setup failed
+  | 'installing_pip'    // Installing pip
+  | 'installing_deps'   // Installing skill dependencies (markitdown, pypdf, etc.)
+  | 'ready'         // Ready to use
+  | 'skipped'       // No sandbox needed (native mode)
+  | 'error';        // Setup failed
 
 export interface SandboxSetupProgress {
   phase: SandboxSetupPhase;
@@ -501,11 +501,11 @@ export interface SandboxSetupProgress {
 
 // Sandbox sync types (per-session file sync)
 export type SandboxSyncPhase =
-  | 'starting_agent' // Starting WSL/Lima agent
-  | 'syncing_files' // Syncing files to sandbox
+  | 'starting_agent'  // Starting WSL/Lima agent
+  | 'syncing_files'   // Syncing files to sandbox
   | 'syncing_skills' // Copying skills
-  | 'ready' // Sync complete
-  | 'error'; // Sync failed
+  | 'ready'           // Sync complete
+  | 'error';          // Sync failed
 
 export interface SandboxSyncStatus {
   sessionId: string;
@@ -520,14 +520,8 @@ export type ServerEvent =
   | { type: 'stream.message'; payload: { sessionId: string; message: Message } }
   | { type: 'stream.partial'; payload: { sessionId: string; delta: string } }
   | { type: 'stream.thinking'; payload: { sessionId: string; delta: string } }
-  | {
-      type: 'stream.executionTime';
-      payload: { sessionId: string; messageId: string; executionTimeMs: number };
-    }
-  | {
-      type: 'session.status';
-      payload: { sessionId: string; status: SessionStatus; error?: string };
-    }
+  | { type: 'stream.executionTime'; payload: { sessionId: string; messageId: string; executionTimeMs: number } }
+  | { type: 'session.status'; payload: { sessionId: string; status: SessionStatus; error?: string } }
   | { type: 'session.update'; payload: { sessionId: string; updates: Partial<Session> } }
   | { type: 'session.list'; payload: { sessions: Session[] } }
   | { type: 'permission.request'; payload: PermissionRequest }
@@ -535,37 +529,21 @@ export type ServerEvent =
   | { type: 'sudo.password.request'; payload: SudoPasswordRequest }
   | { type: 'sudo.password.dismiss'; payload: { toolUseId: string } }
   | { type: 'trace.step'; payload: { sessionId: string; step: TraceStep } }
-  | {
-      type: 'trace.update';
-      payload: { sessionId: string; stepId: string; updates: Partial<TraceStep> };
-    }
+  | { type: 'trace.update'; payload: { sessionId: string; stepId: string; updates: Partial<TraceStep> } }
   | { type: 'folder.selected'; payload: { path: string } }
   | { type: 'config.status'; payload: { isConfigured: boolean; config: AppConfig } }
   | { type: 'sandbox.progress'; payload: SandboxSetupProgress }
   | { type: 'sandbox.sync'; payload: SandboxSyncStatus }
   | { type: 'skills.storageChanged'; payload: SkillsStorageChangeEvent }
-  | {
-      type: 'plugins.runtimeApplied';
-      payload: { sessionId: string; plugins: Array<{ name: string; path: string }> };
-    }
+  | { type: 'plugins.runtimeApplied'; payload: { sessionId: string; plugins: Array<{ name: string; path: string }> } }
   | { type: 'workdir.changed'; payload: { path: string } }
   | { type: 'session.contextInfo'; payload: { sessionId: string; contextWindow: number } }
-  | {
-      type: 'navigate.to';
-      payload: { page: 'welcome' | 'settings' | 'session'; tab?: string; sessionId?: string };
-    }
+  | { type: 'navigate.to'; payload: { page: 'welcome' | 'settings' | 'session'; tab?: string; sessionId?: string } }
   | { type: 'native-theme.changed'; payload: { shouldUseDarkColors: boolean } }
   | { type: 'new-session' }
   | { type: 'navigate'; payload: string }
   | { type: 'scheduled-task.error'; payload: { taskId: string; error: string } }
-  | {
-      type: 'error';
-      payload: {
-        message: string;
-        code?: 'CONFIG_REQUIRED_ACTIVE_SET';
-        action?: 'open_api_settings';
-      };
-    };
+  | { type: 'error'; payload: { message: string; code?: 'CONFIG_REQUIRED_ACTIVE_SET'; action?: 'open_api_settings' } };
 
 // Settings types
 export interface Settings {
@@ -579,15 +557,7 @@ export interface Settings {
 }
 
 // Tool types
-export type ToolName =
-  | 'read'
-  | 'write'
-  | 'edit'
-  | 'glob'
-  | 'grep'
-  | 'bash'
-  | 'webFetch'
-  | 'webSearch';
+export type ToolName = 'read' | 'write' | 'edit' | 'glob' | 'grep' | 'bash' | 'webFetch' | 'webSearch';
 
 export interface ToolResult {
   success: boolean;
@@ -783,7 +753,10 @@ export interface LocalServiceInfo {
   models?: string[];
 }
 
-export type LocalOllamaDiscoveryStatus = 'unavailable' | 'service_available' | 'models_available';
+export type LocalOllamaDiscoveryStatus =
+  | 'unavailable'
+  | 'service_available'
+  | 'models_available';
 
 export interface LocalOllamaDiscoveryResult {
   available: boolean;

--- a/src/tests/renderer-crash-safety.test.ts
+++ b/src/tests/renderer-crash-safety.test.ts
@@ -17,11 +17,22 @@ function shortenPath(p: string): string {
 }
 
 /** getToolLabel — mirrors MessageCard.tsx */
-function getToolLabel(name: string, input: unknown): string {
-  const inp = (input as Record<string, unknown>) || {};
+function getMcpToolDisplayName(name: string, displayName?: string): string {
+  if (typeof displayName === 'string' && displayName.trim().length > 0) {
+    return displayName;
+  }
   if (name.startsWith('mcp__')) {
     const match = name.match(/^mcp__(.+?)__(.+)$/);
     return match?.[2] || name;
+  }
+  return name;
+}
+
+/** getToolLabel — mirrors MessageCard.tsx */
+function getToolLabel(name: string, input: unknown, displayName?: string): string {
+  const inp = (input as Record<string, unknown>) || {};
+  if (name.startsWith('mcp__')) {
+    return getMcpToolDisplayName(name, displayName);
   }
   const nameLower = name.toLowerCase();
   if (nameLower === 'read' || nameLower === 'read_file') {
@@ -115,6 +126,12 @@ describe('getToolLabel', () => {
 
   it('handles MCP tool names', () => {
     expect(getToolLabel('mcp__server__doSomething', {})).toBe('doSomething');
+  });
+
+  it('prefers original MCP display names when provided', () => {
+    expect(getToolLabel('mcp__server__browser_context', {}, 'browser.context')).toBe(
+      'browser.context'
+    );
   });
 
   it('handles bash with command', () => {

--- a/tests/mcp-tool-name.test.ts
+++ b/tests/mcp-tool-name.test.ts
@@ -6,18 +6,33 @@ vi.mock('electron', () => ({
     getPath: () => '/tmp',
     getVersion: () => '0.0.0',
   },
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
 }));
 
 import { MCPManager } from '../src/main/mcp/mcp-manager';
+
+type TestManagerInternals = {
+  clients: Map<string, unknown>;
+  tools: Map<string, unknown>;
+  serverConfigs: Map<string, unknown>;
+  reconnectServer: ReturnType<typeof vi.fn>;
+};
+
+function asTestManager(manager: MCPManager): MCPManager & TestManagerInternals {
+  return manager as MCPManager & TestManagerInternals;
+}
 
 function createManagerWithTool(toolName: string) {
   const manager = new MCPManager();
   const mockClient = {
     callTool: vi.fn().mockResolvedValue({ ok: true }),
-  } as any;
+  };
+  const testManager = asTestManager(manager);
 
-  (manager as any).clients = new Map([['server-1', mockClient]]);
-  (manager as any).tools = new Map([
+  testManager.clients = new Map([['server-1', mockClient]]);
+  testManager.tools = new Map([
     [
       toolName,
       {
@@ -61,6 +76,7 @@ describe('MCP tool name parsing', () => {
   it('reconnects and retries when tool returns structured Not connected error', async () => {
     const toolName = 'mcp__GUI_Operate__screenshot_for_display';
     const manager = new MCPManager();
+    const testManager = asTestManager(manager);
     const mockClient = {
       callTool: vi
         .fn()
@@ -73,10 +89,10 @@ describe('MCP tool name parsing', () => {
           ],
         })
         .mockResolvedValueOnce({ ok: true }),
-    } as any;
+    };
 
-    (manager as any).clients = new Map([['server-1', mockClient]]);
-    (manager as any).tools = new Map([
+    testManager.clients = new Map([['server-1', mockClient]]);
+    testManager.tools = new Map([
       [
         toolName,
         {
@@ -88,11 +104,11 @@ describe('MCP tool name parsing', () => {
         },
       ],
     ]);
-    (manager as any).reconnectServer = vi.fn().mockResolvedValue(true);
+    testManager.reconnectServer = vi.fn().mockResolvedValue(true);
 
     const result = await manager.callTool(toolName, { display_index: 0 });
 
-    expect((manager as any).reconnectServer).toHaveBeenCalledWith('server-1');
+    expect(testManager.reconnectServer).toHaveBeenCalledWith('server-1');
     expect(mockClient.callTool).toHaveBeenCalledTimes(2);
     expect(result).toEqual({ ok: true });
   });
@@ -100,6 +116,7 @@ describe('MCP tool name parsing', () => {
   it('does not reconnect when tool returns plain text content without structured error envelope', async () => {
     const toolName = 'mcp__GUI_Operate__screenshot_for_display';
     const manager = new MCPManager();
+    const testManager = asTestManager(manager);
     const mockClient = {
       callTool: vi.fn().mockResolvedValue({
         content: [
@@ -109,10 +126,10 @@ describe('MCP tool name parsing', () => {
           },
         ],
       }),
-    } as any;
+    };
 
-    (manager as any).clients = new Map([['server-1', mockClient]]);
-    (manager as any).tools = new Map([
+    testManager.clients = new Map([['server-1', mockClient]]);
+    testManager.tools = new Map([
       [
         toolName,
         {
@@ -124,11 +141,11 @@ describe('MCP tool name parsing', () => {
         },
       ],
     ]);
-    (manager as any).reconnectServer = vi.fn().mockResolvedValue(true);
+    testManager.reconnectServer = vi.fn().mockResolvedValue(true);
 
     const result = await manager.callTool(toolName, { display_index: 0 });
 
-    expect((manager as any).reconnectServer).not.toHaveBeenCalled();
+    expect(testManager.reconnectServer).not.toHaveBeenCalled();
     expect(mockClient.callTool).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       content: [
@@ -138,5 +155,91 @@ describe('MCP tool name parsing', () => {
         },
       ],
     });
+  });
+
+  it('sanitizes model-facing MCP tool names while calling the original tool name', async () => {
+    const manager = new MCPManager();
+    const testManager = asTestManager(manager);
+    const mockClient = {
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {
+            name: 'browser.context',
+            description: 'Inspect browser context',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      }),
+      callTool: vi.fn().mockResolvedValue({ ok: true }),
+    };
+
+    testManager.clients = new Map([['server-1', mockClient]]);
+    testManager.serverConfigs = new Map([
+      [
+        'server-1',
+        {
+          id: 'server-1',
+          name: 'Browser Context',
+          type: 'stdio',
+          enabled: true,
+        },
+      ],
+    ]);
+
+    await manager.refreshTools();
+
+    const [tool] = manager.getTools();
+    expect(tool.name).toBe('mcp__Browser_Context__browser_context');
+    expect(tool.originalName).toBe('browser.context');
+
+    await manager.callTool(tool.name, { url: 'https://example.com' });
+
+    expect(mockClient.callTool).toHaveBeenCalledWith({
+      name: 'browser.context',
+      arguments: { url: 'https://example.com' },
+    });
+  });
+
+  it('deduplicates sanitized MCP tool names that would otherwise collide', async () => {
+    const manager = new MCPManager();
+    const testManager = asTestManager(manager);
+    const mockClient = {
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {
+            name: 'browser.context',
+            description: '',
+            inputSchema: { type: 'object', properties: {} },
+          },
+          {
+            name: 'browser:context',
+            description: '',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      }),
+      callTool: vi.fn().mockResolvedValue({ ok: true }),
+    };
+
+    testManager.clients = new Map([['server-1', mockClient]]);
+    testManager.serverConfigs = new Map([
+      [
+        'server-1',
+        {
+          id: 'server-1',
+          name: 'Browser Context',
+          type: 'stdio',
+          enabled: true,
+        },
+      ],
+    ]);
+
+    await manager.refreshTools();
+
+    const toolNames = manager.getTools().map((tool) => tool.name);
+    expect(toolNames).toEqual([
+      'mcp__Browser_Context__browser_context',
+      'mcp__Browser_Context__browser_context_2',
+    ]);
   });
 });

--- a/tests/mcp-tool-name.test.ts
+++ b/tests/mcp-tool-name.test.ts
@@ -207,12 +207,12 @@ describe('MCP tool name parsing', () => {
       listTools: vi.fn().mockResolvedValue({
         tools: [
           {
-            name: 'browser.context',
+            name: 'browser:context',
             description: '',
             inputSchema: { type: 'object', properties: {} },
           },
           {
-            name: 'browser:context',
+            name: 'browser.context',
             description: '',
             inputSchema: { type: 'object', properties: {} },
           },
@@ -236,10 +236,90 @@ describe('MCP tool name parsing', () => {
 
     await manager.refreshTools();
 
-    const toolNames = manager.getTools().map((tool) => tool.name);
-    expect(toolNames).toEqual([
+    const tools = manager.getTools();
+    expect(tools.map((tool) => tool.originalName)).toEqual(['browser.context', 'browser:context']);
+    expect(tools.map((tool) => tool.name)).toEqual([
       'mcp__Browser_Context__browser_context',
       'mcp__Browser_Context__browser_context_2',
     ]);
+  });
+
+  it('keeps sanitized MCP tool names within provider length limits', async () => {
+    const manager = new MCPManager();
+    const testManager = asTestManager(manager);
+    const originalToolName = 'browser.' + 'context-'.repeat(10);
+    const mockClient = {
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {
+            name: originalToolName,
+            description: '',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      }),
+      callTool: vi.fn().mockResolvedValue({ ok: true }),
+    };
+
+    testManager.clients = new Map([['server-1', mockClient]]);
+    testManager.serverConfigs = new Map([
+      [
+        'server-1',
+        {
+          id: 'server-1',
+          name: 'Browser Context Server With A Very Long Display Name',
+          type: 'stdio',
+          enabled: true,
+        },
+      ],
+    ]);
+
+    await manager.refreshTools();
+
+    const [tool] = manager.getTools();
+    expect(tool.name.length).toBeLessThanOrEqual(64);
+
+    await manager.callTool(tool.name, { url: 'https://example.com' });
+
+    expect(mockClient.callTool).toHaveBeenCalledWith({
+      name: originalToolName,
+      arguments: { url: 'https://example.com' },
+    });
+  });
+
+  it('falls back to tool when the original tool name sanitizes to an empty string', async () => {
+    const manager = new MCPManager();
+    const testManager = asTestManager(manager);
+    const mockClient = {
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {
+            name: '!!!',
+            description: '',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      }),
+      callTool: vi.fn().mockResolvedValue({ ok: true }),
+    };
+
+    testManager.clients = new Map([['server-1', mockClient]]);
+    testManager.serverConfigs = new Map([
+      [
+        'server-1',
+        {
+          id: 'server-1',
+          name: 'Browser Context',
+          type: 'stdio',
+          enabled: true,
+        },
+      ],
+    ]);
+
+    await manager.refreshTools();
+
+    const [tool] = manager.getTools();
+    expect(tool.name).toBe('mcp__Browser_Context__tool');
+    expect(tool.originalName).toBe('!!!');
   });
 });

--- a/tests/mcp-tool-name.test.ts
+++ b/tests/mcp-tool-name.test.ts
@@ -11,7 +11,7 @@ vi.mock('electron', () => ({
   },
 }));
 
-import { MCPManager } from '../src/main/mcp/mcp-manager';
+import { formatMcpToolName, MCPManager } from '../src/main/mcp/mcp-manager';
 
 type TestManagerInternals = {
   clients: Map<string, unknown>;
@@ -321,5 +321,12 @@ describe('MCP tool name parsing', () => {
     const [tool] = manager.getTools();
     expect(tool.name).toBe('mcp__Browser_Context__tool');
     expect(tool.originalName).toBe('!!!');
+  });
+
+  it('falls back to a hashed safe name when an absurdly long suffix leaves no room for the base', () => {
+    const toolName = formatMcpToolName('mcp__Browser_Context__browser_context', '9'.repeat(80));
+
+    expect(toolName.length).toBeLessThanOrEqual(64);
+    expect(toolName.startsWith('tool_')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- sanitize model-facing MCP tool names so OpenAI-compatible providers do not reject punctuation-heavy names
- preserve each tool original MCP name for execution and keep UI labels human-readable
- add regression coverage for sanitized-name routing and collision handling

## Testing
- npm run typecheck
- ./resources/node/darwin-arm64/bin/node ./node_modules/vitest/vitest.mjs run tests/mcp-tool-name.test.ts src/tests/mcp/mcp-manager.test.ts