### PR TITLE
fix(bot): fall back when ripgrep is unavailable

### DIFF
--- a/.github/scripts/deepseek-common.mjs
+++ b/.github/scripts/deepseek-common.mjs
@@ -72,6 +72,10 @@ function formatCommandError(command, args, error) {
   return `${command} ${args.join(' ')} failed: ${details}`.trim();
 }
 
+function isMissingExecutable(error) {
+  return error?.code === 'ENOENT' || String(error?.message || '').includes('ENOENT');
+}
+
 export function runGh(args, options = {}) {
   try {
     return execFileSync('gh', args, {
@@ -86,6 +90,77 @@ export function runGh(args, options = {}) {
   }
 }
 
+function buildGitGrepArgsFromRgArgs(args) {
+  const gitArgs = ['grep'];
+  const pathspecs = [];
+  let hasPattern = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case '-n':
+      case '--line-number':
+      case '-F':
+      case '--fixed-strings':
+        gitArgs.push(arg);
+        break;
+      case '--max-count':
+        if (args[index + 1]) {
+          gitArgs.push(arg, args[index + 1]);
+          index += 1;
+        }
+        break;
+      case '-e':
+        if (args[index + 1] !== undefined) {
+          gitArgs.push(arg, args[index + 1]);
+          hasPattern = true;
+          index += 1;
+        }
+        break;
+      case '--glob': {
+        const glob = args[index + 1];
+        if (glob) {
+          pathspecs.push(glob.startsWith('!') ? `:!${glob.slice(1)}` : glob);
+          index += 1;
+        }
+        break;
+      }
+      default:
+        if (arg && !arg.startsWith('-')) {
+          pathspecs.push(arg);
+        }
+        break;
+    }
+  }
+
+  if (!hasPattern) {
+    return null;
+  }
+
+  return [...gitArgs, '--', ...(pathspecs.length > 0 ? pathspecs : ['.'])];
+}
+
+function runGitGrepFallback(rgArgs) {
+  const gitArgs = buildGitGrepArgsFromRgArgs(rgArgs);
+  if (!gitArgs) {
+    return '';
+  }
+
+  try {
+    return execFileSync('git', gitArgs, {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      maxBuffer: 10 * 1024 * 1024,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    if (error.status === 1 || isMissingExecutable(error)) {
+      return '';
+    }
+    throw new Error(formatCommandError('git', gitArgs, error));
+  }
+}
+
 export function runRg(args) {
   try {
     return execFileSync('rg', args, {
@@ -97,6 +172,9 @@ export function runRg(args) {
   } catch (error) {
     if (error.status === 1) {
       return '';
+    }
+    if (isMissingExecutable(error)) {
+      return runGitGrepFallback(args);
     }
     throw new Error(formatCommandError('rg', args, error));
   }
@@ -391,6 +469,8 @@ export function searchRepoSnippets(seedText, maxLines = 30) {
     '!dist-mcp/**',
     '--glob',
     '!website/**',
+    '--glob',
+    '!.claude/**',
     '.'
   );
 

--- a/tests/deepseek-common.test.ts
+++ b/tests/deepseek-common.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function importCommonWithExecFileSync(execFileSync: ReturnType<typeof vi.fn>) {
+  vi.resetModules();
+  vi.doMock('node:child_process', () => ({ execFileSync }));
+  return import('../.github/scripts/deepseek-common.mjs');
+}
+
+function missingCommandError(command: string): NodeJS.ErrnoException {
+  const error = new Error(`spawnSync ${command} ENOENT`) as NodeJS.ErrnoException;
+  error.code = 'ENOENT';
+  return error;
+}
+
+describe('deepseek-common runRg', () => {
+  afterEach(() => {
+    vi.doUnmock('node:child_process');
+    vi.resetModules();
+  });
+
+  it('falls back to git grep when ripgrep is not installed', async () => {
+    const execFileSync = vi.fn((command: string, args: string[]) => {
+      if (command === 'rg') {
+        throw missingCommandError('rg');
+      }
+      if (command === 'git') {
+        expect(args).toEqual([
+          'grep',
+          '-n',
+          '-F',
+          '--max-count',
+          '2',
+          '-e',
+          'Roadmap',
+          '--',
+          ':!node_modules/**',
+          '.',
+        ]);
+        return 'ROADMAP.md:1:# Open Cowork Roadmap\n';
+      }
+      throw new Error(`unexpected command: ${command}`);
+    });
+
+    const { runRg } = await importCommonWithExecFileSync(execFileSync);
+
+    expect(
+      runRg(['-n', '-F', '--max-count', '2', '-e', 'Roadmap', '--glob', '!node_modules/**', '.'])
+    ).toBe('ROADMAP.md:1:# Open Cowork Roadmap');
+  });
+
+  it('returns no snippets when ripgrep and git grep are both unavailable', async () => {
+    const execFileSync = vi.fn((command: string) => {
+      throw missingCommandError(command);
+    });
+
+    const { runRg } = await importCommonWithExecFileSync(execFileSync);
+
+    expect(runRg(['-n', '-F', '-e', 'Roadmap', '.'])).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- Add a `git grep` fallback when the DeepSeek bot helper cannot spawn `rg`.
- Keep missing snippet search tools non-fatal so issue auto-response can continue with issue metadata and docs.
- Exclude tracked `.claude/**` content from repo snippet searches to better match ripgrep's default hidden-directory behavior.
- Add targeted tests for missing `rg` and missing fallback search tools.

## Root Cause

The Issue Auto Response workflow failed before reaching DeepSeek because GitHub's runner did not have `rg` installed:

```text
spawnSync rg ENOENT
```

## Validation

- `npx vitest run tests/deepseek-common.test.ts`
- Simulated `PATH` with `git` but without `rg` and verified `searchRepoSnippets()` returns snippets without `.claude/**` entries
- `git diff --check`
- `node --check .github/scripts/deepseek-common.mjs`
- `npm run lint` (passes with existing warnings)
