### PR TITLE
fix(ci): apply patch-package in release.yml lint-and-test job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Apply patches
+        run: npx patch-package
+
       - name: Build native modules for tests
         run: npm rebuild better-sqlite3
 


### PR DESCRIPTION
## Summary

Hotfix for v3.3.1 release pipeline. The `release.yml` lint-and-test job runs `npm ci --ignore-scripts` (consistent with `ci.yml` for supply-chain safety) but was missing the `npx patch-package` step that `ci.yml` has right after install.

As a result `patches/@mariozechner+pi-ai+0.60.0.patch` never applied during release.yml runs, and `tests/deepseek-thinking-serialization.test.ts` correctly failed:

```
Error: Expected @mariozechner/pi-ai patch to be applied before running this suite
```

912 unit tests passed; only the patch-verification test correctly detected the missing patch. Because lint-and-test failed, the mac/win build jobs were skipped → v3.3.1 release tag produced no artifacts.

## What changed

`.github/workflows/release.yml` — add `npx patch-package` step in the lint-and-test job, immediately after `npm ci --ignore-scripts`. This mirrors the existing pattern in `ci.yml`.

```diff
 - name: Install dependencies
   run: npm ci --ignore-scripts

+- name: Apply patches
+  run: npx patch-package
+
 - name: Build native modules for tests
   run: npm rebuild better-sqlite3
```

## Follow-up

After merge:
- Re-push `v3.3.1` tag (deleted earlier today after the broken run) so release.yml runs cleanly and produces the macOS + Windows artifacts.