### PR TITLE
feat(loop-guard): tool-call loop detection (PR #175 maintainer rescue)

### DIFF
--- a/src/main/claude/agent-runner-loop-guard.ts
+++ b/src/main/claude/agent-runner-loop-guard.ts
@@ -1,0 +1,382 @@
+/**
+ * Loop guard — detects runaway tool-call loops inside a single agent turn.
+ *
+ * Two-layer strategy:
+ *
+ *   Layer 1  Hash-based group detection
+ *     - Hash the entire tool-call list of each assistant message (MD5 over stable keys).
+ *     - Track hashes in a sliding window (default 20 entries).
+ *     - 3 repeats  → warn  (inject a "please stop" steering message)
+ *     - 5 repeats  → halt  (inject a hard "stop now, produce text" steering message)
+ *     - 8 repeats  → abort (upstream gave up listening — kill the turn)
+ *
+ *   Layer 2  Per-tool frequency detection (no parameter comparison)
+ *     - Tracks cumulative invocations of each tool type within the turn.
+ *     - Catches cross-parameter loops such as repeatedly reading *different* files.
+ *     - 30 invocations → warn
+ *     - 50 invocations → halt
+ *     - 80 invocations → abort
+ *
+ * Stable tool key generation (for hashing):
+ *   - read_file            → `${tool}:${path}#bucket=${floor(startLine / 200)}`
+ *                            (adjacent line ranges collapse into the same key)
+ *   - write_file / str_replace / edit_file / create_file / search_replace
+ *                          → `${tool}:${md5(fullArgs)}`
+ *                            (any content change = distinct operation)
+ *   - everything else      → `${tool}:${md5(extracted key fields)}`
+ *                            where key fields = path/file_path/url/query/command/regex/pattern
+ *
+ * This module is **pure** — no electron, no logger, no network — so it is
+ * trivially unit-testable. The host (agent-runner.ts) is responsible for
+ * translating decisions into side effects (sendUserMessage steer, abort, etc.).
+ */
+
+import { createHash } from 'node:crypto';
+
+/** Configuration knobs. All fields are required once normalised. */
+export interface LoopGuardConfig {
+  /** How many most-recent assistant-message hashes to retain. */
+  messageHashWindow: number;
+  /** Same hash appearing this many times → soft warning. */
+  duplicateHashWarnThreshold: number;
+  /** Same hash appearing this many times → hard halt steering. */
+  duplicateHashHaltThreshold: number;
+  /** Same hash appearing this many times → unilateral abort. */
+  duplicateHashAbortThreshold: number;
+  /** Same tool invoked this many times in the turn → soft warning. */
+  toolFrequencyWarnThreshold: number;
+  /** Same tool invoked this many times in the turn → hard halt steering. */
+  toolFrequencyHaltThreshold: number;
+  /** Same tool invoked this many times in the turn → unilateral abort. */
+  toolFrequencyAbortThreshold: number;
+  /** Line-number bucket width used to collapse adjacent read_file ranges. */
+  readFileLineBucketSize: number;
+}
+
+export const DEFAULT_LOOP_GUARD_CONFIG: LoopGuardConfig = {
+  messageHashWindow: 20,
+  duplicateHashWarnThreshold: 3,
+  duplicateHashHaltThreshold: 5,
+  duplicateHashAbortThreshold: 8,
+  toolFrequencyWarnThreshold: 30,
+  toolFrequencyHaltThreshold: 50,
+  toolFrequencyAbortThreshold: 80,
+  readFileLineBucketSize: 200,
+};
+
+export interface ToolCallDescriptor {
+  name: string;
+  input: Record<string, unknown> | undefined;
+}
+
+export type LoopGuardAction =
+  | 'none'
+  | 'hash_warn'
+  | 'hash_halt'
+  | 'hash_abort'
+  | 'freq_warn'
+  | 'freq_halt'
+  | 'freq_abort';
+
+export interface LoopGuardDecision {
+  action: LoopGuardAction;
+  reason: string;
+  count?: number;
+  toolName?: string;
+  hash?: string;
+  window?: number;
+}
+
+const NOOP_DECISION: LoopGuardDecision = { action: 'none', reason: 'ok' };
+
+// ─── Pure helpers ───────────────────────────────────────────────────────────
+
+/** Deterministic JSON — sorted keys, recursive. */
+function normaliseForHash(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(normaliseForHash);
+  const src = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const k of Object.keys(src).sort()) out[k] = normaliseForHash(src[k]);
+  return out;
+}
+
+function md5(value: unknown): string {
+  return createHash('md5')
+    .update(JSON.stringify(normaliseForHash(value)))
+    .digest('hex');
+}
+
+const READ_FILE_PATTERN = /\bread[-_]?file\b/i;
+const WRITE_LIKE_PATTERN =
+  /\b(write[-_]?file|str[-_]?replace|edit[-_]?file|create[-_]?file|search[-_]?replace|apply[-_]?patch|append[-_]?file)\b/i;
+
+const KEY_FIELDS = [
+  'path',
+  'file_path',
+  'filePath',
+  'file',
+  'url',
+  'query',
+  'q',
+  'command',
+  'cmd',
+  'regex',
+  'pattern',
+  'keyword',
+  'keywords',
+] as const;
+
+/** Build a stable key that represents "the same logical call". */
+export function stableToolKey(
+  toolName: string,
+  input: Record<string, unknown> | undefined,
+  config: Pick<LoopGuardConfig, 'readFileLineBucketSize'> = {
+    readFileLineBucketSize: DEFAULT_LOOP_GUARD_CONFIG.readFileLineBucketSize,
+  }
+): string {
+  const name = toolName || 'unknown';
+  if (!input || typeof input !== 'object') return `${name}:∅`;
+
+  // read_file — bucket by line range so "read lines 1-100" and "read lines 50-150"
+  // of the same file count as the same logical operation.
+  if (READ_FILE_PATTERN.test(name) || name === 'read') {
+    const path = pickString(input, ['file_path', 'filePath', 'path', 'file']) ?? '';
+    const rawStart = pickNumber(input, ['start_line', 'startLine', 'offset', 'line']);
+    const start = rawStart ?? 0;
+    const bucket = Math.floor(start / Math.max(1, config.readFileLineBucketSize));
+    return `${name}:${path}#bucket=${bucket}`;
+  }
+
+  // Destructive writes — any content change is a distinct op.
+  if (WRITE_LIKE_PATTERN.test(name)) {
+    return `${name}:${md5(input)}`;
+  }
+
+  // Generic tools — hash the subset of key fields when available, otherwise full input.
+  const extracted: Record<string, unknown> = {};
+  for (const k of KEY_FIELDS) {
+    if (k in input) extracted[k] = (input as Record<string, unknown>)[k];
+  }
+  const target = Object.keys(extracted).length > 0 ? extracted : input;
+  return `${name}:${md5(target)}`;
+}
+
+function pickString(input: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const k of keys) {
+    const v = input[k];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return undefined;
+}
+
+function pickNumber(input: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const k of keys) {
+    const v = input[k];
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+    if (typeof v === 'string' && v !== '' && !Number.isNaN(Number(v))) return Number(v);
+  }
+  return undefined;
+}
+
+/** Hash the ordered list of stable keys for one assistant message. */
+export function messageCallsHash(
+  toolCalls: ToolCallDescriptor[],
+  config: Pick<LoopGuardConfig, 'readFileLineBucketSize'> = {
+    readFileLineBucketSize: DEFAULT_LOOP_GUARD_CONFIG.readFileLineBucketSize,
+  }
+): string {
+  if (!toolCalls || toolCalls.length === 0) return '';
+  const keys = toolCalls.map((tc) => stableToolKey(tc.name, tc.input, config));
+  return md5(keys);
+}
+
+// ─── LoopGuard class ────────────────────────────────────────────────────────
+
+export class LoopGuard {
+  private readonly config: LoopGuardConfig;
+  private readonly hashWindow: string[] = [];
+  private readonly hashCounts = new Map<string, number>();
+  private readonly hashWarnIssued = new Set<string>();
+  private readonly hashHaltIssued = new Set<string>();
+  private readonly hashAbortIssued = new Set<string>();
+  private readonly toolFrequency = new Map<string, number>();
+  private readonly toolWarnIssued = new Set<string>();
+  private readonly toolHaltIssued = new Set<string>();
+  private readonly toolAbortIssued = new Set<string>();
+
+  constructor(config: Partial<LoopGuardConfig> = {}) {
+    this.config = { ...DEFAULT_LOOP_GUARD_CONFIG, ...config };
+  }
+
+  /**
+   * Record a complete assistant message's tool-call list and decide whether
+   * to intervene. Call once per `message_end` that contains tool_use blocks.
+   */
+  recordAssistantMessage(toolCalls: ToolCallDescriptor[]): LoopGuardDecision {
+    if (!toolCalls || toolCalls.length === 0) return NOOP_DECISION;
+
+    const hash = messageCallsHash(toolCalls, this.config);
+    this.pushHash(hash);
+    const count = this.hashCounts.get(hash) ?? 0;
+
+    if (count >= this.config.duplicateHashAbortThreshold && !this.hashAbortIssued.has(hash)) {
+      this.hashAbortIssued.add(hash);
+      return this.mkDecision('hash_abort', `identical tool-call group repeated ${count} times`, {
+        count,
+        hash,
+        window: this.config.messageHashWindow,
+      });
+    }
+    if (count >= this.config.duplicateHashHaltThreshold && !this.hashHaltIssued.has(hash)) {
+      this.hashHaltIssued.add(hash);
+      return this.mkDecision('hash_halt', `identical tool-call group repeated ${count} times`, {
+        count,
+        hash,
+        window: this.config.messageHashWindow,
+      });
+    }
+    if (count >= this.config.duplicateHashWarnThreshold && !this.hashWarnIssued.has(hash)) {
+      this.hashWarnIssued.add(hash);
+      return this.mkDecision('hash_warn', `identical tool-call group repeated ${count} times`, {
+        count,
+        hash,
+        window: this.config.messageHashWindow,
+      });
+    }
+    return NOOP_DECISION;
+  }
+
+  /**
+   * Record a single tool invocation start and decide whether the per-tool
+   * frequency limit is tripped. Call once per `tool_execution_start`.
+   */
+  recordToolInvocation(toolName: string): LoopGuardDecision {
+    const name = toolName || 'unknown';
+    const count = (this.toolFrequency.get(name) ?? 0) + 1;
+    this.toolFrequency.set(name, count);
+
+    if (count >= this.config.toolFrequencyAbortThreshold && !this.toolAbortIssued.has(name)) {
+      this.toolAbortIssued.add(name);
+      return this.mkDecision('freq_abort', `tool "${name}" invoked ${count} times in this turn`, {
+        count,
+        toolName: name,
+      });
+    }
+    if (count >= this.config.toolFrequencyHaltThreshold && !this.toolHaltIssued.has(name)) {
+      this.toolHaltIssued.add(name);
+      return this.mkDecision('freq_halt', `tool "${name}" invoked ${count} times in this turn`, {
+        count,
+        toolName: name,
+      });
+    }
+    if (count >= this.config.toolFrequencyWarnThreshold && !this.toolWarnIssued.has(name)) {
+      this.toolWarnIssued.add(name);
+      return this.mkDecision('freq_warn', `tool "${name}" invoked ${count} times in this turn`, {
+        count,
+        toolName: name,
+      });
+    }
+    return NOOP_DECISION;
+  }
+
+  /** Expose raw counters for diagnostics / testing. */
+  snapshot(): {
+    hashCounts: Record<string, number>;
+    toolFrequency: Record<string, number>;
+    window: string[];
+  } {
+    return {
+      hashCounts: Object.fromEntries(this.hashCounts),
+      toolFrequency: Object.fromEntries(this.toolFrequency),
+      window: [...this.hashWindow],
+    };
+  }
+
+  private pushHash(hash: string): void {
+    this.hashWindow.push(hash);
+    this.hashCounts.set(hash, (this.hashCounts.get(hash) ?? 0) + 1);
+    while (this.hashWindow.length > this.config.messageHashWindow) {
+      const removed = this.hashWindow.shift();
+      if (removed == null) break;
+      const prev = this.hashCounts.get(removed) ?? 0;
+      if (prev <= 1) {
+        this.hashCounts.delete(removed);
+        // once it fully leaves the window, allow fresh warn/halt cycles for it again
+        this.hashWarnIssued.delete(removed);
+        this.hashHaltIssued.delete(removed);
+      } else {
+        this.hashCounts.set(removed, prev - 1);
+      }
+    }
+  }
+
+  private mkDecision(
+    action: LoopGuardAction,
+    reason: string,
+    details: Partial<Pick<LoopGuardDecision, 'count' | 'toolName' | 'hash' | 'window'>>
+  ): LoopGuardDecision {
+    return { action, reason, ...details };
+  }
+}
+
+// ─── Human-facing message builders ──────────────────────────────────────────
+
+export const LOOP_GUARD_GUIDANCE =
+  '\n\n**Suggestions:**\n' +
+  '- Enable "Thinking" mode in settings and retry, especially for models like gemini-3.1-pro that tend to fall into empty loops when thinking is disabled\n' +
+  '- Switch to a model with built-in reasoning capabilities (e.g., claude-sonnet-4-6)\n' +
+  '- Break complex tasks into smaller subtasks and send them separately';
+
+/** Steering message injected to the model when warn threshold is crossed. */
+export function buildWarnSteerMessage(decision: LoopGuardDecision): string {
+  if (decision.action === 'hash_warn') {
+    return (
+      `[Loop Guard · Warning] You have executed the same group of tool calls ${decision.count} times in a row.\n` +
+      'Please stop the repetitive calls. Based on the information you have already collected, try to provide an interim text conclusion, or change your strategy (use different tools / adjust parameters / break into subtasks).'
+    );
+  }
+  if (decision.action === 'freq_warn') {
+    return (
+      `[Loop Guard · Warning] The tool "${decision.toolName}" has been invoked ${decision.count} times in this turn.\n` +
+      'Please assess whether the information you have is sufficient to answer. If so, output a text conclusion directly; if not, use a different tool or more precise parameters.'
+    );
+  }
+  return '[Loop Guard · Warning]';
+}
+
+/** Steering message injected when halt threshold is crossed (stronger). */
+export function buildHaltSteerMessage(decision: LoopGuardDecision): string {
+  if (decision.action === 'hash_halt') {
+    return (
+      `[Loop Guard · STOP] Identical tool-call group has now repeated ${decision.count} times — this is a loop.\n` +
+      '**STOP all tool calls immediately. You must output the final conclusion in plain text based on the information you have already collected. Do not make any further tool calls.**'
+    );
+  }
+  if (decision.action === 'freq_halt') {
+    return (
+      `[Loop Guard · STOP] The tool "${decision.toolName}" has been invoked ${decision.count} times — this is a loop.\n` +
+      '**STOP all tool calls immediately. You must output the final conclusion in plain text based on the information you have already collected. Do not make any further tool calls.**'
+    );
+  }
+  return '[Loop Guard · STOP]';
+}
+
+/** Final message sent to the user when we unilaterally abort. */
+export function buildAbortUserMessage(decision: LoopGuardDecision): string {
+  if (decision.action === 'hash_abort') {
+    return (
+      `**Loop Guard: The model continued to repeat the same group of tool calls ${decision.count} times even after receiving stop instructions. Session forcibly terminated.**` +
+      LOOP_GUARD_GUIDANCE
+    );
+  }
+  if (decision.action === 'freq_abort') {
+    return (
+      `**Loop Guard: Tool "${decision.toolName}" has been invoked ${decision.count} times in this turn, far exceeding reasonable limits. Session forcibly terminated.**` +
+      LOOP_GUARD_GUIDANCE
+    );
+  }
+  return (
+    '**Loop Guard: Tool-call loop detected. Session forcibly terminated.**' + LOOP_GUARD_GUIDANCE
+  );
+}

