### PR TITLE
fix: render KaTeX math in messages

### DIFF
--- a/src/renderer/components/MessageMarkdown.tsx
+++ b/src/renderer/components/MessageMarkdown.tsx
@@ -7,11 +7,11 @@ import rehypeKatex from 'rehype-katex';
 
 // Hoisted to module scope to avoid re-creating arrays on every render
 const REMARK_PLUGINS = [remarkMath, [remarkGfm, { singleTilde: false }]] as const;
-// rehypeKatex must run BEFORE rehypeSanitize so that KaTeX output is generated
-// first, then sanitized — the reverse order strips KaTeX markup before it renders.
+// Sanitize user-authored HTML before KaTeX expands math nodes. Running
+// rehypeSanitize after rehypeKatex strips the generated KaTeX markup/classes.
 const REHYPE_PLUGINS = [
-  [rehypeKatex, { throwOnError: false, strict: false }],
   rehypeSanitize,
+  [rehypeKatex, { throwOnError: false, strict: false }],
 ] as const;
 
 export interface MessageMarkdownProps {

--- a/tests/message-markdown-katex.test.ts
+++ b/tests/message-markdown-katex.test.ts
@@ -1,0 +1,26 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { MessageMarkdown } from '../src/renderer/components/MessageMarkdown';
+
+describe('MessageMarkdown KaTeX rendering', () => {
+  it('renders inline math as KaTeX markup', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(MessageMarkdown, { normalizedText: '$E=mc^2$' })
+    );
+
+    expect(html).toContain('katex');
+    expect(html).toContain('math');
+    expect(html).not.toContain('$E=mc^2$');
+  });
+
+  it('renders display math as KaTeX markup', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(MessageMarkdown, { normalizedText: '$$\n\\int_0^1 f(x)dx\n$$' })
+    );
+
+    expect(html).toContain('katex-display');
+    expect(html).toContain('katex');
+    expect(html).not.toContain('$$\n\\int_0^1 f(x)dx\n$$');
+  });
+});


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. Link related issues with "Fixes #NNN" or "Closes #NNN". -->

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Refactor / performance (`refactor` / `perf`)
- [ ] Documentation (`docs`)
- [ ] Tests (`test`)
- [ ] Build / CI (`build` / `ci`)
- [ ] Other: <!-- describe -->

## Checklist

- [ ] Code follows the project style (TypeScript strict, ESLint, Prettier)
- [ ] Commit messages follow Conventional Commits (`feat:`, `fix:`, etc.)
- [ ] Self-review completed — no debug logs, no commented-out code
- [ ] Tests added or updated for the changed behaviour
- [ ] `npm run test` passes locally
- [ ] `npm run lint` passes locally
- [ ] UI changes tested on both macOS and Windows (or noted as platform-specific)
- [ ] New user-facing strings added to i18n files (`en` + `zh`)

## Testing

<!-- Describe how you tested this change. Include steps to reproduce the scenario. -->

## Screenshots / recordings (if applicable)

<!-- Attach screenshots or screen recordings for UI changes. -->
