### PR TITLE
fix(agent-runner): preserve thinking blocks when rebuilding cold-start history

### DIFF
--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -86,6 +86,68 @@ function estimateCharsPerToken(sampleText: string): number {
   return 4 - cjkRatio * 2.5; // Range: 1.5 (pure CJK) ~ 4 (pure English)
 }
 
+/**
+ * Serialize a message's content blocks into the XML representation used inside the
+ * cold-start `<conversation_history>` preamble.
+ *
+ * Why this exists: when the cached pi-coding-agent SDK session is disposed (cwd
+ * change or runtime-signature change), agent-runner rebuilds history from
+ * DB-persisted messages. The previous implementation only kept `text` blocks,
+ * which silently dropped `thinking`, `tool_use`, and `tool_result` blocks.
+ * Providers that require previous reasoning/tool-call replay (e.g. DeepSeek V4
+ * Flash) then fail with 400 on the next turn, and every other thinking-capable
+ * model loses its reasoning trace across cwd switches (issue #162 \u2014 Bug B).
+ *
+ * Blocks handled:
+ *   - text          \u2192 raw text (matches the legacy serializer's output)
+ *   - thinking      \u2192 `<thinking>\u2026</thinking>`
+ *   - tool_use      \u2192 `<tool_use name="\u2026" id="\u2026">{json input}</tool_use>`
+ *   - tool_result   \u2192 `<tool_result tool_use_id="\u2026"[ is_error="true"]>\u2026</tool_result>`
+ *   - image         \u2192 skipped (binary, cannot live inside an XML text preamble)
+ *   - file_attachment \u2192 skipped (large, would bloat the prompt)
+ */
+export function serializeMessageContentForHistory(content: ContentBlock[]): string {
+  const parts: string[] = [];
+  for (const block of content) {
+    switch (block.type) {
+      case 'text': {
+        const text = block.text ?? '';
+        if (text.length > 0) parts.push(text);
+        break;
+      }
+      case 'thinking': {
+        const thinking = block.thinking ?? '';
+        if (thinking.length > 0) parts.push(`<thinking>${thinking}</thinking>`);
+        break;
+      }
+      case 'tool_use': {
+        const name = block.name ?? 'unknown';
+        const id = block.id ?? '';
+        let inputStr: string;
+        try {
+          inputStr = JSON.stringify(block.input ?? {});
+        } catch {
+          inputStr = '{}';
+        }
+        parts.push(`<tool_use name="${name}" id="${id}">${inputStr}</tool_use>`);
+        break;
+      }
+      case 'tool_result': {
+        const id = block.toolUseId ?? '';
+        const errAttr = block.isError ? ' is_error="true"' : '';
+        const text = block.content ?? '';
+        parts.push(`<tool_result tool_use_id="${id}"${errAttr}>${text}</tool_result>`);
+        break;
+      }
+      case 'image':
+      case 'file_attachment':
+        // Skip \u2014 not representable as XML text in a history preamble.
+        break;
+    }
+  }
+  return parts.join('\n');
+}
+
 // Bundled node/npx paths never change at runtime — resolve once.
 let cachedBundledNodePaths: { node: string; npx: string } | null | undefined = undefined;
 
@@ -1635,27 +1697,28 @@ ${hints.join('\n')}
           const historyBudgetRatio = provider === 'ollama' && contextWindow < 16384 ? 0.15 : 0.3;
           const historyTokenBudget = Math.floor(contextWindow * historyBudgetRatio);
 
-          // Sample recent messages to estimate chars-per-token ratio
+          // Sample recent messages to estimate chars-per-token ratio. Sampling the
+          // full serialized form (text + thinking + tool blocks) gives a better CJK
+          // ratio estimate than sampling text only.
           const sampleText = historyMessages
             .slice(-3)
-            .flatMap((m) =>
-              m.content.filter((c) => c.type === 'text').map((c) => (c as { text: string }).text)
-            )
+            .map((m) => serializeMessageContentForHistory(m.content))
             .join('');
           const charsPerToken = estimateCharsPerToken(sampleText);
           const historyCharBudget = Math.floor(historyTokenBudget * charsPerToken);
 
           const historyItems: string[] = [];
           let charCount = 0;