--- a/src/main/claude/agent-runner-loop-guard.ts
+++ b/src/main/claude/agent-runner-loop-guard.ts
@@ -3,12 +3,16 @@
  *
  * Two-layer strategy:
  *
- *   Layer 1  Hash-based group detection
+ *   Layer 1  Hash-based group detection (consecutive streak)
  *     - Hash the entire tool-call list of each assistant message (MD5 over stable keys).
- *     - Track hashes in a sliding window (default 20 entries).
- *     - 3 repeats  → warn  (inject a "please stop" steering message)
- *     - 5 repeats  → halt  (inject a hard "stop now, produce text" steering message)
- *     - 8 repeats  → abort (upstream gave up listening — kill the turn)
+ *     - Count the *current consecutive streak* of identical hashes. Any different
+ *       hash resets the streak to 1. This avoids false positives from interleaved
+ *       patterns like A/B/A/B/A which are not actually loops.
+ *     - The recent hashes are still retained in a sliding window (default 20 entries)
+ *       for diagnostics; the window does NOT influence the streak comparison.
+ *     - 3 in a row  → warn  (inject a "please stop" steering message)
+ *     - 5 in a row  → halt  (inject a hard "stop now, produce text" steering message)
+ *     - 8 in a row  → abort (upstream gave up listening — kill the turn)
  *
  *   Layer 2  Per-tool frequency detection (no parameter comparison)
  *     - Tracks cumulative invocations of each tool type within the turn.
