### PR TITLE
fix: extend MCP timeouts for complex servers

### DIFF
--- a/src/main/mcp/mcp-manager.ts
+++ b/src/main/mcp/mcp-manager.ts
@@ -25,6 +25,10 @@ import { getDefaultShell } from '../utils/shell-resolver';
 const MCP_LIST_TOOLS_TIMEOUT_MS = 5 * 60 * 1000;
 const MCP_TOOL_CALL_TIMEOUT_MS = 5 * 60 * 1000;
 
+type RefreshToolsResult =
+  | { kind: 'success'; serverId: string; tools: MCPTool[] }
+  | { kind: 'error'; serverId: string; error: unknown };
+
 /**
  * MCP Server Configuration
  */
@@ -131,6 +135,24 @@ function createUniqueMcpToolName(baseName: string, usedNames: Set<string>): stri
   usedNames.add(candidate);
   return candidate;
 }
+
+async function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutId!);
+  }
+}
+
 
 function getTrustedWindowsNpxDirectories(
   env: Record<string, string | undefined> = process.env
@@ -1394,102 +1416,105 @@ export class MCPManager {
    */
   async refreshTools(): Promise<void> {
     log('[MCPManager] Refreshing tools from all servers');
-    const newTools = new Map<string, MCPTool>();
-    const usedToolNames = new Set<string>();
 
-    for (const [serverId, client] of this.clients.entries()) {
-      try {
+    const toolResults: RefreshToolsResult[] = await Promise.all(
+      Array.from(this.clients.entries()).map(async ([serverId, client]) => {
         const config = this.serverConfigs.get(serverId);
-        if (!config) continue;
+        if (!config) {
+          return { kind: 'success', serverId, tools: [] as MCPTool[] };
+        }
 
-        // Complex MCP servers can take minutes to enumerate their tools.
         const timeoutMs = MCP_LIST_TOOLS_TIMEOUT_MS;
-        const listToolsPromise = client.listTools();
-        let timeoutId: ReturnType<typeof setTimeout>;
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          timeoutId = setTimeout(
-            () => reject(new Error(`listTools timeout after ${timeoutMs}ms`)),
-            timeoutMs
-          );
-        });
-
         log(`[MCPManager] Fetching tools from ${config.name} (timeout: ${timeoutMs}ms)...`);
 
-        let listToolsResult;
         try {
-          listToolsResult = await Promise.race([listToolsPromise, timeoutPromise]);
-          clearTimeout(timeoutId!);
-        } catch (error) {
-          clearTimeout(timeoutId!);
-          throw error;
-        }
-
-        log(`[MCPManager] Raw tools from ${config.name}:`, listToolsResult);
-
-        const sortedTools = [...listToolsResult.tools].sort((left, right) => {
-          const leftName = left.name || '';
-          const rightName = right.name || '';
-          if (leftName < rightName) {
-            return -1;
-          }
-          if (leftName > rightName) {
-            return 1;
-          }
-          return 0;
-        });
-
-        for (const tool of sortedTools) {
-          // OpenAI-compatible providers reject tool names that contain punctuation
-          // like dots or colons, so we expose a sanitized model-facing name while
-          // preserving the original MCP tool name for the actual call.
-          const serverKey = sanitizeMcpToolSegment(config.name, 'server');
-          const originalToolName =
-            typeof tool.name === 'string' && tool.name.trim().length > 0 ? tool.name : 'tool';
-          const sanitizedToolName = sanitizeMcpToolSegment(originalToolName, 'tool');
-          const prefixedName = createUniqueMcpToolName(
-            `mcp__${serverKey}__${sanitizedToolName}`,
-            usedToolNames
+          const listToolsResult = await raceWithTimeout(
+            client.listTools(),
+            timeoutMs,
+            `listTools timeout after ${timeoutMs}ms`
           );
 
-          newTools.set(prefixedName, {
-            name: prefixedName,
-            originalName: originalToolName,
-            description: tool.description || '',
-            inputSchema: {
-              type: 'object',
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              properties: (tool.inputSchema as any)?.properties || {},
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              required: (tool.inputSchema as any)?.required,
-            },
-            serverId,
-            serverName: config.name,
+          log(`[MCPManager] Raw tools from ${config.name}:`, listToolsResult);
+
+          // Sort alphabetically so dedup suffix assignment is deterministic
+          // across reconnects (otherwise session history can reference a name
+          // that later changes if the server returns tools in a new order).
+          const sortedTools = [...listToolsResult.tools].sort((left, right) => {
+            const leftName = left.name || '';
+            const rightName = right.name || '';
+            if (leftName < rightName) return -1;
+            if (leftName > rightName) return 1;
+            return 0;
+          });
+
+          // OpenAI-compatible providers reject tool names that contain
+          // punctuation like dots or colons, so we expose a sanitized
+          // model-facing name while preserving the original MCP tool name
+          // for the actual call.
+          const serverKey = sanitizeMcpToolSegment(config.name, 'server');
+          const usedToolNames = new Set<string>();
+          const tools = sortedTools.map((tool) => {
+            const originalToolName =
+              typeof tool.name === 'string' && tool.name.trim().length > 0
+                ? tool.name
+                : 'tool';
+            const sanitizedToolName = sanitizeMcpToolSegment(originalToolName, 'tool');
+            const prefixedName = createUniqueMcpToolName(
+              `mcp__${serverKey}__${sanitizedToolName}`,
+              usedToolNames
+            );
+            return {
+              name: prefixedName,
+              originalName: originalToolName,
+              description: tool.description || '',
+              inputSchema: {
+                type: 'object',
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                properties: (tool.inputSchema as any)?.properties || {},
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                required: (tool.inputSchema as any)?.required,
+              },
+              serverId,
+              serverName: config.name,
+            } satisfies MCPTool;
+          });
+
+          log(`[MCPManager] ✓ Loaded ${tools.length} tools from ${config.name}`);
+          return { kind: 'success' as const, serverId, tools };
+        } catch (error) {
+          return { kind: 'error' as const, serverId, error };
+        }
+      })
+    );
+
+    const newTools = new Map<string, MCPTool>();
+    for (const result of toolResults) {
+      if (result.kind === 'success') {
+        for (const tool of result.tools) {
+          newTools.set(tool.name, tool);
+        }
+        continue;
+      }
+
+      const error = result.error;
+      const errMsg = error instanceof Error ? error.message : String(error);
+      logError(`[MCPManager] ❌ Error listing tools from ${result.serverId}:`, errMsg);
+
+      try {
+        const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed());
+        if (win) {
+          win.webContents.send('server-event', {
+            type: 'mcp:tools-refresh-error',
+            payload: { serverId: result.serverId, error: errMsg },
           });
         }
+      } catch (_notifyErr) {
+        // Best-effort notification; logging already happened above
+      }
 
-        log(`[MCPManager] ✓ Loaded ${listToolsResult.tools.length} tools from ${config.name}`);
-      } catch (error: unknown) {
-        const errMsg = error instanceof Error ? error.message : String(error);
-        logError(`[MCPManager] ❌ Error listing tools from ${serverId}:`, errMsg);
-
-        // Notify renderer that tools refresh failed for this server
-        try {
-          const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed());
-          if (win) {
-            win.webContents.send('server-event', {
-              type: 'mcp:tools-refresh-error',
-              payload: { serverId, error: errMsg },
-            });
-          }
-        } catch (_notifyErr) {
-          // Best-effort notification; logging already happened above
-        }
-
-        // If Chrome server, try to reconnect
-        const config = this.serverConfigs.get(serverId);
-        if (config && config.name.toLowerCase().includes('chrome')) {
-          log(`[MCPManager] Chrome server may need reconnection. Trying to refresh...`);
-        }
+      const config = this.serverConfigs.get(result.serverId);
+      if (config && config.name.toLowerCase().includes('chrome')) {
+        log(`[MCPManager] Chrome server may need reconnection. Trying to refresh...`);
       }
     }
 
@@ -1538,6 +1563,7 @@ export class MCPManager {
     const maxRetries = 2;
     let lastError: unknown;
     let compatHotReloadTried = false;
+    const deadline = Date.now() + MCP_TOOL_CALL_TIMEOUT_MS;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       // Re-lookup tool on every iteration: after reconnect the registry is refreshed
@@ -1548,26 +1574,20 @@ export class MCPManager {
           throw new Error(`MCP server not connected: ${currentTool.serverId}`);
         }
 
-        // Complex MCP tools may legitimately need minutes to run.
-        const timeoutMs = MCP_TOOL_CALL_TIMEOUT_MS;
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          throw new Error(`Tool call timeout after ${MCP_TOOL_CALL_TIMEOUT_MS}ms`);
+        }
+
         const callPromise = client.callTool({
           name: actualToolName,
           arguments: args,
         });
-        let callTimeoutId: ReturnType<typeof setTimeout>;
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          callTimeoutId = setTimeout(
-            () => reject(new Error(`Tool call timeout after ${timeoutMs}ms`)),
-            timeoutMs
-          );
-        });
-
-        let result;
-        try {
-          result = await Promise.race([callPromise, timeoutPromise]);
-        } finally {
-          clearTimeout(callTimeoutId!);
-        }
+        const result = await raceWithTimeout(
+          callPromise,
+          remainingMs,
+          `Tool call timeout after ${MCP_TOOL_CALL_TIMEOUT_MS}ms`
+        );
 
         const toolErrorMessage = extractStructuredToolErrorMessage(result);
         if (shouldReconnectOnStructuredToolError(toolErrorMessage)) {
@@ -1625,9 +1645,16 @@ export class MCPManager {
         }
 
         if (errorMsg.includes('timeout')) {
-          log(`[MCPManager] Tool call timeout detected, retrying after backoff...`);
+          if (attempt >= maxRetries || deadline - Date.now() <= 0) {
+            break;
+          }
+          log(`[MCPManager] Tool call timeout detected, retrying within shared deadline...`);
           const delay = Math.min(2000 * Math.pow(1.5, attempt), 10000);
-          await new Promise((resolve) => setTimeout(resolve, delay));
+          const remainingAfterDelay = deadline - Date.now();
+          if (remainingAfterDelay <= 0) {
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, Math.min(delay, remainingAfterDelay)));
           continue;
         }
 

--- a/src/main/mcp/mcp-manager.ts
+++ b/src/main/mcp/mcp-manager.ts
@@ -22,6 +22,9 @@ import path from 'path';
 import { log, logError, logWarn, logCtx, logCtxError, logTiming } from '../utils/logger';
 import { getDefaultShell } from '../utils/shell-resolver';
 
+const MCP_LIST_TOOLS_TIMEOUT_MS = 5 * 60 * 1000;
+const MCP_TOOL_CALL_TIMEOUT_MS = 5 * 60 * 1000;
+
 /**
  * MCP Server Configuration
  */
@@ -1399,12 +1402,15 @@ export class MCPManager {
         const config = this.serverConfigs.get(serverId);
         if (!config) continue;
 
-        // Add timeout for listTools call to prevent hanging
-        const timeoutMs = 10000; // 10 second timeout
+        // Complex MCP servers can take minutes to enumerate their tools.
+        const timeoutMs = MCP_LIST_TOOLS_TIMEOUT_MS;
         const listToolsPromise = client.listTools();
         let timeoutId: ReturnType<typeof setTimeout>;
         const timeoutPromise = new Promise<never>((_, reject) => {
-          timeoutId = setTimeout(() => reject(new Error('listTools timeout after 10s')), timeoutMs);
+          timeoutId = setTimeout(
+            () => reject(new Error(`listTools timeout after ${timeoutMs}ms`)),
+            timeoutMs
+          );
         });
 
         log(`[MCPManager] Fetching tools from ${config.name} (timeout: ${timeoutMs}ms)...`);
@@ -1542,8 +1548,8 @@ export class MCPManager {
           throw new Error(`MCP server not connected: ${currentTool.serverId}`);
         }
 
-        // Add timeout for tool call
-        const timeoutMs = 30000; // 30 second timeout
+        // Complex MCP tools may legitimately need minutes to run.
+        const timeoutMs = MCP_TOOL_CALL_TIMEOUT_MS;
         const callPromise = client.callTool({
           name: actualToolName,
           arguments: args,

--- a/src/tests/mcp/mcp-manager.test.ts
+++ b/src/tests/mcp/mcp-manager.test.ts
@@ -32,6 +32,23 @@ vi.mock('../../main/utils/shell-resolver', () => ({
 import { MCPManager } from '../../main/mcp/mcp-manager';
 import type { MCPServerConfig } from '../../main/mcp/mcp-manager';
 
+type TestMCPClient = {
+  listTools?: () => Promise<{
+    tools: Array<{ name: string; description?: string; inputSchema?: unknown }>;
+  }>;
+  callTool?: (input: { name: string; arguments: Record<string, unknown> }) => Promise<unknown>;
+};
+
+type TestManagerInternals = {
+  clients: Map<string, TestMCPClient>;
+  tools: Map<string, unknown>;
+  serverConfigs: Map<string, MCPServerConfig>;
+};
+
+function asTestManager(manager: MCPManager): TestManagerInternals {
+  return manager as unknown as TestManagerInternals;
+}
+
 describe('MCPManager', () => {
   let manager: MCPManager;
 
@@ -140,6 +157,87 @@ describe('MCPManager', () => {
       expect(serverStatus).toBeDefined();
       expect(serverStatus!.status).toBe('failed');
       expect(serverStatus!.connected).toBe(false);
+    });
+
+    it('waits five minutes before timing out listTools for slow MCP servers', async () => {
+      vi.useFakeTimers();
+      const testManager = asTestManager(manager);
+      const mockClient: TestMCPClient = {
+        listTools: vi.fn(
+          () =>
+            new Promise<{
+              tools: Array<{
+                name: string;
+                inputSchema: { type: string; properties: Record<string, never> };
+              }>;
+            }>(() => {})
+        ),
+      };
+      testManager.clients = new Map([['slow-server', mockClient]]);
+      testManager.serverConfigs = new Map([
+        [
+          'slow-server',
+          {
+            id: 'slow-server',
+            name: 'Slow Server',
+            type: 'stdio',
+            command: 'slow-server',
+            enabled: true,
+          },
+        ],
+      ]);
+
+      let settled = false;
+      const refreshPromise = manager.refreshTools().then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(299999);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await refreshPromise;
+
+      expect(settled).toBe(true);
+      expect(mockClient.listTools).toHaveBeenCalledTimes(1);
+      expect(manager.getTools()).toEqual([]);
+      vi.useRealTimers();
+    });
+
+    it('retries slow tool calls with a five-minute timeout per attempt', async () => {
+      vi.useFakeTimers();
+      const testManager = asTestManager(manager);
+      const mockClient: TestMCPClient = {
+        callTool: vi.fn(() => new Promise<unknown>(() => {})),
+      };
+      testManager.clients = new Map([['server-1', mockClient]]);
+      testManager.tools = new Map([
+        [
+          'mcp__Slow_Server__inspect',
+          {
+            name: 'mcp__Slow_Server__inspect',
+            description: '',
+            inputSchema: { type: 'object', properties: {} },
+            serverId: 'server-1',
+            serverName: 'Slow Server',
+          },
+        ],
+      ]);
+
+      const callPromise = manager.callTool('mcp__Slow_Server__inspect', { pid: 1234 });
+
+      await vi.advanceTimersByTimeAsync(299999);
+      let settled = false;
+      callPromise.catch(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(605001);
+      await expect(callPromise).rejects.toThrow('Tool call timeout after 300000ms');
+      expect(mockClient.callTool).toHaveBeenCalledTimes(3);
+      vi.useRealTimers();
     });
   });
 

--- a/src/tests/mcp/mcp-manager.test.ts
+++ b/src/tests/mcp/mcp-manager.test.ts
@@ -204,7 +204,83 @@ describe('MCPManager', () => {
       vi.useRealTimers();
     });
 
-    it('retries slow tool calls with a five-minute timeout per attempt', async () => {
+    it('does not let a slow server block fast server tool discovery', async () => {
+      vi.useFakeTimers();
+      const testManager = asTestManager(manager);
+      const slowClient: TestMCPClient = {
+        listTools: vi.fn(
+          () =>
+            new Promise<{
+              tools: Array<{
+                name: string;
+                inputSchema: { type: string; properties: Record<string, never> };
+              }>;
+            }>(() => {})
+        ),
+      };
+      const fastClient: TestMCPClient = {
+        listTools: vi.fn().mockResolvedValue({
+          tools: [
+            {
+              name: 'inspect',
+              description: 'Fast tool',
+              inputSchema: { type: 'object', properties: {} },
+            },
+          ],
+        }),
+      };
+
+      testManager.clients = new Map([
+        ['slow-server', slowClient],
+        ['fast-server', fastClient],
+      ]);
+      testManager.serverConfigs = new Map([
+        [
+          'slow-server',
+          {
+            id: 'slow-server',
+            name: 'Slow Server',
+            type: 'stdio',
+            command: 'slow-server',
+            enabled: true,
+          },
+        ],
+        [
+          'fast-server',
+          {
+            id: 'fast-server',
+            name: 'Fast Server',
+            type: 'stdio',
+            command: 'fast-server',
+            enabled: true,
+          },
+        ],
+      ]);
+
+      const refreshPromise = manager.refreshTools();
+      await Promise.resolve();
+
+      expect(manager.getTools()).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(300000);
+      await refreshPromise;
+
+      expect(fastClient.listTools).toHaveBeenCalledTimes(1);
+      expect(slowClient.listTools).toHaveBeenCalledTimes(1);
+      expect(manager.getTools()).toEqual([
+        {
+          name: 'mcp__Fast_Server__inspect',
+          originalName: 'inspect',
+          description: 'Fast tool',
+          inputSchema: { type: 'object', properties: {}, required: undefined },
+          serverId: 'fast-server',
+          serverName: 'Fast Server',
+        },
+      ]);
+      vi.useRealTimers();
+    });
+
+    it('applies a shared five-minute deadline across tool-call retries', async () => {
       vi.useFakeTimers();
       const testManager = asTestManager(manager);
       const mockClient: TestMCPClient = {
@@ -234,9 +310,9 @@ describe('MCPManager', () => {
       await Promise.resolve();
       expect(settled).toBe(false);
 
-      await vi.advanceTimersByTimeAsync(605001);
+      await vi.advanceTimersByTimeAsync(1);
       await expect(callPromise).rejects.toThrow('Tool call timeout after 300000ms');
-      expect(mockClient.callTool).toHaveBeenCalledTimes(3);
+      expect(mockClient.callTool).toHaveBeenCalledTimes(1);
       vi.useRealTimers();
     });
   });


### PR DESCRIPTION
## Summary
- raise MCP tool discovery timeout to 5 minutes for slow or analysis-heavy servers
- align MCP tool execution timeout with the existing retry path so long-running tools are not cut off prematurely
- add fake-timer regression coverage for both slow listTools and slow callTool flows

## Testing
- npm run typecheck
- ./resources/node/darwin-arm64/bin/node ./node_modules/vitest/vitest.mjs run src/tests/mcp/mcp-manager.test.ts