### PR TITLE
Fix Windows bash tool process leaks

### DIFF
--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -17,6 +17,7 @@ import {
   SessionManager as PiSessionManager,
   SettingsManager as PiSettingsManager,
   createCodingTools,
+  type BashToolOptions,
   type AgentSession as PiAgentSession,
   type ToolDefinition,
 } from '@mariozechner/pi-coding-agent';
@@ -67,6 +68,7 @@ import {
   normalizeToolExecutionResultForUi,
 } from './tool-result-utils';
 import { fetchOllamaModelInfo } from '../config/ollama-api';
+import { createWindowsBashOperations } from './windows-bash-operations';
 
 // Virtual workspace path shown to the model (hides real sandbox path)
 const VIRTUAL_WORKSPACE_PATH = '/workspace';
@@ -527,7 +529,9 @@ ${hints.join('\n')}
   }
 
   private async resolveSkillPaths(sessionId?: string): Promise<string[]> {
-    const basePaths = this._skillsAdapter ? this._skillsAdapter.getSkillPaths() : this.legacySkillPaths();
+    const basePaths = this._skillsAdapter
+      ? this._skillsAdapter.getSkillPaths()
+      : this.legacySkillPaths();
     const mergedPaths = new Set(
       basePaths.filter((item): item is string => Boolean(item && fs.existsSync(item)))
     );
@@ -1566,7 +1570,10 @@ ${hints.join('\n')}
         try {
           cachedSession.session.dispose();
         } catch (disposeError) {
-          logWarn('[ClaudeAgentRunner] dispose error while recreating pi session for skills:', disposeError);
+          logWarn(
+            '[ClaudeAgentRunner] dispose error while recreating pi session for skills:',
+            disposeError
+          );
         }
         this.piSessions.delete(session.id);
         cachedSession = undefined;
@@ -1863,7 +1870,12 @@ Tool routing:
       // executed via Pi SDK's Bash tool can find bundled and user-installed executables.
       await enrichProcessPathForBuild();
 
-      const codingTools = createCodingTools(effectiveCwd);
+      const bashOptions: BashToolOptions | undefined =
+        process.platform === 'win32' ? { operations: createWindowsBashOperations() } : undefined;
+      const codingTools = createCodingTools(
+        effectiveCwd,
+        bashOptions ? { bash: bashOptions } : undefined
+      );
 
       // Inject a default 120s timeout for bash commands when the model omits one
       const withTimeout = ClaudeAgentRunner.wrapBashToolWithDefaultTimeout(

--- a/src/main/claude/windows-bash-operations.ts
+++ b/src/main/claude/windows-bash-operations.ts
@@ -1,0 +1,244 @@
+import { existsSync } from 'fs';
+import path from 'path';
+import { spawn, type ChildProcess, type SpawnOptions } from 'child_process';
+import {
+  SettingsManager as PiSettingsManager,
+  type BashOperations,
+} from '@mariozechner/pi-coding-agent';
+import { getDefaultShell } from '../utils/shell-resolver';
+
+const DEFAULT_TERMINATION_GRACE_MS = 5000;
+const DEFAULT_TASKKILL_WAIT_MS = 3000;
+
+type SpawnProcess = (command: string, args: string[], options: SpawnOptions) => ChildProcess;
+
+export interface WindowsShellInvocation {
+  shell: string;
+  args: string[];
+}
+
+export interface WindowsBashOperationsOptions {
+  spawnProcess?: SpawnProcess;
+  shellResolver?: (cwd: string) => string;
+  terminationGraceMs?: number;
+  taskkillWaitMs?: number;
+}
+
+function normalizeShellPath(shellPath: string): string {
+  const trimmed = shellPath.trim();
+  const quoted = trimmed.match(/^"(.+)"$/);
+  return quoted ? quoted[1] : trimmed;
+}
+
+function defaultShellResolver(cwd: string): string {
+  try {
+    const configuredShell = PiSettingsManager.create(cwd).getShellPath();
+    return configuredShell ? normalizeShellPath(configuredShell) : getDefaultShell();
+  } catch {
+    return getDefaultShell();
+  }
+}
+
+export function buildWindowsShellInvocation(
+  command: string,
+  shellPath = getDefaultShell()
+): WindowsShellInvocation {
+  const shell = normalizeShellPath(shellPath);
+  const shellName = path.win32.basename(shell).toLowerCase();
+
+  if (shellName === 'cmd' || shellName === 'cmd.exe') {
+    return { shell, args: ['/d', '/s', '/c', command] };
+  }
+
+  if (
+    shellName === 'powershell' ||
+    shellName === 'powershell.exe' ||
+    shellName === 'pwsh' ||
+    shellName === 'pwsh.exe'
+  ) {
+    return {
+      shell,
+      args: [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        command,
+      ],
+    };
+  }
+
+  return { shell, args: ['-c', command] };
+}
+
+function createSpawnProcess(): SpawnProcess {
+  return (command, args, options) => spawn(command, args, options);
+}
+
+async function waitForProcessClose(child: ChildProcess, timeoutMs: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    let settled = false;
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutHandle);
+      child.off('close', finish);
+      child.off('error', finish);
+      resolve();
+    };
+
+    child.once('close', finish);
+    child.once('error', finish);
+    const timeoutHandle = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        // Ignore cleanup failures; the caller is already terminating a process tree.
+      }
+      finish();
+    }, timeoutMs);
+    timeoutHandle.unref?.();
+  });
+}
+
+async function killWindowsProcessTree(
+  pid: number,
+  spawnProcess: SpawnProcess,
+  taskkillWaitMs: number
+): Promise<void> {
+  try {
+    const taskkill = spawnProcess('taskkill', ['/F', '/T', '/PID', String(pid)], {
+      detached: false,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    await waitForProcessClose(taskkill, taskkillWaitMs);
+  } catch {
+    try {
+      process.kill(pid);
+    } catch {
+      // Process may already be gone.
+    }
+  }
+}
+
+export function createWindowsBashOperations(
+  options: WindowsBashOperationsOptions = {}
+): BashOperations {
+  const spawnProcess = options.spawnProcess ?? createSpawnProcess();
+  const shellResolver = options.shellResolver ?? defaultShellResolver;
+  const terminationGraceMs = options.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS;
+  const taskkillWaitMs = options.taskkillWaitMs ?? DEFAULT_TASKKILL_WAIT_MS;
+
+  return {
+    exec: (command, cwd, { onData, signal, timeout, env }) =>
+      new Promise((resolve, reject) => {
+        if (!existsSync(cwd)) {
+          reject(
+            new Error(`Working directory does not exist: ${cwd}\nCannot execute bash commands.`)
+          );
+          return;
+        }
+
+        if (signal?.aborted) {
+          reject(new Error('aborted'));
+          return;
+        }
+
+        const { shell, args } = buildWindowsShellInvocation(command, shellResolver(cwd));
+        const child = spawnProcess(shell, args, {
+          cwd,
+          detached: false,
+          env: env ?? process.env,
+          stdio: ['ignore', 'pipe', 'pipe'],
+          windowsHide: true,
+        });
+
+        let settled = false;
+        let timedOut = false;
+        let timeoutHandle: NodeJS.Timeout | undefined;
+        let forcedSettleHandle: NodeJS.Timeout | undefined;
+
+        const cleanup = () => {
+          if (timeoutHandle) clearTimeout(timeoutHandle);
+          if (forcedSettleHandle) clearTimeout(forcedSettleHandle);
+          child.stdout?.off('data', onData);
+          child.stderr?.off('data', onData);
+          child.off('close', onClose);
+          child.off('error', onError);
+          signal?.removeEventListener('abort', onAbort);
+        };
+
+        const settleResolve = (value: { exitCode: number | null }) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          resolve(value);
+        };
+
+        const settleReject = (error: Error) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          reject(error);
+        };
+
+        const terminateChild = (reason: 'aborted' | 'timeout') => {
+          if (child.pid) {
+            void killWindowsProcessTree(child.pid, spawnProcess, taskkillWaitMs);
+          } else {
+            try {
+              child.kill();
+            } catch {
+              // Ignore cleanup failures; the close/error path will settle or the grace timer will.
+            }
+          }
+
+          forcedSettleHandle = setTimeout(() => {
+            settleReject(
+              reason === 'timeout' ? new Error(`timeout:${timeout}`) : new Error('aborted')
+            );
+          }, terminationGraceMs);
+          forcedSettleHandle.unref?.();
+        };
+
+        function onClose(code: number | null) {
+          if (signal?.aborted) {
+            settleReject(new Error('aborted'));
+            return;
+          }
+          if (timedOut) {
+            settleReject(new Error(`timeout:${timeout}`));
+            return;
+          }
+          settleResolve({ exitCode: code });
+        }
+
+        function onError(error: Error) {
+          settleReject(error);
+        }
+
+        function onAbort() {
+          terminateChild('aborted');
+        }
+
+        child.stdout?.on('data', onData);
+        child.stderr?.on('data', onData);
+        child.once('close', onClose);
+        child.once('error', onError);
+
+        if (timeout !== undefined && timeout > 0) {
+          timeoutHandle = setTimeout(() => {
+            timedOut = true;
+            terminateChild('timeout');
+          }, timeout * 1000);
+          timeoutHandle.unref?.();
+        }
+
+        signal?.addEventListener('abort', onAbort, { once: true });
+      }),
+  };
+}