@@ -196,10 +200,14 @@ export function messageCallsHash(
 export class LoopGuard {
   private readonly config: LoopGuardConfig;
   private readonly hashWindow: string[] = [];
-  private readonly hashCounts = new Map<string, number>();
-  private readonly hashWarnIssued = new Set<string>();
-  private readonly hashHaltIssued = new Set<string>();
-  private readonly hashAbortIssued = new Set<string>();
+  /** The hash of the most recently recorded assistant message (null = none yet). */
+  private currentHash: string | null = null;
+  /** Length of the current consecutive run of `currentHash`. */
+  private currentStreak = 0;
+  /** Whether warn/halt/abort have already been emitted for the *current* streak. */
+  private streakWarnIssued = false;
+  private streakHaltIssued = false;
+  private streakAbortIssued = false;
   private readonly toolFrequency = new Map<string, number>();
   private readonly toolWarnIssued = new Set<string>();
   private readonly toolHaltIssued = new Set<string>();
@@ -212,37 +220,52 @@ export class LoopGuard {
   /**
    * Record a complete assistant message's tool-call list and decide whether
    * to intervene. Call once per `message_end` that contains tool_use blocks.
+   *
+   * Decision is based on the *current consecutive streak* of identical hashes,
+   * not the cumulative count over the window. Patterns like A/B/A/B never fire.
    */
   recordAssistantMessage(toolCalls: ToolCallDescriptor[]): LoopGuardDecision {
     if (!toolCalls || toolCalls.length === 0) return NOOP_DECISION;
 
     const hash = messageCallsHash(toolCalls, this.config);
     this.pushHash(hash);
-    const count = this.hashCounts.get(hash) ?? 0;
+    const count = this.currentStreak;
 
-    if (count >= this.config.duplicateHashAbortThreshold && !this.hashAbortIssued.has(hash)) {
-      this.hashAbortIssued.add(hash);
-      return this.mkDecision('hash_abort', `identical tool-call group repeated ${count} times`, {
-        count,
-        hash,
-        window: this.config.messageHashWindow,
-      });
+    if (count >= this.config.duplicateHashAbortThreshold && !this.streakAbortIssued) {
+      this.streakAbortIssued = true;
+      return this.mkDecision(
+        'hash_abort',
+        `identical tool-call group repeated ${count} times in a row`,
+        {
+          count,
+          hash,
+          window: this.config.messageHashWindow,
+        }
+      );
     }
-    if (count >= this.config.duplicateHashHaltThreshold && !this.hashHaltIssued.has(hash)) {
-      this.hashHaltIssued.add(hash);
-      return this.mkDecision('hash_halt', `identical tool-call group repeated ${count} times`, {
-        count,
-        hash,
-        window: this.config.messageHashWindow,
-      });
+    if (count >= this.config.duplicateHashHaltThreshold && !this.streakHaltIssued) {
+      this.streakHaltIssued = true;
+      return this.mkDecision(
+        'hash_halt',
+        `identical tool-call group repeated ${count} times in a row`,
+        {
+          count,
+          hash,
+          window: this.config.messageHashWindow,
+        }
+      );
     }
-    if (count >= this.config.duplicateHashWarnThreshold && !this.hashWarnIssued.has(hash)) {
-      this.hashWarnIssued.add(hash);
-      return this.mkDecision('hash_warn', `identical tool-call group repeated ${count} times`, {
-        count,
-        hash,
-        window: this.config.messageHashWindow,
-      });
+    if (count >= this.config.duplicateHashWarnThreshold && !this.streakWarnIssued) {
+      this.streakWarnIssued = true;
+      return this.mkDecision(
+        'hash_warn',
+        `identical tool-call group repeated ${count} times in a row`,
+        {
+          count,
+          hash,
+          window: this.config.messageHashWindow,
+        }
+      );
     }
     return NOOP_DECISION;
   }
@@ -282,32 +305,39 @@ export class LoopGuard {
 
   /** Expose raw counters for diagnostics / testing. */
   snapshot(): {
-    hashCounts: Record<string, number>;
+    currentHash: string | null;
+    currentStreak: number;
     toolFrequency: Record<string, number>;
     window: string[];
   } {
     return {
-      hashCounts: Object.fromEntries(this.hashCounts),
+      currentHash: this.currentHash,
+      currentStreak: this.currentStreak,
       toolFrequency: Object.fromEntries(this.toolFrequency),
       window: [...this.hashWindow],
     };
   }
 
   private pushHash(hash: string): void {
+    // Maintain a small sliding window purely for diagnostics. The window
+    // length does not influence streak comparison.
     this.hashWindow.push(hash);
-    this.hashCounts.set(hash, (this.hashCounts.get(hash) ?? 0) + 1);
     while (this.hashWindow.length > this.config.messageHashWindow) {
-      const removed = this.hashWindow.shift();
-      if (removed == null) break;
-      const prev = this.hashCounts.get(removed) ?? 0;
-      if (prev <= 1) {
-        this.hashCounts.delete(removed);
-        // once it fully leaves the window, allow fresh warn/halt cycles for it again
-        this.hashWarnIssued.delete(removed);
-        this.hashHaltIssued.delete(removed);
-      } else {
-        this.hashCounts.set(removed, prev - 1);
-      }
+      this.hashWindow.shift();
+    }
+
+    // Streak bookkeeping: only consecutive identical hashes count toward the
+    // duplicate-hash thresholds. A different hash resets the streak to 1 and
+    // clears the per-streak issued flags so the new streak can warn/halt/abort
+    // on its own merits.
+    if (hash === this.currentHash) {
+      this.currentStreak += 1;
+    } else {
+      this.currentHash = hash;
+      this.currentStreak = 1;
+      this.streakWarnIssued = false;
+      this.streakHaltIssued = false;
+      this.streakAbortIssued = false;
     }
   }
 

--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -65,6 +65,14 @@ import {
 import { buildPiSessionRuntimeSignature } from './pi-session-runtime';
 import { ThinkTagStreamParser } from './think-tag-parser';
 import {
+  LoopGuard,
+  buildAbortUserMessage,
+  buildHaltSteerMessage,
+  buildWarnSteerMessage,
+  type LoopGuardDecision,
+  type ToolCallDescriptor,
+} from './agent-runner-loop-guard';
+import {
   normalizeMcpToolResultForModel,
   normalizeToolExecutionResultForUi,
 } from './tool-result-utils';
@@ -2322,6 +2330,61 @@ Tool routing:
       const promptStartedAt = Date.now();
       const streamEventCounts = new Map<string, number>();
 
+      // ── Loop guard: protect against runaway tool-call loops ──
+      // (e.g. gemini-3.1-pro with thinking=off has been observed producing hundreds
+      //  of empty-text + single-tool-call responses in a single turn)
+      // Two layers: hash of whole tool-call group (window=20, warn=3/halt=5/abort=8)
+      //             + per-tool frequency (warn=30/halt=50/abort=80).
+      const loopGuard = new LoopGuard();
+      const handleLoopGuardDecision = (decision: LoopGuardDecision, context: string): void => {
+        if (decision.action === 'none' || controller.signal.aborted) return;
+        logWarn(`[LoopGuard] ${context}: action=${decision.action} reason=${decision.reason}`);
+
+        if (decision.action === 'hash_abort' || decision.action === 'freq_abort') {
+          if (!hasEmittedError) {
+            hasEmittedError = true;
+            this.sendMessage(session.id, {
+              id: uuidv4(),
+              sessionId: session.id,
+              role: 'assistant',
+              content: [{ type: 'text', text: buildAbortUserMessage(decision) }],
+              timestamp: Date.now(),
+            });
+          }
+          this.sendTraceUpdate(session.id, thinkingStepId, {
+            status: 'error',
+            title: 'Stopped: tool-call loop detected',
+          });
+          try {
+            controller.abort();
+          } catch (abortErr) {
+            logWarn('[LoopGuard] abort error:', abortErr);
+          }
+          return;
+        }
+
+        const steerText =
+          decision.action === 'hash_halt' || decision.action === 'freq_halt'
+            ? buildHaltSteerMessage(decision)
+            : buildWarnSteerMessage(decision);
+        // fire-and-forget: SDK queues the steering message for the next turn
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const sessionAny = piSession as any;
+          if (typeof sessionAny.sendUserMessage === 'function') {
+            Promise.resolve(sessionAny.sendUserMessage(steerText, { deliverAs: 'steer' })).catch(
+              (err: unknown) => {
+                logWarn('[LoopGuard] sendUserMessage(steer) failed:', err);
+              }
+            );
+          } else {
+            logWarn('[LoopGuard] piSession.sendUserMessage is not available; skipping steer');
+          }
+        } catch (steerErr) {
+          logWarn('[LoopGuard] sendUserMessage(steer) threw:', steerErr);
+        }
+      };
+
       // Ollama cold-start feedback: if provider is 'ollama' and no stream event arrives
       // within 10 seconds, show a "model loading" trace update so users know what's happening.
       let ollamaColdStartTimerId: ReturnType<typeof setTimeout> | undefined;
@@ -2587,6 +2650,25 @@ Tool routing:
                   type: 'stream.partial',
                   payload: { sessionId: session.id, delta: '' },
                 });
+
+                // ── Loop guard layer 1: hash of this message's tool-call group ──
+                const toolUseDescriptors: ToolCallDescriptor[] = [];
+                for (const block of resolvedPayload.effectiveContent) {
+                  if (block.type === 'toolCall') {
+                    toolUseDescriptors.push({
+                      name: block.name || '',
+                      input: (block.arguments as Record<string, unknown>) || undefined,
+                    });
+                  }
+                }
+                if (toolUseDescriptors.length > 0) {
+                  handleLoopGuardDecision(
+                    loopGuard.recordAssistantMessage(toolUseDescriptors),
+                    'message_end'
+                  );
+                  if (controller.signal.aborted) break;
+                }
+
                 if (contentBlocks.length > 0) {
                   const msgWithUsage = msg as { usage?: unknown };
                   const tokenUsage = normalizeTokenUsage(msgWithUsage.usage);
@@ -2621,6 +2703,11 @@ Tool routing:
 
             case 'tool_execution_start': {
               logCtx(`[ClaudeAgentRunner] Tool execution start: ${event.toolName}`);
+              // ── Loop guard layer 2: per-tool cumulative frequency ──
+              handleLoopGuardDecision(
+                loopGuard.recordToolInvocation(event.toolName),
+                'tool_execution_start'
+              );
               break;
             }
 

--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -1211,6 +1211,10 @@ ${hints.join('\n')}
 
     const thinkingStepId = uuidv4();
     let abortedByTimeout = false;
+    // Set to true when the loop-guard unilaterally aborts (hash_abort / freq_abort).
+    // The catch block consults this flag to avoid overwriting the 'error' trace
+    // status that handleLoopGuardDecision has already published.
+    let abortedByLoopGuard = false;
 
     try {
       this.pathResolver.registerSession(session.id, session.mountedPaths);
@@ -2356,6 +2360,10 @@ Tool routing:
             title: 'Stopped: tool-call loop detected',
           });
           try {
+            // Mark BEFORE calling abort() so the AbortError handler in the
+            // outer catch can distinguish a loop-guard abort from a user
+            // cancel and skip the "Cancelled" trace overwrite.
+            abortedByLoopGuard = true;
             controller.abort();
           } catch (abortErr) {
             logWarn('[LoopGuard] abort error:', abortErr);
@@ -2868,6 +2876,14 @@ Tool routing:
         });
         return;
       }
+      // If the SDK swallowed the AbortError after a loop-guard abort, preserve
+      // the 'error' trace status that handleLoopGuardDecision already published.
+      // The user-facing message and trace step are already set; do not overwrite
+      // them with the default "Task completed" below.
+      if (controller.signal.aborted && abortedByLoopGuard) {
+        logCtx('[ClaudeAgentRunner] Aborted by loop guard (detected after prompt returned)');
+        return;
+      }
       // Complete - update the initial thinking step
       this.sendTraceUpdate(session.id, thinkingStepId, {
         status: terminalErrorText ? 'error' : 'completed',
@@ -2889,6 +2905,11 @@ Tool routing:
             status: 'error',
             title: 'Request timed out',
           });
+        } else if (abortedByLoopGuard) {
+          // Loop guard already published the user-facing assistant message and
+          // an 'error' trace step with the loop-detected title. Do NOT overwrite
+          // them here with a 'completed/Cancelled' state.
+          logCtx('[ClaudeAgentRunner] Aborted by loop guard');
         } else {
           logCtx('[ClaudeAgentRunner] Aborted by user');
           this.sendTraceUpdate(session.id, thinkingStepId, {

--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -2345,16 +2345,18 @@ Tool routing:
         logWarn(`[LoopGuard] ${context}: action=${decision.action} reason=${decision.reason}`);
 
         if (decision.action === 'hash_abort' || decision.action === 'freq_abort') {
-          if (!hasEmittedError) {
-            hasEmittedError = true;
-            this.sendMessage(session.id, {
-              id: uuidv4(),
-              sessionId: session.id,
-              role: 'assistant',
-              content: [{ type: 'text', text: buildAbortUserMessage(decision) }],
-              timestamp: Date.now(),
-            });
-          }
+          // Always surface the loop-guard explanation, even if an earlier
+          // error already set hasEmittedError — the user must see why the
+          // session stopped. Mark the flag afterward to suppress duplicate
+          // generic-error chatter from later paths in this turn.
+          this.sendMessage(session.id, {
+            id: uuidv4(),
+            sessionId: session.id,
+            role: 'assistant',
+            content: [{ type: 'text', text: buildAbortUserMessage(decision) }],
+            timestamp: Date.now(),
+          });
+          hasEmittedError = true;
           this.sendTraceUpdate(session.id, thinkingStepId, {
             status: 'error',
             title: 'Stopped: tool-call loop detected',

--- a/tests/agent-runner-loop-guard-abort.test.ts
+++ b/tests/agent-runner-loop-guard-abort.test.ts
@@ -90,4 +90,29 @@ describe('agent-runner loop-guard abort preserves error trace status', () => {
     const localBlock = agentRunnerContent.slice(localStart, titleIdx);
     expect(localBlock).toContain("status: 'error'");
   });
+
+  it('always emits the buildAbortUserMessage explanation, even if a prior error set hasEmittedError', () => {
+    // Regression test for bot review on PR #225: the original block gated the
+    // sendMessage(buildAbortUserMessage) on `if (!hasEmittedError)`, which
+    // suppressed the loop-guard explanation when any earlier path had already
+    // emitted an error. Users would then see only the error trace step with no
+    // chat message explaining why the session stopped.
+    //
+    // Pin: the sendMessage that wraps buildAbortUserMessage must NOT be inside
+    // an `if (!hasEmittedError)` gate, and the assignment to hasEmittedError
+    // should follow the sendMessage so the suppression intent is preserved for
+    // later generic-error paths.
+    const sendIdx = agentRunnerContent.indexOf('text: buildAbortUserMessage(decision)');
+    expect(sendIdx).toBeGreaterThan(-1);
+
+    // The 200 chars immediately before the sendMessage must not contain a
+    // bare `if (!hasEmittedError) {` gate (i.e., the old suppression check).
+    const preamble = agentRunnerContent.slice(Math.max(0, sendIdx - 400), sendIdx);
+    expect(preamble).not.toMatch(/if\s*\(\s*!hasEmittedError\s*\)\s*\{/);
+
+    // hasEmittedError should be assigned AFTER the sendMessage to suppress
+    // duplicate generic errors later in this turn, not before.
+    const trailing = agentRunnerContent.slice(sendIdx, sendIdx + 400);
+    expect(trailing).toContain('hasEmittedError = true');
+  });
 });

--- a/tests/agent-runner-loop-guard-abort.test.ts
+++ b/tests/agent-runner-loop-guard-abort.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const agentRunnerPath = path.resolve(process.cwd(), 'src/main/claude/agent-runner.ts');
+const agentRunnerContent = readFileSync(agentRunnerPath, 'utf8');
+
+/**
+ * These tests pin the post-rescue catch-block disposition for loop-guard
+ * aborts. The bug they guard against: when handleLoopGuardDecision called
+ * controller.abort(), the AbortError ended up in the generic "Aborted by
+ * user" branch which overwrote the loop-guard's 'error' trace step with
+ * status:'completed', title:'Cancelled'.
+ */
+describe('agent-runner loop-guard abort preserves error trace status', () => {
+  it('declares an abortedByLoopGuard flag in the prompt() scope', () => {
+    expect(agentRunnerContent).toContain('let abortedByLoopGuard = false;');
+  });
+
+  it('sets the flag immediately before controller.abort() in handleLoopGuardDecision', () => {
+    // The assignment must appear in the loop-guard block AND must precede the
+    // controller.abort() call so the AbortError handler sees the flag.
+    const setIdx = agentRunnerContent.indexOf('abortedByLoopGuard = true;');
+    expect(setIdx).toBeGreaterThan(-1);
+
+    const abortIdx = agentRunnerContent.indexOf('controller.abort();', setIdx);
+    expect(abortIdx).toBeGreaterThan(setIdx);
+
+    // No other lines should sneak between the flag set and the abort call —
+    // keep them adjacent so the intent is obvious.
+    const between = agentRunnerContent.slice(setIdx, abortIdx);
+    const nonTrivialLines = between
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0 && !l.startsWith('//'));
+    expect(nonTrivialLines.length).toBeLessThanOrEqual(2);
+  });
+
+  it('the AbortError catch branch checks abortedByLoopGuard before falling into the user-cancel branch', () => {
+    // Pull out the AbortError handler block for inspection.
+    const start = agentRunnerContent.indexOf("error.name === 'AbortError'");
+    expect(start).toBeGreaterThan(-1);
+    const end = agentRunnerContent.indexOf('} else {', start);
+    expect(end).toBeGreaterThan(start);
+    const block = agentRunnerContent.slice(start, end + 800);
+
+    // The branch for loop-guard must exist and must be reached BEFORE the
+    // generic "Aborted by user" path that emits 'Cancelled'.
+    const loopGuardBranchIdx = block.indexOf('abortedByLoopGuard');
+    const userCancelIdx = block.indexOf("title: 'Cancelled'");
+    expect(loopGuardBranchIdx).toBeGreaterThan(-1);
+    expect(userCancelIdx).toBeGreaterThan(loopGuardBranchIdx);
+  });
+
+  it('the loop-guard catch branch does NOT overwrite the trace status with Cancelled', () => {
+    // Capture the loop-guard branch body and assert the executable code
+    // contains neither sendTraceUpdate nor a 'Cancelled' literal — the guard
+    // already published the error trace.
+    const branchStart = agentRunnerContent.indexOf('} else if (abortedByLoopGuard) {');
+    expect(branchStart).toBeGreaterThan(-1);
+    const branchEnd = agentRunnerContent.indexOf('} else {', branchStart);
+    expect(branchEnd).toBeGreaterThan(branchStart);
+    const branch = agentRunnerContent.slice(branchStart, branchEnd);
+
+    // Strip single-line comments so the explanatory prose can mention
+    // "Cancelled" without tripping the assertion.
+    const codeOnly = branch
+      .split('\n')
+      .map((line) => line.replace(/\/\/.*$/, ''))
+      .join('\n');
+
+    expect(codeOnly).not.toContain('Cancelled');
+    expect(codeOnly).not.toContain('sendTraceUpdate');
+    expect(branch).toContain('Aborted by loop guard');
+  });
+
+  it('the post-prompt short-circuit also returns early on a swallowed loop-guard abort', () => {
+    // Some SDK builds swallow AbortError and return void instead of throwing.
+    // For that path we still need to skip the "Task completed" trace update.
+    expect(agentRunnerContent).toContain('if (controller.signal.aborted && abortedByLoopGuard)');
+    expect(agentRunnerContent).toContain('Aborted by loop guard (detected after prompt returned)');
+  });
+
+  it('the loop-guard decision handler still publishes the error trace step before aborting', () => {
+    // The trace update with status:'error' and the loop-detected title must
+    // stay in place so the catch branch has something to preserve.
+    expect(agentRunnerContent).toContain("title: 'Stopped: tool-call loop detected'");
+    const titleIdx = agentRunnerContent.indexOf("title: 'Stopped: tool-call loop detected'");
+    const localStart = agentRunnerContent.lastIndexOf('sendTraceUpdate', titleIdx);
+    const localBlock = agentRunnerContent.slice(localStart, titleIdx);
+    expect(localBlock).toContain("status: 'error'");
+  });
+});

--- a/tests/agent-runner-loop-guard.test.ts
+++ b/tests/agent-runner-loop-guard.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_LOOP_GUARD_CONFIG,
+  LoopGuard,
+  buildAbortUserMessage,
+  buildHaltSteerMessage,
+  buildWarnSteerMessage,
+  messageCallsHash,
+  stableToolKey,
+  type ToolCallDescriptor,
+} from '../src/main/claude/agent-runner-loop-guard';
+
+describe('stableToolKey', () => {
+  it('buckets adjacent read_file line ranges into the same key', () => {
+    const a = stableToolKey('read_file', { file_path: '/a/b.ts', start_line: 1 });
+    const b = stableToolKey('read_file', { file_path: '/a/b.ts', start_line: 100 });
+    const c = stableToolKey('read_file', { file_path: '/a/b.ts', start_line: 199 });
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it('separates read_file buckets when crossing the 200-line boundary', () => {
+    const a = stableToolKey('read_file', { file_path: '/a/b.ts', start_line: 10 });
+    const b = stableToolKey('read_file', { file_path: '/a/b.ts', start_line: 500 });
+    expect(a).not.toBe(b);
+  });
+
+  it('distinguishes different files for read_file', () => {
+    const a = stableToolKey('read_file', { file_path: '/a/b.ts', start_line: 0 });
+    const b = stableToolKey('read_file', { file_path: '/a/c.ts', start_line: 0 });
+    expect(a).not.toBe(b);
+  });
+
+  it('treats write_file content changes as distinct operations', () => {
+    const a = stableToolKey('write_file', { file_path: '/a.ts', content: 'hello' });
+    const b = stableToolKey('write_file', { file_path: '/a.ts', content: 'world' });
+    expect(a).not.toBe(b);
+  });
+
+  it('str_replace with different replacement payloads yields different keys', () => {
+    const a = stableToolKey('str_replace', { path: '/f', old_str: 'a', new_str: 'b' });
+    const b = stableToolKey('str_replace', { path: '/f', old_str: 'a', new_str: 'c' });
+    expect(a).not.toBe(b);
+  });
+
+  it('generic tool extracts only key fields (ignores noise)', () => {
+    const a = stableToolKey('web_search', { query: 'foo', session_id: 'x', ts: 1 });
+    const b = stableToolKey('web_search', { query: 'foo', session_id: 'y', ts: 2 });
+    expect(a).toBe(b);
+  });
+
+  it('generic tool with different query yields different keys', () => {
+    const a = stableToolKey('web_search', { query: 'foo' });
+    const b = stableToolKey('web_search', { query: 'bar' });
+    expect(a).not.toBe(b);
+  });
+
+  it('is stable against key ordering in input objects', () => {
+    const a = stableToolKey('bash', { command: 'ls', cwd: '/a' });
+    const b = stableToolKey('bash', { cwd: '/a', command: 'ls' });
+    expect(a).toBe(b);
+  });
+
+  it('returns a deterministic placeholder for missing input', () => {
+    expect(stableToolKey('any', undefined)).toBe('any:∅');
+  });
+});
+
+describe('messageCallsHash', () => {
+  it('returns the same hash for identical tool-call groups regardless of object key ordering', () => {
+    const groupA: ToolCallDescriptor[] = [
+      { name: 'bash', input: { command: 'ls' } },
+      { name: 'read_file', input: { file_path: '/x', start_line: 0 } },
+    ];
+    const groupB: ToolCallDescriptor[] = [
+      { name: 'bash', input: { command: 'ls' } },
+      { name: 'read_file', input: { start_line: 0, file_path: '/x' } },
+    ];
+    expect(messageCallsHash(groupA)).toBe(messageCallsHash(groupB));
+  });
+
+  it('order matters (sequence of calls is part of identity)', () => {
+    const group1: ToolCallDescriptor[] = [
+      { name: 'a', input: { x: 1 } },
+      { name: 'b', input: { y: 2 } },
+    ];
+    const group2: ToolCallDescriptor[] = [
+      { name: 'b', input: { y: 2 } },
+      { name: 'a', input: { x: 1 } },
+    ];
+    expect(messageCallsHash(group1)).not.toBe(messageCallsHash(group2));
+  });
+
+  it('empty tool-call list hashes to empty string', () => {
+    expect(messageCallsHash([])).toBe('');
+  });
+});
+
+describe('LoopGuard layer 1 — hash-based group detection', () => {
+  const buildCall = (name: string, input: Record<string, unknown>): ToolCallDescriptor => ({
+    name,
+    input,
+  });
+
+  it('emits hash_warn on the 3rd identical group and halt on the 5th and abort on the 8th', () => {
+    const guard = new LoopGuard();
+    const group = [buildCall('bash', { command: 'echo hi' })];
+
+    const decisions = Array.from({ length: 10 }, () => guard.recordAssistantMessage(group));
+
+    expect(decisions[0].action).toBe('none');
+    expect(decisions[1].action).toBe('none');
+    expect(decisions[2].action).toBe('hash_warn');
+    expect(decisions[2].count).toBe(3);
+    expect(decisions[3].action).toBe('none');
+    expect(decisions[4].action).toBe('hash_halt');
+    expect(decisions[4].count).toBe(5);
+    expect(decisions[5].action).toBe('none');
+    expect(decisions[6].action).toBe('none');
+    expect(decisions[7].action).toBe('hash_abort');
+    expect(decisions[7].count).toBe(8);
+    expect(decisions[8].action).toBe('none');
+    expect(decisions[9].action).toBe('none');
+  });
+
+  it('different groups do not contribute to each other', () => {
+    const guard = new LoopGuard();
+    const groupA = [buildCall('read_file', { file_path: '/a', start_line: 0 })];
+    const groupB = [buildCall('read_file', { file_path: '/b', start_line: 0 })];
+
+    const seq = [groupA, groupB, groupA, groupB, groupA, groupB, groupA, groupB];
+    const actions = seq.map((g) => guard.recordAssistantMessage(g).action);
+    expect(actions[4]).toBe('hash_warn');
+    expect(actions[5]).toBe('hash_warn');
+    expect(actions[6]).toBe('none');
+    expect(actions[7]).toBe('none');
+  });
+
+  it('empty tool-call messages (pure text responses) are ignored by the guard', () => {
+    const guard = new LoopGuard();
+    expect(guard.recordAssistantMessage([]).action).toBe('none');
+    expect(guard.recordAssistantMessage([]).action).toBe('none');
+    expect(guard.recordAssistantMessage([]).action).toBe('none');
+  });
+
+  it('respects sliding window — old entries drop out and allow re-triggering', () => {
+    const guard = new LoopGuard({ messageHashWindow: 3 });
+    const A = [buildCall('a', { x: 1 })];
+    const B = [buildCall('b', { x: 1 })];
+
+    expect(guard.recordAssistantMessage(A).action).toBe('none');
+    expect(guard.recordAssistantMessage(A).action).toBe('none');
+    expect(guard.recordAssistantMessage(A).action).toBe('hash_warn');
+
+    guard.recordAssistantMessage(B);
+    guard.recordAssistantMessage(B);
+    guard.recordAssistantMessage(B);
+
+    expect(guard.recordAssistantMessage(A).action).toBe('none');
+    expect(guard.recordAssistantMessage(A).action).toBe('none');
+    expect(guard.recordAssistantMessage(A).action).toBe('hash_warn');
+  });
+
+  it('collapses adjacent read_file ranges so they count as the same group', () => {
+    const guard = new LoopGuard();
+    const actions = [0, 50, 100, 150, 199]
+      .map((start) => [buildCall('read_file', { file_path: '/big.ts', start_line: start })])
+      .map((g) => guard.recordAssistantMessage(g).action);
+
+    expect(actions[0]).toBe('none');
+    expect(actions[1]).toBe('none');
+    expect(actions[2]).toBe('hash_warn');
+    expect(actions[3]).toBe('none');
+    expect(actions[4]).toBe('hash_halt');
+  });
+});
+
+describe('LoopGuard layer 2 — per-tool frequency detection', () => {
+  it('per-tool counters are independent across tool names', () => {
+    const guard = new LoopGuard();
+    for (let i = 0; i < 29; i++) guard.recordToolInvocation('read_file');
+    for (let i = 0; i < 29; i++) guard.recordToolInvocation('bash');
+    expect(guard.recordToolInvocation('read_file').action).toBe('freq_warn');
+    expect(guard.recordToolInvocation('bash').action).toBe('freq_warn');
+  });
+
+  it('custom thresholds via constructor are honoured', () => {
+    const guard = new LoopGuard({
+      toolFrequencyWarnThreshold: 2,
+      toolFrequencyHaltThreshold: 3,
+      toolFrequencyAbortThreshold: 4,
+    });
+    expect(guard.recordToolInvocation('x').action).toBe('none');
+    expect(guard.recordToolInvocation('x').action).toBe('freq_warn');
+    expect(guard.recordToolInvocation('x').action).toBe('freq_halt');
+    expect(guard.recordToolInvocation('x').action).toBe('freq_abort');
+  });
+});
+
+describe('Message builders', () => {
+  it('warn / halt / abort messages all contain the count or tool name', () => {
+    const warnHash = buildWarnSteerMessage({ action: 'hash_warn', reason: 'x', count: 3 });
+    expect(warnHash).toContain('3');
+    expect(warnHash).toContain('Loop Guard');
+
+    const haltFreq = buildHaltSteerMessage({
+      action: 'freq_halt',
+      reason: 'x',
+      toolName: 'bash',
+      count: 50,
+    });
+    expect(haltFreq).toContain('bash');
+    expect(haltFreq).toContain('50');
+    expect(haltFreq).toContain('STOP');
+
+    const abortHash = buildAbortUserMessage({ action: 'hash_abort', reason: 'x', count: 8 });
+    expect(abortHash).toContain('8');
+    expect(abortHash).toContain('Loop Guard');
+    expect(abortHash).toContain('Thinking');
+  });
+});
+
+describe('DEFAULT_LOOP_GUARD_CONFIG', () => {
+  it('matches the documented thresholds', () => {
+    expect(DEFAULT_LOOP_GUARD_CONFIG.messageHashWindow).toBe(20);
+    expect(DEFAULT_LOOP_GUARD_CONFIG.duplicateHashWarnThreshold).toBe(3);
+    expect(DEFAULT_LOOP_GUARD_CONFIG.duplicateHashHaltThreshold).toBe(5);
+    expect(DEFAULT_LOOP_GUARD_CONFIG.duplicateHashAbortThreshold).toBe(8);
+    expect(DEFAULT_LOOP_GUARD_CONFIG.toolFrequencyWarnThreshold).toBe(30);
+    expect(DEFAULT_LOOP_GUARD_CONFIG.toolFrequencyHaltThreshold).toBe(50);
+    expect(DEFAULT_LOOP_GUARD_CONFIG.toolFrequencyAbortThreshold).toBe(80);
+    expect(DEFAULT_LOOP_GUARD_CONFIG.readFileLineBucketSize).toBe(200);
+  });
+});

--- a/tests/agent-runner-loop-guard.test.ts
+++ b/tests/agent-runner-loop-guard.test.ts
@@ -97,7 +97,7 @@ describe('messageCallsHash', () => {
   });
 });
 
-describe('LoopGuard layer 1 — hash-based group detection', () => {
+describe('LoopGuard layer 1 — hash-based group detection (streak semantics)', () => {
   const buildCall = (name: string, input: Record<string, unknown>): ToolCallDescriptor => ({
     name,
     input,
@@ -124,17 +124,38 @@ describe('LoopGuard layer 1 — hash-based group detection', () => {
     expect(decisions[9].action).toBe('none');
   });
 
-  it('different groups do not contribute to each other', () => {
+  it('A/B/A/B/A interleaved pattern does NOT fire (no consecutive streak)', () => {
+    // Regression test for false-positive bug: under the old frequency-map
+    // semantics, the 5-element A/B/A/B/A sequence would push A's count to 3
+    // and incorrectly trigger hash_warn. Under streak semantics the streak
+    // never exceeds 1 because every message is a different hash from the
+    // previous one.
+    const guard = new LoopGuard();
+    const A = [buildCall('a', { x: 1 })];
+    const B = [buildCall('b', { x: 1 })];
+
+    const actions = [A, B, A, B, A, B, A, B, A, B].map(
+      (g) => guard.recordAssistantMessage(g).action
+    );
+
+    for (const action of actions) {
+      expect(action).toBe('none');
+    }
+  });
+
+  it('different consecutive groups do not contribute to each other', () => {
     const guard = new LoopGuard();
     const groupA = [buildCall('read_file', { file_path: '/a', start_line: 0 })];
     const groupB = [buildCall('read_file', { file_path: '/b', start_line: 0 })];
 
-    const seq = [groupA, groupB, groupA, groupB, groupA, groupB, groupA, groupB];
-    const actions = seq.map((g) => guard.recordAssistantMessage(g).action);
-    expect(actions[4]).toBe('hash_warn');
-    expect(actions[5]).toBe('hash_warn');
-    expect(actions[6]).toBe('none');
-    expect(actions[7]).toBe('none');
+    // Each block of 3 consecutive identical messages fires exactly one warn for
+    // its own hash; the streak resets when the group changes.
+    expect(guard.recordAssistantMessage(groupA).action).toBe('none');
+    expect(guard.recordAssistantMessage(groupA).action).toBe('none');
+    expect(guard.recordAssistantMessage(groupA).action).toBe('hash_warn');
+    expect(guard.recordAssistantMessage(groupB).action).toBe('none');
+    expect(guard.recordAssistantMessage(groupB).action).toBe('none');
+    expect(guard.recordAssistantMessage(groupB).action).toBe('hash_warn');
   });
 
   it('empty tool-call messages (pure text responses) are ignored by the guard', () => {
@@ -144,25 +165,28 @@ describe('LoopGuard layer 1 — hash-based group detection', () => {
     expect(guard.recordAssistantMessage([]).action).toBe('none');
   });
 
-  it('respects sliding window — old entries drop out and allow re-triggering', () => {
-    const guard = new LoopGuard({ messageHashWindow: 3 });
+  it('streak resets when a different hash arrives, allowing fresh warn/halt cycles', () => {
+    const guard = new LoopGuard();
     const A = [buildCall('a', { x: 1 })];
     const B = [buildCall('b', { x: 1 })];
 
+    // First A-streak fires at length 3.
     expect(guard.recordAssistantMessage(A).action).toBe('none');
     expect(guard.recordAssistantMessage(A).action).toBe('none');
     expect(guard.recordAssistantMessage(A).action).toBe('hash_warn');
 
+    // A run of Bs breaks the A-streak and clears its per-streak issued flags.
     guard.recordAssistantMessage(B);
     guard.recordAssistantMessage(B);
     guard.recordAssistantMessage(B);
 
+    // A subsequent A-streak can warn again.
     expect(guard.recordAssistantMessage(A).action).toBe('none');
     expect(guard.recordAssistantMessage(A).action).toBe('none');
     expect(guard.recordAssistantMessage(A).action).toBe('hash_warn');
   });
 
-  it('collapses adjacent read_file ranges so they count as the same group', () => {
+  it('collapses adjacent read_file ranges so they count as the same consecutive group', () => {
     const guard = new LoopGuard();
     const actions = [0, 50, 100, 150, 199]
       .map((start) => [buildCall('read_file', { file_path: '/big.ts', start_line: start })])
@@ -173,6 +197,24 @@ describe('LoopGuard layer 1 — hash-based group detection', () => {
     expect(actions[2]).toBe('hash_warn');
     expect(actions[3]).toBe('none');
     expect(actions[4]).toBe('hash_halt');
+  });
+
+  it('snapshot exposes currentStreak and currentHash for diagnostics', () => {
+    const guard = new LoopGuard();
+    const A = [buildCall('a', { x: 1 })];
+    const B = [buildCall('b', { x: 1 })];
+
+    guard.recordAssistantMessage(A);
+    guard.recordAssistantMessage(A);
+    const snap1 = guard.snapshot();
+    expect(snap1.currentStreak).toBe(2);
+    expect(typeof snap1.currentHash).toBe('string');
+    expect(snap1.window).toHaveLength(2);
+
+    guard.recordAssistantMessage(B);
+    const snap2 = guard.snapshot();
+    expect(snap2.currentStreak).toBe(1);
+    expect(snap2.currentHash).not.toBe(snap1.currentHash);
   });
 });
 


### PR DESCRIPTION
## Summary

This PR rescues @joekingss's excellent loop-guard work from #175 so it can ship in v3.3.1. The original PR has `maintainerCanModify=false` and is branched off the author's fork `main`, so we cannot push the two follow-up fixes directly to it. To preserve authorship we cherry-picked the original commit verbatim (Author/Date/Co-author all retained) and stacked the two maintainer fixes on top as separate commits.

Closes #175

## Commits

1. **`feat(loop-guard): add tool-call loop detection and protection`** — original commit by @joekingss, cherry-picked unchanged. Adds `agent-runner-loop-guard.ts` (382 LoC), wires Layer 1 (hash of tool-call signature, warn=3 / halt=5 / abort=8) into `message_end` and Layer 2 (per-tool name count, 30/50/80) into `tool_execution_start`, plus 21 unit tests.
2. **`fix(loop-guard): use streak counter instead of frequency map`** (maintainer) — replaces the per-hash frequency map in the 20-message sliding window with a single (currentHash, currentStreak) pair. Patterns like A/B/A/B/A no longer false-positive at warn threshold because the streak resets on any hash change. Adds A/B/A/B regression test and snapshot diagnostic test.
3. **`fix(loop-guard): preserve error trace status across loop-guard abort`** (maintainer) — introduces `abortedByLoopGuard` flag in the `prompt()` scope, set immediately before `controller.abort()` in `handleLoopGuardDecision`. The AbortError catch gains a branch parallel to `abortedByTimeout` that preserves the guard's `status:'error'` trace step instead of overwriting it with `status:'completed', title:'Cancelled'`. A swallowed-AbortError short-circuit is added on the post-prompt path for SDK builds that return void after abort. New `agent-runner-loop-guard-abort.test.ts` pins the wiring.

## Why a new PR

@joekingss disabled `maintainerCanModify` on #175 and the PR head is `Golden-Bridge-404:main` (their fork's default branch). GitHub rules forbid maintainer pushes in that configuration, so the only way to ship reviewer-requested fixes is a new branch on the upstream remote. All credit for the original design and 700+ LoC of implementation belongs to @joekingss, preserved via cherry-pick (commit author/date) and a `Co-authored-by` trailer below.

## Compatibility

- Orthogonal to #165 (permissions). #165 uses `setBeforeToolCall` hook; loop-guard uses stream events (`message_end`, `tool_execution_start`). No shared state. Cherry-pick of the original commit auto-merged cleanly against current `main`.

## Test plan

- [x] `npm run lint` — 0 errors, 8 pre-existing warnings
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/agent-runner-loop-guard.test.ts` — 23/23 pass (was 21, +2 for streak regression + snapshot)
- [x] `npx vitest run tests/agent-runner-loop-guard-abort.test.ts` — 6/6 pass (new file, pins catch-block disposition)
- [x] Full suite: 889/907 pass; 18 failures are in `src/tests/memory/*` and `tests/deepseek-thinking-serialization.test.ts` and pre-exist on `origin/main` (verified by checking out main and re-running).
- [ ] Manual: trigger a Gemini empty-loop scenario with `thinking=off` and confirm the assistant receives a "loop detected" error message with `status:'error'` trace step (not "Cancelled").

Co-authored-by: joekingss <hexianglin@storswift.com>