### PR TITLE
fix: route OpenAI Responses and Gemini diagnostics

### DIFF
--- a/src/main/claude/pi-model-resolution.ts
+++ b/src/main/claude/pi-model-resolution.ts
@@ -70,6 +70,18 @@ function shouldDisableDeveloperRoleForEndpoint(
   return true;
 }
 
+function shouldPreserveOpenAIResponsesApi(
+  model: Model<Api>,
+  options: PiModelLookupOptions
+): boolean {
+  if (model.api !== 'openai-responses') {
+    return false;
+  }
+
+  const endpoint = options.customBaseUrl?.trim() || model.baseUrl?.trim();
+  return !endpoint || isOfficialOpenAIBaseUrl(endpoint);
+}
+
 export function inferPiApi(protocol: string): string {
   switch (protocol) {
     case 'anthropic':
@@ -269,7 +281,12 @@ export function applyPiModelRuntimeOverrides(
   }
 
   const effectiveProvider = options.rawProvider || options.configProvider;
-  if (options.customBaseUrl && isCustomProvider && nextModel.api === 'openai-responses') {
+  if (
+    options.customBaseUrl &&
+    isCustomProvider &&
+    nextModel.api === 'openai-responses' &&
+    !shouldPreserveOpenAIResponsesApi(nextModel, options)
+  ) {
     // Most custom OpenAI-compatible relays only implement chat/completions.
     nextModel = { ...nextModel, api: 'openai-completions' } as typeof nextModel;
   }
@@ -328,7 +345,7 @@ export function applyPiModelRuntimeOverrides(
   // Handle custom provider with explicit protocol override
   if (isCustomProvider && options.customProtocol) {
     const targetApi = inferPiApi(options.customProtocol);
-    if (nextModel.api !== targetApi) {
+    if (nextModel.api !== targetApi && !shouldPreserveOpenAIResponsesApi(nextModel, options)) {
       nextModel = { ...nextModel, api: targetApi } as typeof nextModel;
     }
   }

--- a/src/main/config/api-diagnostics.ts
+++ b/src/main/config/api-diagnostics.ts
@@ -145,11 +145,19 @@ export function isLikelyAuthFailure(error: { status?: number; message: string })
 
   const message = error.message.toLowerCase();
   return (
-    /api\s*key.*not\s*valid|invalid.*api\s*key|api\s*key.*invalid|unauthorized|forbidden|permission\s*denied/.test(
+    /api\s*key.*(?:not\s*valid|invalid)|invalid.*api\s*key|unauthorized|forbidden|permission\s*denied/.test(
       message
     ) ||
     (error.status === 400 && /api\s*key|auth|credential|permission/.test(message))
   );
+}
+
+function isGeminiModelsGetProbeUnavailable(error: { status?: number; message: string }): boolean {
+  if (error.status !== undefined) {
+    return false;
+  }
+
+  return /models\.get|reading ['"]get['"]|reading get/i.test(error.message);
 }
 
 export function shouldContinueAfterGeminiAuthProbeError(error: {
@@ -164,7 +172,7 @@ export function shouldContinueAfterGeminiAuthProbeError(error: {
     return false;
   }
 
-  return error.status === undefined;
+  return isGeminiModelsGetProbeUnavailable(error);
 }
 
 function getModelDiagnosticFix(

--- a/src/main/config/api-diagnostics.ts
+++ b/src/main/config/api-diagnostics.ts
@@ -138,6 +138,35 @@ function getApiErrorInfo(err: unknown): { status?: number; message: string } {
   return { message: String(err) };
 }
 
+export function isLikelyAuthFailure(error: { status?: number; message: string }): boolean {
+  if (error.status === 401 || error.status === 403) {
+    return true;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    /api\s*key.*not\s*valid|invalid.*api\s*key|api\s*key.*invalid|unauthorized|forbidden|permission\s*denied/.test(
+      message
+    ) ||
+    (error.status === 400 && /api\s*key|auth|credential|permission/.test(message))
+  );
+}
+
+export function shouldContinueAfterGeminiAuthProbeError(error: {
+  status?: number;
+  message: string;
+}): boolean {
+  if (error.status === 404) {
+    return true;
+  }
+
+  if (isLikelyAuthFailure(error)) {
+    return false;
+  }
+
+  return error.status === undefined;
+}
+
 function getModelDiagnosticFix(
   errorType: Awaited<ReturnType<typeof probeWithClaudeSdk>>['errorType'],
   model: string
@@ -346,18 +375,16 @@ async function stepAuth(input: DiagnosticInput, step: DiagnosticStep): Promise<v
       step.status = 'ok';
     } catch (err) {
       const e = getApiErrorInfo(err);
-      if (e.status === 404) {
-        // Custom Gemini proxy may not implement models.get — treat like OpenAI 404 path
+      if (shouldContinueAfterGeminiAuthProbeError(e)) {
+        // Some SDK/proxy combinations do not support the lightweight models.get
+        // endpoint. Continue to the live model probe, which exercises inference.
         step.status = 'ok';
-        step.fix = 'models_get_not_supported';
-        log(
-          '[Diagnostics] Gemini auth: models.get returned 404 — proxy may not support this endpoint, continuing to model check'
-        );
+        step.fix = e.status === 404 ? 'models_get_not_supported' : 'gemini_auth_probe_unavailable';
+        log('[Diagnostics] Gemini auth probe unavailable, continuing to model check:', e.message);
       } else {
         step.status = 'fail';
         step.error = e.message;
-        step.fix =
-          e.status === 401 || e.status === 403 ? 'auth_invalid_key' : 'auth_request_failed';
+        step.fix = isLikelyAuthFailure(e) ? 'auth_invalid_key' : 'auth_request_failed';
       }
     }
 

--- a/src/tests/claude/pi-model-resolution.test.ts
+++ b/src/tests/claude/pi-model-resolution.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { Api, Model } from '@mariozechner/pi-ai';
+import {
+  applyPiModelRuntimeOverrides,
+  resolvePiRegistryModel,
+} from '../../main/claude/pi-model-resolution';
+
+const openAIResponsesModel = {
+  id: 'gpt-5.4',
+  name: 'GPT-5.4',
+  api: 'openai-responses',
+  provider: 'openai',
+  baseUrl: 'https://api.openai.com/v1',
+  reasoning: true,
+  input: ['text', 'image'],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128000,
+  maxTokens: 16384,
+} as Model<Api>;
+
+describe('pi model runtime overrides', () => {
+  it('keeps OpenAI Responses for custom OpenAI configs that target official OpenAI', () => {
+    const model = resolvePiRegistryModel('openai/gpt-5.4', {
+      configProvider: 'openai',
+      rawProvider: 'custom',
+      customProtocol: 'openai',
+      customBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    expect(model?.api).toBe('openai-responses');
+    expect(model?.baseUrl).toBe('https://api.openai.com/v1');
+  });
+
+  it('still downgrades Responses models for generic custom OpenAI-compatible relays', () => {
+    const model = applyPiModelRuntimeOverrides(openAIResponsesModel, {
+      configProvider: 'openai',
+      rawProvider: 'custom',
+      customProtocol: 'openai',
+      customBaseUrl: 'https://relay.example.test/v1',
+    });
+
+    expect(model.api).toBe('openai-completions');
+    expect(model.baseUrl).toBe('https://relay.example.test/v1');
+    expect(model.compat).toMatchObject({
+      supportsDeveloperRole: false,
+      supportsStore: false,
+    });
+  });
+});

--- a/src/tests/config/api-diagnostics.test.ts
+++ b/src/tests/config/api-diagnostics.test.ts
@@ -20,6 +20,14 @@ describe('Gemini diagnostics auth probe handling', () => {
     ).toBe(true);
   });
 
+  it('does not continue when the auth probe fails with a network error', () => {
+    expect(
+      shouldContinueAfterGeminiAuthProbeError({
+        message: 'fetch failed',
+      })
+    ).toBe(false);
+  });
+
   it('does not continue past likely credential failures', () => {
     const invalidKey = {
       status: 400,

--- a/src/tests/config/api-diagnostics.test.ts
+++ b/src/tests/config/api-diagnostics.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isLikelyAuthFailure,
+  shouldContinueAfterGeminiAuthProbeError,
+} from '../../main/config/api-diagnostics';
+
+describe('Gemini diagnostics auth probe handling', () => {
+  it('continues to model verification when the lightweight models.get probe is unavailable', () => {
+    expect(
+      shouldContinueAfterGeminiAuthProbeError({
+        message: "Cannot read properties of undefined (reading 'get')",
+      })
+    ).toBe(true);
+
+    expect(
+      shouldContinueAfterGeminiAuthProbeError({
+        status: 404,
+        message: 'not found',
+      })
+    ).toBe(true);
+  });
+
+  it('does not continue past likely credential failures', () => {
+    const invalidKey = {
+      status: 400,
+      message: 'API key not valid. Please pass a valid API key.',
+    };
+
+    expect(isLikelyAuthFailure(invalidKey)).toBe(true);
+    expect(shouldContinueAfterGeminiAuthProbeError(invalidKey)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve `openai-responses` routing for official OpenAI GPT-5.x models when configured through Custom > OpenAI, so GPT-5.4 does not get forced through `/chat/completions`.
- Let Gemini diagnostics continue to the live model check when the lightweight `models.get` auth probe is unavailable, while still failing fast for likely invalid API keys.
- Add focused tests for the OpenAI routing and Gemini diagnostic fallback behavior.

## Validation
- `npx vitest run src/tests/claude/pi-model-resolution.test.ts src/tests/config/api-diagnostics.test.ts src/tests/claude/claude-sdk-one-shot.test.ts src/tests/config/auth-utils.test.ts`
- `npm run lint`
- `npm run typecheck`

## Notes
- Full `npx vitest run` is not clean on this Windows/Node 24 local environment because existing tests depend on Ubuntu/Node 22 behavior (`better-sqlite3` native binding before rebuild, Windows path expectations, symlink privileges, and Node 24 `fs.rmSync(file)` behavior). CI runs Ubuntu + Node 22 and rebuilds `better-sqlite3`.

Closes #193
Closes #195