### PR TITLE
fix(markdown): allow math class tokens through rehype-sanitize for KaTeX

### DIFF
--- a/src/renderer/components/MessageMarkdown.tsx
+++ b/src/renderer/components/MessageMarkdown.tsx
@@ -2,15 +2,31 @@ import { memo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkMath from 'remark-math';
 import remarkGfm from 'remark-gfm';
-import rehypeSanitize from 'rehype-sanitize';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeKatex from 'rehype-katex';
 
 // Hoisted to module scope to avoid re-creating arrays on every render
 const REMARK_PLUGINS = [remarkMath, [remarkGfm, { singleTilde: false }]] as const;
-// Sanitize user-authored HTML before KaTeX expands math nodes. Running
-// rehypeSanitize after rehypeKatex strips the generated KaTeX markup/classes.
+
+// remark-math emits <code class="language-math math-inline"> (inline) and
+// <pre><code class="language-math math-display"> (display). The default schema
+// allows only /^language-./ on <code>, stripping the math-* tokens before
+// rehypeKatex processes them.
+const mathSanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    // Merged into one tuple — findDefinition returns the first match per key,
+    // so a second ['className', ...] entry would be silently ignored.
+    code: [['className', /^language-./, 'math-inline', 'math-display']],
+  },
+};
+
+// NOTE: rehypeSanitize runs BEFORE rehypeKatex — KaTeX output is unsanitized.
+// Safe while trust is false (default), which disables \href, \htmlClass, etc.
+// If KaTeX trust is ever enabled, add a second sanitize pass.
 const REHYPE_PLUGINS = [
-  rehypeSanitize,
+  [rehypeSanitize, mathSanitizeSchema],
   [rehypeKatex, { throwOnError: false, strict: false }],
 ] as const;
 

--- a/tests/message-markdown-katex.test.ts
+++ b/tests/message-markdown-katex.test.ts
@@ -10,7 +10,7 @@ describe('MessageMarkdown KaTeX rendering', () => {
     );
 
     expect(html).toContain('katex');
-    expect(html).toContain('math');
+    expect(html).toContain('katex-html');
     expect(html).not.toContain('$E=mc^2$');
   });
 


### PR DESCRIPTION
## Summary

Fixes #158.

PR #187 moved `rehypeSanitize` before `rehypeKatex`, which is the right order — but the default `rehype-sanitize` schema strips the `math-inline` and `math-display` class tokens that `remark-math` injects onto `<code>` elements, so `rehypeKatex` still finds nothing to process. The tests added in #187 are still failing on `main` for this reason. This PR fixes the schema so those tokens survive sanitization.

`remark-math` converts `$...$` and `$$...$$` into `<code class="language-math math-inline">` and `<pre><code class="language-math math-display">` in the rehype AST. The default schema allows only `/^language-./` on `<code>` — `language-math` survives, but `math-inline` and `math-display` are stripped. Fix: replace the `code` className definition with a single merged tuple that preserves all three tokens.

## Type of change

- [x] Bug fix (`fix`)

## Checklist

- [x] Code follows the project style (TypeScript strict, ESLint, Prettier)
- [x] Commit messages follow Conventional Commits
- [x] Self-review completed — no debug logs, no commented-out code
- [x] Tests pass — `tests/message-markdown-katex.test.ts` (added in #187) covers inline and display math; both tests were failing on `main` before this change
- [x] `npm run lint` passes locally
- [x] `npx tsc --noEmit` passes locally
- [ ] UI changes tested on macOS/Windows — verified via `renderToStaticMarkup` tests; not run in the Electron app
- [ ] New i18n strings — N/A

## Testing

```bash
npx vitest run tests/message-markdown-katex.test.ts
```