### PR TITLE
chore: replace legacy sdk/sandbox naming with Open Cowork canonical names

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -144,7 +144,7 @@ Open Cowork 提供**多级沙盒保护**，确保系统安全：
 
 ```bash
 brew install lima
-# Open Cowork 会自动创建和管理 'claude-sandbox' 虚拟机
+# Open Cowork 会自动创建和管理 Lima 虚拟机（内部 Lima 实例名：'claude-sandbox'）
 ```
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -152,7 +152,7 @@ Open Cowork provides **multi-level sandbox protection** to keep your system safe
 
 ```bash
 brew install lima
-# Open Cowork will automatically create and manage a 'claude-sandbox' VM
+# Open Cowork will automatically create and manage a Lima VM (internal Lima name: 'claude-sandbox')
 ```
 
 ---

--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -4,7 +4,7 @@
  * AI query execution engine (1514 lines).
  *
  * Responsibilities:
- * - Runs AI conversations via the pi-coding-agent SDK (createAgentSession)
+ * - Runs AI conversations via the Open Cowork agent SDK (createAgentSession)
  * - Routes providers via pi-ai SDK for model resolution
  * - Bridges MCP tools into SDK ToolDefinition format
  * - Streams responses back as ServerEvents (stream.message, stream.partial, trace.step)
