### PR TITLE
fix(installer): bundle npm package so npm.cmd / npx shims work

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -73,6 +73,8 @@ win:
       to: mcp
     - from: resources/node/win32-x64
       to: node
+    - from: resources/node/win32-x64/node_modules/npm
+      to: node/node_modules/npm
     - from: dist-wsl-agent
       to: wsl-agent
     - from: .claude/skills
@@ -99,6 +101,8 @@ mac:
       to: mcp
     - from: resources/node/darwin-${arch}
       to: node
+    - from: resources/node/darwin-${arch}/lib/node_modules/npm
+      to: node/lib/node_modules/npm
     # Bundled Python runtime + site-packages for GUI automation helpers (Pillow, pyobjc/Quartz)
     - from: resources/python/darwin-${arch}
       to: python
@@ -122,6 +126,8 @@ linux:
       to: mcp
     - from: resources/node/linux-x64
       to: node
+    - from: resources/node/linux-x64/lib/node_modules/npm
+      to: node/lib/node_modules/npm
     - from: resources/python/linux-${arch}
       to: python
     - from: .claude/skills


### PR DESCRIPTION
## Summary

Fixes #221

The Windows installer shipped `node.exe` + `npm.cmd`/`npx.cmd`/`npm.ps1` shims but **not** the `node_modules/npm/` directory those shims require. Any in-app `npm`/`npx` invocation (MCP server install, etc.) failed because Node couldn't find `npm-cli.js`.

The same omission existed for macOS (`lib/node_modules/npm`) and Linux (`lib/node_modules/npm`), though the immediate bug report is Windows.

## Root cause

`electron-builder.yml` `extraResources` copied the node binary directory (e.g. `resources/node/win32-x64 → node`) but never explicitly included the `npm` package that lives inside it. The build-prep step downloads the full node distribution including npm, so the directory exists locally — it just wasn't listed in `extraResources`.

## What changed

`electron-builder.yml` — three new `extraResources` entries, one per platform:

| Platform | Source | Destination |
|----------|--------|-------------|
| win32-x64 | `resources/node/win32-x64/node_modules/npm` | `node/node_modules/npm` |
| darwin-${arch} | `resources/node/darwin-${arch}/lib/node_modules/npm` | `node/lib/node_modules/npm` |
| linux-x64 | `resources/node/linux-x64/lib/node_modules/npm` | `node/lib/node_modules/npm` |

No other files were changed. npm is pure JS so no filter/unpack rules are needed.

## Manual test instructions

1. Run the build prep step to download node distributions: `npm run download-node` (or equivalent)
2. Build the installer for at least one platform (e.g. `npm run build -- --win`)
3. Verify `resources/node/win32-x64/node_modules/npm/bin/npm-cli.js` is included in the built installer:
   - For Windows NSIS: inspect the unpacked output under `release/win-unpacked/resources/node/node_modules/npm/bin/npm-cli.js`
   - For macOS dir target: check `release/mac/Open Cowork.app/Contents/Resources/node/lib/node_modules/npm/bin/npm-cli.js`
4. Install the app and trigger an MCP server installation — confirm npm runs without a "Cannot find module" error