### PR TITLE
fix(mcp): sanitize MCP tool names for strict providers like DeepSeek

### DIFF
--- a/src/main/mcp/mcp-manager.ts
+++ b/src/main/mcp/mcp-manager.ts
@@ -42,6 +42,7 @@ export interface MCPServerConfig {
  */
 export interface MCPTool {
   name: string;
+  originalToolName: string; // raw name from the MCP server — used when calling the server
   description: string;
   inputSchema: {
     type: string;
@@ -1355,10 +1356,13 @@ export class MCPManager {
           // Format: mcp__<ServerName>__<toolName> (double underscores, preserve case)
           // Sanitize: collapse whitespace and collapse any accidental __ sequences
           const serverKey = config.name.replace(/\s+/g, '_').replace(/__/g, '_');
-          const prefixedName = `mcp__${serverKey}__${tool.name}`;
+          // Sanitize tool.name for strict providers (e.g. DeepSeek) that require ^[a-zA-Z0-9_-]+$
+          const sanitizedToolName = tool.name.replace(/[^a-zA-Z0-9_-]/g, '_');
+          const prefixedName = `mcp__${serverKey}__${sanitizedToolName}`;
 
           newTools.set(prefixedName, {
             name: prefixedName,
+            originalToolName: tool.name, // preserved for the actual MCP server call
             description: tool.description || '',
             inputSchema: {
               type: 'object',
@@ -1426,15 +1430,8 @@ export class MCPManager {
       throw new Error(`MCP tool not found: ${toolName}`);
     }
 
-    // 提取实际工具名（格式：mcp__<ServerName>__<toolName>）
-    let actualToolName = toolName;
-    if (toolName.startsWith('mcp__')) {
-      const remainder = toolName.slice('mcp__'.length);
-      const separatorIndex = remainder.indexOf('__');
-      if (separatorIndex !== -1) {
-        actualToolName = remainder.slice(separatorIndex + 2);
-      }
-    }
+    // Use the stored original name so dots/colons in tool names survive the sanitization pass
+    const actualToolName = tool.originalToolName;
 
     logCtx(`[MCPManager] Calling tool ${actualToolName} on server ${tool.serverName}`);
 

--- a/src/main/mcp/mcp-manager.ts
+++ b/src/main/mcp/mcp-manager.ts
@@ -1357,8 +1357,19 @@ export class MCPManager {
           // Sanitize: collapse whitespace and collapse any accidental __ sequences
           const serverKey = config.name.replace(/\s+/g, '_').replace(/__/g, '_');
           // Sanitize tool.name for strict providers (e.g. DeepSeek) that require ^[a-zA-Z0-9_-]+$
-          const sanitizedToolName = tool.name.replace(/[^a-zA-Z0-9_-]/g, '_');
-          const prefixedName = `mcp__${serverKey}__${sanitizedToolName}`;
+          // Collapse consecutive underscores so spaces don't erode the __ separator convention.
+          const sanitizedToolName =
+            tool.name
+              .replace(/[^a-zA-Z0-9_-]/g, '_')
+              .replace(/_+/g, '_')
+              .replace(/^_|_$/g, '') || '_unnamed_';
+          // Disambiguate collisions: two names that sanitize identically get a numeric suffix.
+          let finalName = sanitizedToolName;
+          let counter = 1;
+          while (newTools.has(`mcp__${serverKey}__${finalName}`)) {
+            finalName = `${sanitizedToolName}_${counter++}`;
+          }
+          const prefixedName = `mcp__${serverKey}__${finalName}`;
 
           newTools.set(prefixedName, {
             name: prefixedName,

--- a/tests/mcp-tool-name.test.ts
+++ b/tests/mcp-tool-name.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('electron', () => ({
@@ -10,7 +11,16 @@ vi.mock('electron', () => ({
 
 import { MCPManager } from '../src/main/mcp/mcp-manager';
 
-function createManagerWithTool(toolName: string) {
+function stripMcpPrefix(toolName: string): string {
+  if (toolName.startsWith('mcp__')) {
+    const remainder = toolName.slice('mcp__'.length);
+    const sep = remainder.indexOf('__');
+    if (sep !== -1) return remainder.slice(sep + 2);
+  }
+  return toolName;
+}
+
+function createManagerWithTool(toolName: string, originalToolName = stripMcpPrefix(toolName)) {
   const manager = new MCPManager();
   const mockClient = {
     callTool: vi.fn().mockResolvedValue({ ok: true }),
@@ -22,6 +32,7 @@ function createManagerWithTool(toolName: string) {
       toolName,
       {
         name: toolName,
+        originalToolName,
         description: '',
         inputSchema: { type: 'object', properties: {} },
         serverId: 'server-1',
@@ -81,6 +92,7 @@ describe('MCP tool name parsing', () => {
         toolName,
         {
           name: toolName,
+          originalToolName: stripMcpPrefix(toolName),
           description: '',
           inputSchema: { type: 'object', properties: {} },
           serverId: 'server-1',
@@ -117,6 +129,7 @@ describe('MCP tool name parsing', () => {
         toolName,
         {
           name: toolName,
+          originalToolName: stripMcpPrefix(toolName),
           description: '',
           inputSchema: { type: 'object', properties: {} },
           serverId: 'server-1',

--- a/tests/mcp-tool-name.test.ts
+++ b/tests/mcp-tool-name.test.ts
@@ -109,6 +109,67 @@ describe('MCP tool name parsing', () => {
     expect(result).toEqual({ ok: true });
   });
 
+  it('sanitizes tool name with dots and colons, preserving original for the call', async () => {
+    const prefixedName = 'mcp__Server__my_resource_read';
+    const { manager, mockClient } = createManagerWithTool(prefixedName, 'my.resource.read');
+
+    await manager.callTool(prefixedName, {});
+
+    expect(mockClient.callTool).toHaveBeenCalledWith({
+      name: 'my.resource.read',
+      arguments: {},
+    });
+  });
+
+  it('disambiguates colliding sanitized names with a numeric suffix', async () => {
+    const manager = new MCPManager();
+    const mockClient = { callTool: vi.fn().mockResolvedValue({ ok: true }) } as any;
+
+    (manager as any).clients = new Map([['server-1', mockClient]]);
+    (manager as any).tools = new Map([
+      [
+        'mcp__Server__my_tool',
+        {
+          name: 'mcp__Server__my_tool',
+          originalToolName: 'my.tool',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+          serverId: 'server-1',
+          serverName: 'Server',
+        },
+      ],
+      [
+        'mcp__Server__my_tool_1',
+        {
+          name: 'mcp__Server__my_tool_1',
+          originalToolName: 'my-tool',
+          description: '',
+          inputSchema: { type: 'object', properties: {} },
+          serverId: 'server-1',
+          serverName: 'Server',
+        },
+      ],
+    ]);
+
+    await manager.callTool('mcp__Server__my_tool', {});
+    expect(mockClient.callTool).toHaveBeenCalledWith({ name: 'my.tool', arguments: {} });
+
+    await manager.callTool('mcp__Server__my_tool_1', {});
+    expect(mockClient.callTool).toHaveBeenCalledWith({ name: 'my-tool', arguments: {} });
+  });
+
+  it('falls back to _unnamed_ for tool names that sanitize to empty string', async () => {
+    const prefixedName = 'mcp__Server___unnamed_';
+    const { manager, mockClient } = createManagerWithTool(prefixedName, '..');
+
+    await manager.callTool(prefixedName, {});
+
+    expect(mockClient.callTool).toHaveBeenCalledWith({
+      name: '..',
+      arguments: {},
+    });
+  });
+
   it('does not reconnect when tool returns plain text content without structured error envelope', async () => {
     const toolName = 'mcp__GUI_Operate__screenshot_for_display';
     const manager = new MCPManager();


### PR DESCRIPTION
## Summary

Fixes #159

Tool names containing periods or colons (e.g. `my.tool`, `ns:action`) cause 400 errors from providers like DeepSeek that require names matching `^[a-zA-Z0-9_-]+$`. The API-facing prefixed name was built as `mcp__ServerName__<raw tool.name>`, passing illegal characters through to the model API.

**Changes:**
- Sanitize `tool.name` at the point of prefixed-name construction: `tool.name.replace(/[^a-zA-Z0-9_-]/g, '_')`
- Add `originalToolName` field to `MCPTool` to preserve the raw name for the actual MCP server call (the old prefix-stripping approach would have produced the sanitized name instead of the original, silently breaking tool execution)
- `callTool` now uses `tool.originalToolName` directly rather than re-deriving from the key

## Type of change

- [x] Bug fix (`fix`)

## Checklist

- [x] Code follows the project style (TypeScript strict, ESLint, Prettier)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, etc.)
- [x] Self-review completed — no debug logs, no commented-out code
- [ ] Tests added or updated for the changed behaviour
- [x] `npm run lint` passes locally

## Testing

1. Configure an MCP server that exposes tools with dots or colons in their names (e.g. a server returning `"my.resource.read"`)
2. With the fix: the tool is registered as `mcp__ServerName__my_resource_read` (safe for DeepSeek/strict providers), and calling it correctly forwards `my.resource.read` to the MCP server
3. Without the fix: the API call fails with 400 from strict providers; or, with naive sanitization only, the MCP server call fails because it receives `my_resource_read` instead of `my.resource.read`

`tsc --noEmit` passes with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)