### PR TITLE
fix(mcp): increase listTools timeout from 10s to 5 minutes

### DIFF
--- a/src/main/mcp/mcp-manager.ts
+++ b/src/main/mcp/mcp-manager.ts
@@ -1330,11 +1330,14 @@ export class MCPManager {
         if (!config) continue;
 
         // Add timeout for listTools call to prevent hanging
-        const timeoutMs = 10000; // 10 second timeout
+        const timeoutMs = 300_000; // 5 minute timeout — complex MCP servers can take time to enumerate
         const listToolsPromise = client.listTools();
         let timeoutId: ReturnType<typeof setTimeout>;
         const timeoutPromise = new Promise<never>((_, reject) => {
-          timeoutId = setTimeout(() => reject(new Error('listTools timeout after 10s')), timeoutMs);
+          timeoutId = setTimeout(
+            () => reject(new Error(`listTools timeout after ${timeoutMs}ms`)),
+            timeoutMs
+          );
         });
 
         log(`[MCPManager] Fetching tools from ${config.name} (timeout: ${timeoutMs}ms)...`);


### PR DESCRIPTION
## Summary

Fixes #161

The `listTools()` call had a 10-second timeout. Complex MCP servers (those that spawn subprocesses, enumerate many resources, or download dependencies at startup) routinely exceed this limit, causing spurious tool-refresh failures on first connect.

**Changes:**
- `src/main/mcp/mcp-manager.ts`: raise `timeoutMs` from `10_000` to `300_000` (5 minutes)
- Update the rejection message to be dynamic (`listTools timeout after ${timeoutMs}ms`) rather than hard-coding "10s"

Note: the issue description mentioned 30s as the existing value; the actual code had 10s for `listTools` (30s was the separate `callTool` timeout). Only `listTools` is changed here.

## Type of change

- [x] Bug fix (`fix`)

## Checklist

- [x] Code follows the project style (TypeScript strict, ESLint, Prettier)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, etc.)
- [x] Self-review completed — no debug logs, no commented-out code
- [x] `npm run lint` passes locally

## Testing

Connect an MCP server that takes more than 10 seconds to enumerate its tools (e.g. one that runs `npx` on first launch). Confirm tools load successfully instead of failing with a timeout error.

`tsc --noEmit` passes with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)