-          // Build from newest to oldest, then reverse
+          // Build from newest to oldest, then reverse. We preserve thinking and
+          // tool blocks (not just text) so providers requiring reasoning/tool-call
+          // replay (DeepSeek V4 Flash, and any thinking-capable model after a
+          // cwd switch) continue to function after a cold start. See #162 Bug B.
           for (let i = historyMessages.length - 1; i >= 0; i--) {
             const msg = historyMessages[i];
-            const textContent = msg.content
-              .filter((c) => c.type === 'text')
-              .map((c) => (c as { text: string }).text)
-              .join('\n');
+            const serialized = serializeMessageContentForHistory(msg.content);
+            if (serialized.length === 0) continue;
             const roleTag = msg.role === 'user' ? 'user' : 'assistant';
-            const entry = `<turn role="${roleTag}">${textContent}</turn>`;
+            const entry = `<turn role="${roleTag}">${serialized}</turn>`;
             if (charCount + entry.length > historyCharBudget) break;
             charCount += entry.length;
             historyItems.unshift(entry);

--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -86,6 +86,27 @@ function estimateCharsPerToken(sampleText: string): number {
   return 4 - cjkRatio * 2.5; // Range: 1.5 (pure CJK) ~ 4 (pure English)
 }
 
+// Escape characters that would break the cold-start `<conversation_history>`
+// envelope when interpolated into XML tag bodies or attribute values. Raw user
+// text blocks are intentionally not escaped (preserves legacy compatibility);
+// only the new wrapper tags (`<thinking>`, `<tool_use>`, `<tool_result>`) and
+// their attributes pass through these.
+//
+// Attribute values additionally need `"` escaped because attributes are
+// double-quoted. Tag bodies do not (keeping `"` keeps JSON input legible to
+// the model).
+function escapeXmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function escapeXmlText(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 /**
  * Serialize a message's content blocks into the XML representation used inside the
  * cold-start `<conversation_history>` preamble.
@@ -117,7 +138,7 @@ export function serializeMessageContentForHistory(content: ContentBlock[]): stri
       }
       case 'thinking': {
         const thinking = block.thinking ?? '';
-        if (thinking.length > 0) parts.push(`<thinking>${thinking}</thinking>`);
+        if (thinking.length > 0) parts.push(`<thinking>${escapeXmlText(thinking)}</thinking>`);
         break;
       }
       case 'tool_use': {
@@ -129,14 +150,36 @@ export function serializeMessageContentForHistory(content: ContentBlock[]): stri
         } catch {
           inputStr = '{}';
         }
-        parts.push(`<tool_use name="${name}" id="${id}">${inputStr}</tool_use>`);
+        parts.push(
+          `<tool_use name="${escapeXmlAttr(name)}" id="${escapeXmlAttr(id)}">${escapeXmlText(inputStr)}</tool_use>`
+        );
         break;
       }
       case 'tool_result': {
         const id = block.toolUseId ?? '';
         const errAttr = block.isError ? ' is_error="true"' : '';
-        const text = block.content ?? '';
-        parts.push(`<tool_result tool_use_id="${id}"${errAttr}>${text}</tool_result>`);
+        // Local type says `content: string`, but Anthropic-style payloads
+        // from older message rows or third-party providers may store an
+        // array of content blocks. Flatten defensively so we never serialize
+        // "[object Object]".
+        const rawContent = (block as { content: unknown }).content;
+        let text: string;
+        if (typeof rawContent === 'string') {
+          text = rawContent;
+        } else if (Array.isArray(rawContent)) {
+          text = rawContent
+            .map((c) =>
+              c && typeof c === 'object' && 'text' in c
+                ? String((c as { text: unknown }).text ?? '')
+                : ''
+            )
+            .join('\n');
+        } else {
+          text = '';
+        }
+        parts.push(
+          `<tool_result tool_use_id="${escapeXmlAttr(id)}"${errAttr}>${escapeXmlText(text)}</tool_result>`
+        );
         break;
       }
       case 'image':

--- a/src/tests/claude/agent-runner-history-rebuild.test.ts
+++ b/src/tests/claude/agent-runner-history-rebuild.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the cold-start `<conversation_history>` rebuild path in
+ * `src/main/claude/agent-runner.ts`.
+ *
+ * The rebuild path is exercised when the cached pi-coding-agent SDK session is
+ * disposed (cwd change at `session-manager.ts:~993`, or runtime-signature
+ * change at `agent-runner.ts:~1583`) and agent-runner has to reconstruct
+ * conversation history from DB-persisted messages.
+ *
+ * Bug #162 (Bug B): the previous implementation filtered to `type === 'text'`
+ * only, silently dropping `thinking`, `tool_use`, and `tool_result` blocks.
+ * Providers that require previous reasoning/tool-call replay (DeepSeek V4
+ * Flash, and any thinking-capable model after a cwd switch) then 400 on the
+ * next turn. These tests pin the new serializer behavior so the regression
+ * cannot return.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+// agent-runner.ts pulls a wide tree of Electron + native deps via its
+// constructor; we only need a pure helper, so stub the heaviest imports.
+vi.mock('@mariozechner/pi-ai', () => ({
+  completeSimple: vi.fn(),
+  getModel: vi.fn(() => undefined),
+}));
+
+vi.mock('../../main/claude/shared-auth', () => ({
+  getSharedAuthStorage: () => ({ setRuntimeApiKey: vi.fn() }),
+  ModelRegistry: vi.fn(),
+}));
+
+import type { ContentBlock } from '../../renderer/types';
+import { serializeMessageContentForHistory } from '../../main/claude/agent-runner';
+
+describe('serializeMessageContentForHistory', () => {
+  it('serializes a single text block as raw text (legacy compatible)', () => {
+    const blocks: ContentBlock[] = [{ type: 'text', text: 'hello world' }];
+    expect(serializeMessageContentForHistory(blocks)).toBe('hello world');
+  });
+
+  it('omits empty text blocks', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'text', text: '' },
+      { type: 'text', text: 'kept' },
+    ];
+    expect(serializeMessageContentForHistory(blocks)).toBe('kept');
+  });
+
+  it('wraps thinking blocks in <thinking> tags', () => {
+    const blocks: ContentBlock[] = [{ type: 'thinking', thinking: 'reasoning trace' }];
+    expect(serializeMessageContentForHistory(blocks)).toBe('<thinking>reasoning trace</thinking>');
+  });
+
+  it('serializes tool_use blocks with name, id, and JSON input', () => {
+    const blocks: ContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'toolu_01',
+        name: 'Bash',
+        input: { command: 'ls -la' },
+      },
+    ];
+    expect(serializeMessageContentForHistory(blocks)).toBe(
+      '<tool_use name="Bash" id="toolu_01">{"command":"ls -la"}</tool_use>'
+    );
+  });
+
+  it('serializes tool_result blocks with toolUseId and content', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'tool_result', toolUseId: 'toolu_01', content: 'file1\nfile2' },
+    ];
+    expect(serializeMessageContentForHistory(blocks)).toBe(
+      '<tool_result tool_use_id="toolu_01">file1\nfile2</tool_result>'
+    );
+  });
+
+  it('marks tool_result errors with is_error="true"', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'tool_result', toolUseId: 'toolu_02', content: 'boom', isError: true },
+    ];
+    expect(serializeMessageContentForHistory(blocks)).toBe(
+      '<tool_result tool_use_id="toolu_02" is_error="true">boom</tool_result>'
+    );
+  });
+
+  it('skips image and file_attachment blocks (binary / oversized)', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'text', text: 'before' },
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/png', data: 'AAAA' },
+      },
+      {
+        type: 'file_attachment',
+        filename: 'data.bin',
+        relativePath: 'tmp/data.bin',
+        size: 1024,
+      },
+      { type: 'text', text: 'after' },
+    ];
+    expect(serializeMessageContentForHistory(blocks)).toBe('before\nafter');
+  });
+
+  it('preserves block ordering for a typical assistant turn (thinking → text → tool_use)', () => {
+    // This is the exact shape that fails on DeepSeek V4 Flash without the fix:
+    // an assistant turn with reasoning, followed by a textual answer fragment,
+    // followed by a tool call. The model's next turn must see all three to
+    // pass schema validation on providers that replay reasoning.
+    const blocks: ContentBlock[] = [
+      { type: 'thinking', thinking: 'need to inspect the dir first' },
+      { type: 'text', text: 'Let me check the directory.' },
+      {
+        type: 'tool_use',
+        id: 'toolu_99',
+        name: 'Bash',
+        input: { command: 'pwd' },
+      },
+    ];
+    expect(serializeMessageContentForHistory(blocks)).toBe(
+      [
+        '<thinking>need to inspect the dir first</thinking>',
+        'Let me check the directory.',
+        '<tool_use name="Bash" id="toolu_99">{"command":"pwd"}</tool_use>',
+      ].join('\n')
+    );
+  });
+
+  it('preserves block ordering for a user turn carrying a tool_result + free text', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'tool_result', toolUseId: 'toolu_99', content: '/home/user' },
+      { type: 'text', text: 'thanks, now list it' },
+    ];
+    expect(serializeMessageContentForHistory(blocks)).toBe(
+      ['<tool_result tool_use_id="toolu_99">/home/user</tool_result>', 'thanks, now list it'].join(
+        '\n'
+      )
+    );
+  });
+
+  it('falls back to defaults when tool_use fields are missing or unserializable', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const blocks: ContentBlock[] = [
+      // Force a JSON.stringify failure (circular ref) — should degrade to "{}"
+      {
+        type: 'tool_use',
+        id: '',
+        name: '',
+        input: circular,
+      } as ContentBlock,
+    ];
+    expect(serializeMessageContentForHistory(blocks)).toBe('<tool_use name="" id="">{}</tool_use>');
+  });
+
+  it('returns an empty string for messages composed entirely of skipped blocks', () => {
+    const blocks: ContentBlock[] = [
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/jpeg', data: 'AAAA' },
+      },
+      {
+        type: 'file_attachment',
+        filename: 'a.bin',
+        relativePath: 'a.bin',
+        size: 1,
+      },
+    ];
+    expect(serializeMessageContentForHistory(blocks)).toBe('');
+  });
+});

--- a/src/tests/claude/agent-runner-history-rebuild.test.ts
+++ b/src/tests/claude/agent-runner-history-rebuild.test.ts
@@ -167,4 +167,78 @@ describe('serializeMessageContentForHistory', () => {
     ];
     expect(serializeMessageContentForHistory(blocks)).toBe('');
   });
+
+  it('XML-escapes thinking content so </thinking> or & literals cannot break the envelope', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'thinking', thinking: 'I read </thinking> then ran A & B with <foo>' },
+    ];
+    expect(serializeMessageContentForHistory(blocks)).toBe(
+      '<thinking>I read &lt;/thinking&gt; then ran A &amp; B with &lt;foo&gt;</thinking>'
+    );
+  });
+
+  it('XML-escapes tool_use attributes and body', () => {
+    const blocks: ContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'id"with&quote',
+        name: 'name<x>',
+        input: { cmd: 'echo "hi" & echo <bar>' },
+      },
+    ];
+    const out = serializeMessageContentForHistory(blocks);
+    // Attribute values must escape `"` so they don't break the attribute
+    expect(out).toContain('name="name&lt;x&gt;"');
+    expect(out).toContain('id="id&quot;with&amp;quote"');
+    // Body keeps `"` literal (so JSON stays legible) but escapes `<`, `>`, `&`
+    expect(out).toMatch(/<\/tool_use>$/);
+    expect(out).not.toContain('<bar>');
+    expect(out).toContain('&lt;bar&gt;');
+    expect(out).toContain('"cmd"'); // body `"` not escaped
+  });
+
+  it('XML-escapes tool_result content (including </tool_result> literals)', () => {
+    const blocks: ContentBlock[] = [
+      {
+        type: 'tool_result',
+        toolUseId: 'call-1',
+        content: 'output </tool_result> & more',
+      },
+    ];
+    expect(serializeMessageContentForHistory(blocks)).toBe(
+      '<tool_result tool_use_id="call-1">output &lt;/tool_result&gt; &amp; more</tool_result>'
+    );
+  });
+
+  it('flattens tool_result.content when stored as a content-block array (defensive)', () => {
+    // Older message rows or third-party providers may persist tool_result.content
+    // as an Anthropic-style array of content blocks. The local TS type is `string`,
+    // but the serializer must not produce "[object Object]" for legacy data.
+    const blocks = [
+      {
+        type: 'tool_result',
+        toolUseId: 'call-2',
+        content: [
+          { type: 'text', text: 'first line' },
+          { type: 'text', text: 'second line' },
+        ] as unknown as string,
+      },
+    ] as ContentBlock[];
+    const out = serializeMessageContentForHistory(blocks);
+    expect(out).toBe('<tool_result tool_use_id="call-2">first line\nsecond line</tool_result>');
+    expect(out).not.toContain('[object Object]');
+  });
+
+  it('falls back to empty string when tool_result.content is neither string nor array', () => {
+    const blocks = [
+      {
+        type: 'tool_result',
+        toolUseId: 'call-3',
+        content: 42 as unknown as string,
+      },
+    ] as ContentBlock[];
+    expect(serializeMessageContentForHistory(blocks)).toBe(
+      '<tool_result tool_use_id="call-3"></tool_result>'
+    );
+  });
 });


### PR DESCRIPTION
Refs #162 (Bug B)

PR #186 already fixed Bug A in the pi-ai SDK; Bug B is the Open-Cowork-side counterpart and was untouched until now.

## Root cause

When the cached pi-coding-agent SDK session is disposed — which happens on a cwd change (`session-manager.ts:~993`) or a runtime-signature change (`agent-runner.ts:~1583`) — agent-runner reconstructs the `<conversation_history>` preamble from DB-persisted messages. The previous rebuild loop did:

```ts
msg.content.filter((c) => c.type === 'text')
```

which silently dropped `thinking`, `tool_use`, and `tool_result` blocks.

Consequences:

- **DeepSeek V4 Flash** (and any provider that requires previous reasoning to be replayed in `content`) returned a 400 on the very next turn after a cwd switch — this is the exact failure pattern in #162 Bug B.
- **Every other thinking-capable model** (Claude / Gemini / GPT-5.4 / Ollama with thinking on) lost its reasoning trace across cwd switches. No visible 400, but reasoning continuity broke, hurting multi-turn tool-call accuracy and explainability.

## What changed

`src/main/claude/agent-runner.ts`

- Added `serializeMessageContentForHistory(content: ContentBlock[]): string` (exported helper near `estimateCharsPerToken`). It maps each block to its XML form, preserving the original block order inside each turn:

  | Block            | Serialized as                                                          |
  | ---------------- | ---------------------------------------------------------------------- |
  | `text`           | raw text (legacy-compatible)                                           |
  | `thinking`       | `<thinking>...</thinking>`                                             |
  | `tool_use`       | `<tool_use name="..." id="...">{json input}</tool_use>`                |
  | `tool_result`    | `<tool_result tool_use_id="..."[ is_error="true"]>...</tool_result>`   |
  | `image`          | skipped (binary, not representable in an XML text preamble)            |
  | `file_attachment`| skipped (would bloat the prompt)                                       |

- Cold-start rebuild loop inside `ClaudeAgentRunner.run()` now calls the helper instead of the text-only filter. Messages that serialize to an empty string (all skipped blocks) are dropped from the preamble.
- The char-per-token sampling step now serializes the full content so the CJK ratio estimate stays accurate when most of the recent turns are reasoning or tool output.
- The existing message-level "skip messages containing an image" filter above the loop is preserved (defense-in-depth on top of the new block-level skip).

## Why the format

I matched the existing convention in this file: the preamble already uses `<conversation_history>` / `<turn role="...">`, so the new inner tags `<thinking>`, `<tool_use>`, `<tool_result>` follow the same shape. JSON for `tool_use.input` keeps internal quotes properly escaped. No new schema invented; the format is internal to the cold-start path so no backwards-compat shim is needed.

## Test

New `src/tests/claude/agent-runner-history-rebuild.test.ts` (11 cases), pinning:

- text-only round-trip (legacy compatibility)
- empty-text omission
- `<thinking>` wrapping
- `<tool_use>` with name + id + JSON input
- `<tool_result>` with `toolUseId` + content
- `<tool_result>` with `is_error="true"`
- skip behavior for `image` + `file_attachment`
- block ordering for a typical assistant turn (`thinking -> text -> tool_use`) — exactly the shape that broke DeepSeek V4 Flash
- block ordering for a typical user turn (`tool_result -> text`)
- circular-input fallback in `tool_use` JSON.stringify
- empty string for messages composed entirely of skipped blocks

## Verification

- `npm run lint` -> 0 errors (8 pre-existing warnings, all in renderer files)
- `npm run test` -> the new 11 cases pass; pre-existing failures in `src/tests/memory/*` (better-sqlite3 native binding) and `tests/deepseek-thinking-serialization.test.ts` (expects a pi-ai dist file that doesn't exist in this checkout) reproduce on `main` without my changes — confirmed by `git checkout main -- . && vitest`
- `npx tsc --noEmit` -> only pre-existing `slack-channel.ts` module-resolution errors

## Scope

Single function change in a hot path; no refactors to surrounding code in `agent-runner.ts`. ~73-line diff in the source + new test file.