@@ -272,7 +272,7 @@ async function enrichProcessPathForBuild(): Promise<void> {
 // Shared pi-ai auth storage — created once, reused across sessions.
 
 /**
- * Bridge MCP tools from MCPManager into pi-coding-agent ToolDefinition[] format.
+ * Bridge MCP tools from MCPManager into ToolDefinition[] format for the agent SDK.
  * Each MCP tool becomes a customTool whose execute() delegates to mcpManager.callTool().
  */
 function buildMcpCustomTools(mcpManager: MCPManager): ToolDefinition[] {
@@ -762,7 +762,7 @@ ${hints.join('\n')}
     this._skillsAdapter = skillsAdapter;
     this.extensionManager = extensionManager;
 
-    log('[ClaudeAgentRunner] Initialized with pi-coding-agent SDK');
+    log('[ClaudeAgentRunner] Initialized with Open Cowork agent SDK');
     log('[ClaudeAgentRunner] Skills enabled: settingSources=[user, project], Skill tool enabled');
     if (mcpManager) {
       log('[ClaudeAgentRunner] MCP support enabled');
@@ -879,7 +879,7 @@ ${hints.join('\n')}
 
   /**
    * Wrap the bash tool to inject a default timeout when the model omits one.
-   * The pi-coding-agent SDK's bash tool has no default timeout, which means
+   * The agent SDK's bash tool has no default timeout, which means
    * commands can run indefinitely if the model doesn't specify a timeout.
    */
   private static wrapBashToolWithDefaultTimeout(tools: ToolDefinition[]): ToolDefinition[] {
@@ -1440,7 +1440,7 @@ ${hints.join('\n')}
 
       logTiming('after pi-ai model resolution', runStartTime);
 
-      // pi-coding-agent handles path sandboxing via its own tools
+      // the agent SDK handles path sandboxing via its own tools
       const imageCapable = true; // pi-ai models generally support images; let the model handle unsupported cases
       const effectiveCwd =
         useSandboxIsolation && sandboxPath ? sandboxPath : workingDir || process.cwd();
@@ -1845,10 +1845,10 @@ Tool routing:
         .filter((section): section is string => Boolean(section && section.trim()))
         .join('\n\n');
 
-      logTiming('before pi-coding-agent session creation', runStartTime);
+      logTiming('before agent session creation', runStartTime);
 
-      // Create or reuse pi-coding-agent session
-      // Bridge MCP tools as customTools for pi-coding-agent.
+      // Create or reuse agent session
+      // Bridge MCP tools as customTools for the agent SDK.
       // Re-read every query so newly added/removed MCP servers take effect immediately.
       const mcpCustomTools = this.mcpManager ? buildMcpCustomTools(this.mcpManager) : [];
       const extensionCustomTools = extensionResult.customTools || [];
@@ -1934,9 +1934,9 @@ Tool routing:
         }
 
         logCtx('[ClaudeAgentRunner] Reusing cached pi session for:', session.id);
-        logTiming('pi-coding-agent session reused', runStartTime);
+        logTiming('agent session reused', runStartTime);
       } else {
-        // First query in this session — create new pi-coding-agent session
+        // First query in this session — create new agent session
         // ResourceLoader + ModelRegistry only needed for session creation — skip on reuse
         const { DefaultResourceLoader } = await import('@mariozechner/pi-coding-agent');
         const resourceLoader = new DefaultResourceLoader({
@@ -2053,10 +2053,10 @@ Tool routing:
           } // end else (_onPayload exists)
         }
 
-        logTiming('pi-coding-agent session created', runStartTime);
+        logTiming('agent session created', runStartTime);
       }
 
-      // Set up event handler to bridge pi-coding-agent events → our ServerEvent protocol
+      // Set up event handler to bridge agent SDK events → our ServerEvent protocol
 
       // Accumulate streamed text deltas in case message_end.content is empty (pi SDK streaming behaviour)
       let streamedText = '';
@@ -2499,7 +2499,7 @@ Tool routing:
         if (ollamaColdStartTimerId) clearTimeout(ollamaColdStartTimerId);
       }
 
-      logTiming('pi-coding-agent prompt completed', runStartTime);
+      logTiming('agent prompt completed', runStartTime);
 
       // If the SDK swallowed the AbortError and returned void, detect timeout here
       if (controller.signal.aborted && abortedByTimeout) {

--- a/src/main/config/config-store.ts
+++ b/src/main/config/config-store.ts
@@ -391,7 +391,8 @@ function normalizeMemoryModelRuntimeConfig(
 }
 
 function normalizeMemoryRuntimeConfig(raw: unknown): MemoryRuntimeConfig {
-  const value = typeof raw === 'object' && raw !== null ? (raw as Partial<MemoryRuntimeConfig>) : {};
+  const value =
+    typeof raw === 'object' && raw !== null ? (raw as Partial<MemoryRuntimeConfig>) : {};
   return {
     llm: normalizeMemoryModelRuntimeConfig(value.llm, defaultConfig.memoryRuntime.llm),
     embedding: normalizeMemoryModelRuntimeConfig(
@@ -424,7 +425,8 @@ function normalizeMemoryRuntimeConfig(raw: unknown): MemoryRuntimeConfig {
         ? value.evalArtifactsRoot
         : defaultConfig.memoryRuntime.evalArtifactsRoot,
     promptIterationRounds:
-      typeof value.promptIterationRounds === 'number' && Number.isFinite(value.promptIterationRounds)
+      typeof value.promptIterationRounds === 'number' &&
+      Number.isFinite(value.promptIterationRounds)
         ? Math.max(0, Math.min(10, Math.round(value.promptIterationRounds)))
         : defaultConfig.memoryRuntime.promptIterationRounds,
   };
@@ -1625,7 +1627,7 @@ export class ConfigStore {
       }
     }
 
-    // claudeCodePath is no longer used (pi-coding-agent handles model routing natively)
+    // claudeCodePath is no longer used (the agent SDK handles model routing natively)
 
     if (projectedConfig.defaultWorkdir) {
       process.env.COWORK_WORKDIR = projectedConfig.defaultWorkdir;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -810,7 +810,7 @@ app
     log('=== Open Cowork Starting ===');
     log('Config file:', configStore.getPath());
     log('Is configured:', configStore.isConfigured());
-    log('[Runtime] Using pi-coding-agent SDK for all providers');
+    log('[Runtime] Using Open Cowork agent SDK for all providers');
     log('Developer logs:', enableDevLogs ? 'Enabled' : 'Disabled');
     log('Environment Variables:');
     log('  ANTHROPIC_AUTH_TOKEN:', process.env.ANTHROPIC_AUTH_TOKEN ? '✓ Set' : '✗ Not set');
@@ -834,9 +834,7 @@ app
 
     pluginRuntimeService = new PluginRuntimeService(new PluginCatalogService());
     memoryService = new MemoryService(db);
-    const extensionManager = new AgentRuntimeExtensionManager([
-      new MemoryExtension(memoryService),
-    ]);
+    const extensionManager = new AgentRuntimeExtensionManager([new MemoryExtension(memoryService)]);
 
     // Initialize session manager before creating an interactive window.
     // This avoids session.start racing the startup path and hitting a null manager.
@@ -1470,7 +1468,10 @@ ipcMain.handle('config.save', async (_event, newConfig: Partial<AppConfig>) => {
       ? {
           ...newConfig.memoryRuntime,
           llm: newConfig.memoryRuntime.llm
-            ? { ...newConfig.memoryRuntime.llm, apiKey: newConfig.memoryRuntime.llm.apiKey ? '***' : '' }
+            ? {
+                ...newConfig.memoryRuntime.llm,
+                apiKey: newConfig.memoryRuntime.llm.apiKey ? '***' : '',
+              }
             : undefined,
           embedding: newConfig.memoryRuntime.embedding
             ? {

--- a/src/main/session/session-manager.ts
+++ b/src/main/session/session-manager.ts
@@ -127,7 +127,7 @@ export class SessionManager {
    */
   private createAgentRunner(): void {
     this.agentRunner = this.createClaudeAgentRunner();
-    log('[SessionManager] Using pi-coding-agent runner');
+    log('[SessionManager] Using Open Cowork agent runner');
   }
 
   private createClaudeAgentRunner(): ClaudeAgentRunner {
@@ -278,7 +278,9 @@ export class SessionManager {
     const envCwd = process.env.COWORK_WORKDIR || process.env.WORKDIR || process.env.DEFAULT_CWD;
     const effectiveCwd = cwd || envCwd;
     const resolvedMemoryEnabled =
-      typeof memoryEnabled === 'boolean' ? memoryEnabled : configStore.get('memoryEnabled') !== false;
+      typeof memoryEnabled === 'boolean'
+        ? memoryEnabled
+        : configStore.get('memoryEnabled') !== false;
     return {
       id: uuidv4(),
       title,

--- a/tests/agent-runner-pi.test.ts
+++ b/tests/agent-runner-pi.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 const agentRunnerPath = path.resolve(process.cwd(), 'src/main/claude/agent-runner.ts');
 const agentRunnerContent = readFileSync(agentRunnerPath, 'utf8');
 
-describe('ClaudeAgentRunner pi-coding-agent integration', () => {
+describe('ClaudeAgentRunner Open Cowork SDK integration', () => {
   it('avoids dynamic re-import shadowing for config store singletons', () => {
     expect(agentRunnerContent).toContain(
       "import { mcpConfigStore } from '../mcp/mcp-config-store'"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { resolve } from 'path';
 import { builtinModules } from 'module';
 
 // Node built-in modules must be external for Electron main process
-const nodeBuiltins = builtinModules.flatMap(m => [m, `node:${m}`]);
+const nodeBuiltins = builtinModules.flatMap((m) => [m, `node:${m}`]);
 const ignoredWatchPaths = [
   '**/release/**',
   '**/dist/**',
@@ -35,7 +35,7 @@ export default defineConfig({
                 'utf-8-validate',
                 'electron',
                 // Externalize large CJS-compatible main-process dependencies
-                // NOTE: ESM-only packages (pi-coding-agent, pi-ai, electron-store, uuid)
+                // NOTE: ESM-only packages (@mariozechner/pi-coding-agent, pi-ai, electron-store, uuid)
                 // must stay bundled — CJS require() can't load them
                 '@anthropic-ai/sdk',
                 '@larksuiteoapi/node-sdk',


### PR DESCRIPTION
## Summary

Closes #183

Replace stale internal references to `pi-coding-agent` and `claude-sandbox` in comments, log messages, docs, and one test `describe` block. All changes are cosmetic — no runtime behaviour, no file renames, no API changes.

**Files changed (8):**
| File | Change |
|------|--------|
| `src/main/claude/agent-runner.ts` | 10 comment/log edits: `pi-coding-agent SDK` → `Open Cowork agent SDK` |
| `src/main/index.ts` | 1 startup log message |
| `src/main/session/session-manager.ts` | 1 log message |
| `src/main/config/config-store.ts` | 1 comment |
| `vite.config.ts` | Short package name → full `@mariozechner/pi-coding-agent` |
| `readme.md` / `README_zh.md` | Document that the Lima VM's internal name is `claude-sandbox` |
| `tests/agent-runner-pi.test.ts` | `describe` block name |

**Intentional aliases left in place:**
- `@mariozechner/pi-coding-agent` imports — actual npm package, cannot rename
- `claude-sdk-one-shot.ts` filename — renaming cascades to 7 import sites with no user benefit
- `LIMA_INSTANCE_NAME = 'claude-sandbox'` in `lima-bridge.ts` / `lima-sync.ts` and shell commands — persisted VM name on existing user machines; renaming breaks their installations
- `.claude-plugin` paths in plugin services / test fixtures — live plugin manifest format
- `claude plugin install` strings in tests — actual CLI interface under test

## Type of change

- [x] Refactor / performance (`refactor` / `perf`)

## Checklist

- [x] Code follows the project style (TypeScript strict, ESLint, Prettier)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, etc.)
- [x] Self-review completed — no debug logs, no commented-out code
- [x] `npm run lint` passes locally

## Testing

All 14 tests in `tests/agent-runner-pi.test.ts` pass (the suite reads `agent-runner.ts` as a string and checks for specific patterns — none of the checked strings were changed).

`tsc --noEmit` passes with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)