--- a/src/tests/claude/windows-bash-operations.test.ts
+++ b/src/tests/claude/windows-bash-operations.test.ts
@@ -1,0 +1,152 @@
+import { EventEmitter } from 'events';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import type { ChildProcess, SpawnOptions } from 'child_process';
+import {
+  buildWindowsShellInvocation,
+  createWindowsBashOperations,
+} from '../../main/claude/windows-bash-operations';
+
+class FakeChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn();
+
+  constructor(readonly pid?: number) {
+    super();
+  }
+}
+
+function createSpawnMock(children: FakeChildProcess[]) {
+  return vi.fn((command: string, args: string[], _options: SpawnOptions) => {
+    const child = children.shift();
+    if (!child) throw new Error(`Unexpected spawn: ${command} ${args.join(' ')}`);
+    return Object.assign(child, {
+      spawnargs: [command, ...args],
+      spawnfile: command,
+      killed: false,
+      connected: false,
+      exitCode: null,
+      signalCode: null,
+    }) as unknown as ChildProcess;
+  });
+}
+
+describe('windows bash operations', () => {
+  it('uses platform-correct shell arguments for common Windows shells', () => {
+    expect(buildWindowsShellInvocation('dir', 'C:\\Windows\\System32\\cmd.exe')).toEqual({
+      shell: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'dir'],
+    });
+
+    expect(buildWindowsShellInvocation('Write-Output hi', 'pwsh.exe')).toEqual({
+      shell: 'pwsh.exe',
+      args: [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        'Write-Output hi',
+      ],
+    });
+
+    expect(buildWindowsShellInvocation('echo hi', 'C:\\Program Files\\Git\\bin\\bash.exe')).toEqual(
+      {
+        shell: 'C:\\Program Files\\Git\\bin\\bash.exe',
+        args: ['-c', 'echo hi'],
+      }
+    );
+  });
+
+  it('spawns Windows shell commands without detaching the child process', async () => {
+    const child = new FakeChildProcess(1234);
+    const spawnProcess = createSpawnMock([child]);
+    const onData = vi.fn();
+    const ops = createWindowsBashOperations({
+      spawnProcess,
+      shellResolver: () => 'C:\\Windows\\System32\\cmd.exe',
+    });
+
+    const promise = ops.exec('echo hello', process.cwd(), {
+      onData,
+      env: { PATH: 'test-path' },
+    });
+    const output = Buffer.from('hello');
+    child.stdout.emit('data', output);
+    child.emit('close', 0);
+
+    await expect(promise).resolves.toEqual({ exitCode: 0 });
+    expect(onData).toHaveBeenCalledWith(output);
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'C:\\Windows\\System32\\cmd.exe',
+      ['/d', '/s', '/c', 'echo hello'],
+      expect.objectContaining({
+        cwd: process.cwd(),
+        detached: false,
+        env: { PATH: 'test-path' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+      })
+    );
+  });
+
+  it('kills the Windows process tree and rejects when a command times out', async () => {
+    vi.useFakeTimers();
+    try {
+      const child = new FakeChildProcess(4321);
+      const taskkill = new FakeChildProcess(9876);
+      const spawnProcess = createSpawnMock([child, taskkill]);
+      const ops = createWindowsBashOperations({
+        spawnProcess,
+        shellResolver: () => 'cmd.exe',
+        taskkillWaitMs: 10,
+        terminationGraceMs: 10,
+      });
+
+      const promise = ops.exec('node server.js', process.cwd(), {
+        onData: vi.fn(),
+        timeout: 1,
+      });
+      const result = promise.then(
+        () => undefined,
+        (error: Error) => error
+      );
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(spawnProcess).toHaveBeenNthCalledWith(
+        2,
+        'taskkill',
+        ['/F', '/T', '/PID', '4321'],
+        expect.objectContaining({
+          detached: false,
+          stdio: 'ignore',
+          windowsHide: true,
+        })
+      );
+
+      taskkill.emit('close', 0);
+      child.emit('close', null);
+
+      await expect(result).resolves.toMatchObject({ message: 'timeout:1' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not spawn a process when the working directory is missing', async () => {
+    const missingCwd = path.join(os.tmpdir(), `open-cowork-missing-${Date.now()}`);
+    const spawnProcess = createSpawnMock([]);
+    const ops = createWindowsBashOperations({ spawnProcess });
+
+    await expect(
+      ops.exec('echo nope', missingCwd, {
+        onData: vi.fn(),
+      })
+    ).rejects.toThrow('Working directory does not exist');
+    expect(spawnProcess).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the Windows bash tool backend with a non-detached shell runner
- invoke Windows shells with the right arguments (`cmd.exe /d /s /c`, PowerShell `-Command`, POSIX `-c` for Git Bash)
- kill the full Windows process tree on timeout/abort and add regression coverage

Closes #198

## Tests
- npx vitest run src/tests/claude/windows-bash-operations.test.ts
- npm run typecheck
- npm run lint -- --quiet

## Notes
- `npx vitest run` was also attempted locally on Windows. It still fails in existing Windows-sensitive tests unrelated to this PR: pre-build-check fixture assertions, memory path/symlink tests, and two 5s timeout tests.
