### PR TITLE
[codex] Update roadmap for memory follow-ups

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,11 +16,11 @@
 - **CI/CD**: Automated builds, smoke tests, Codex-powered PR review bot
 - **Model Presets**: Up-to-date model catalogs for all major providers
 - **Dependency Policy**: Tiered management strategy with Dependabot grouping
+- **Memory System Foundation**: Unified storage with core/experience memory and source-aware retrieval workflow (PR #138)
 
 ## 🚧 In Progress
 
 - **v3.3.0 Stable Release**: Graduate from beta — all blocking issues resolved
-- **Memory System**: Unified storage with core/experience memory (PR #138 under review)
 
 ## 📋 Planned
 
@@ -29,8 +29,9 @@
 - **Sandbox Hardening**: Deep research and improvement of VM sandbox reliability, startup performance, and cross-platform consistency (Lima on macOS, WSL2 on Windows)
 - **App Slimming**: Reduce installer from ~156 MB to ~80 MB — on-demand Python/Node.js download, lazy-load Feishu SDK, strip unused files ([details](docs/SLIM-PLAN.md))
 - **Code Cleanup**: Split god files (index.ts 2672 lines, gui-operate-server.ts 6884 lines), lazy imports, dead code removal
+- **Naming Standardization**: Clean up 75+ legacy references (claude-sdk, claude-sandbox, claude-plugin, pi-coding-agent) to consistent Open Cowork naming conventions
 - **Tool Completeness**: Implement native TodoWrite, AskUserQuestion, Glob, Grep, WebFetch, WebSearch tool schemas + handlers for API key users
-- **Memory System**: Unified storage, prompt injection, cross-session retrieval, and source-aware reranking
+- **Memory System Enhancements**: Improve prompt injection controls, cross-session retrieval UX, memory source inspection, and source-aware reranking quality
 - **Scheduled Tasks**: Cron-like task scheduling with UI management and persistent execution
 - **Log Management**: Structured logging with rotation, size limits, and user-accessible log viewer improvements
 - **Installation Experience**: Smoother first-run — auto-detect system dependencies, clearer error messages, one-click setup
@@ -50,5 +51,5 @@
 
 ---
 
-_Last updated: 2026-04-18_
+_Last updated: 2026-05-01_
 _Want to contribute? Check our [Contributing Guide](CONTRIBUTING.md) and pick an issue labeled `good first issue`._


### PR DESCRIPTION
## Summary

- Mark the merged PR #138 memory foundation work as completed.
- Keep v3.4.0 memory work on the roadmap as follow-up enhancements around prompt injection controls, cross-session retrieval UX, source inspection, and reranking quality.
- Add the v3.4.0 naming standardization cleanup item for legacy Open Cowork references.

## Validation

- `git diff --check`
- Verified the stale `PR #138 under review` roadmap entry was removed.
