### PR TITLE
fix(mcp): support OAuth on streamable HTTP connectors

### DIFF
--- a/src/main/mcp/mcp-manager.ts
+++ b/src/main/mcp/mcp-manager.ts
@@ -16,9 +16,10 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { createHash } from 'crypto';
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, shell } from 'electron';
 
 import path from 'path';
+import { connectWithOAuthRetry, OpenCoworkMcpOAuthProvider } from './mcp-oauth';
 import { log, logError, logWarn, logCtx, logCtxError, logTiming } from '../utils/logger';
 import { getDefaultShell } from '../utils/shell-resolver';
 
@@ -28,6 +29,8 @@ const MCP_TOOL_CALL_TIMEOUT_MS = 5 * 60 * 1000;
 type RefreshToolsResult =
   | { kind: 'success'; serverId: string; tools: MCPTool[] }
   | { kind: 'error'; serverId: string; error: unknown };
+
+type MCPTransport = StdioClientTransport | SSEClientTransport | StreamableHTTPClientTransport;
 
 /**
  * MCP Server Configuration
@@ -153,7 +156,6 @@ async function raceWithTimeout<T>(
   }
 }
 
-
 function getTrustedWindowsNpxDirectories(
   env: Record<string, string | undefined> = process.env
 ): string[] {
@@ -220,12 +222,11 @@ export function findPreferredWindowsNpxPath(
  */
 export class MCPManager {
   private clients: Map<string, Client> = new Map();
-  private transports: Map<
-    string,
-    StdioClientTransport | SSEClientTransport | StreamableHTTPClientTransport
-  > = new Map();
+  private transports: Map<string, MCPTransport> = new Map();
   private tools: Map<string, MCPTool> = new Map(); // toolName -> MCPTool
   private serverConfigs: Map<string, MCPServerConfig> = new Map();
+  private oauthProviders: Map<string, { provider: OpenCoworkMcpOAuthProvider; serverUrl: string }> =
+    new Map();
   private npxPath: string | null = null; // Cached npx path
   // Fingerprint of last initialized config to skip redundant re-init
   private lastConfigFingerprint: string | null = null;
@@ -644,6 +645,7 @@ export class MCPManager {
     this.lastConfigFingerprint = null;
     await this.disconnectServer(serverId);
     this.serverConfigs.delete(serverId);
+    this.oauthProviders.delete(serverId);
     await this.refreshTools();
   }
 
@@ -749,9 +751,23 @@ export class MCPManager {
    * connectionStatus is always set to 'connected' or 'failed'.
    */
   private async connectServerInternal(config: MCPServerConfig): Promise<void> {
-    let transport: StdioClientTransport | SSEClientTransport | StreamableHTTPClientTransport;
+    let transport: MCPTransport;
     let commandForLogging = '';
     let argsForLogging: string[] = [];
+    const connectTimeoutMs = 30000;
+
+    // Create MCP client before transport connect so streamable HTTP OAuth retries
+    // can reuse the same client instance across the initial unauthorized response
+    // and the authenticated reconnect.
+    const client = new Client(
+      {
+        name: 'open-cowork',
+        version: '0.1.0',
+      },
+      {
+        capabilities: {},
+      }
+    );
 
     if (config.type === 'stdio') {
       if (!config.command) {
@@ -967,46 +983,25 @@ export class MCPManager {
       if (config.headers && Object.keys(config.headers).length > 0) {
         requestInit.headers = config.headers;
       }
-      transport = new StreamableHTTPClientTransport(httpUrl, { requestInit });
+
+      const authProvider = this.getOrCreateStreamableHttpOAuthProvider(config);
+      transport = await connectWithOAuthRetry<StreamableHTTPClientTransport>({
+        connect: async (streamableTransport: StreamableHTTPClientTransport) => {
+          await this.connectClientWithTimeout(client, streamableTransport, connectTimeoutMs);
+        },
+        createTransport: (provider) =>
+          new StreamableHTTPClientTransport(httpUrl, { authProvider: provider, requestInit }),
+        provider: authProvider,
+      });
     } else {
       throw new Error(`Unsupported transport type: ${config.type}`);
     }
 
-    // Create MCP client
-    const client = new Client(
-      {
-        name: 'open-cowork',
-        version: '0.1.0',
-      },
-      {
-        capabilities: {},
-      }
-    );
-
     log(`[MCPManager] MCP client created, attempting to connect...`);
 
     try {
-      // Connect with timeout to prevent hanging indefinitely (e.g. npx download stalls)
-      const connectTimeoutMs = 30000; // 30 second timeout
-      const connectPromise = client.connect(transport);
-      let connectTimeoutId: ReturnType<typeof setTimeout>;
-      const connectTimeoutPromise = new Promise<never>((_, reject) => {
-        connectTimeoutId = setTimeout(
-          () =>
-            reject(new Error(`MCP server connection timed out after ${connectTimeoutMs / 1000}s`)),
-          connectTimeoutMs
-        );
-      });
-
-      try {
-        await Promise.race([connectPromise, connectTimeoutPromise]);
-        clearTimeout(connectTimeoutId!);
-      } catch (error) {
-        clearTimeout(connectTimeoutId!);
-        // Prevent UnhandledPromiseRejection from the orphaned connectPromise
-        // when timeout wins the race and transport is closed beneath it.
-        connectPromise.catch(() => {});
-        throw error;
+      if (config.type !== 'streamable-http') {
+        await this.connectClientWithTimeout(client, transport, connectTimeoutMs);
       }
       log(`[MCPManager] Client.connect() completed successfully`);
 
@@ -1096,6 +1091,70 @@ export class MCPManager {
     if (config.name.toLowerCase().includes('chrome')) {
       await this.ensureChromeReady(config.id, config.name, client);
     }
+  }
+
+  private async connectClientWithTimeout(
+    client: Client,
+    transport: MCPTransport,
+    timeoutMs: number
+  ): Promise<void> {
+    const connectPromise = client.connect(transport);
+    let connectTimeoutId: ReturnType<typeof setTimeout>;
+    const connectTimeoutPromise = new Promise<never>((_, reject) => {
+      connectTimeoutId = setTimeout(
+        () => reject(new Error(`MCP server connection timed out after ${timeoutMs / 1000}s`)),
+        timeoutMs
+      );
+    });
+
+    try {
+      await Promise.race([connectPromise, connectTimeoutPromise]);
+      clearTimeout(connectTimeoutId!);
+    } catch (error) {
+      clearTimeout(connectTimeoutId!);
+      // Prevent UnhandledPromiseRejection from the orphaned connectPromise
+      // when timeout wins the race and transport is closed beneath it.
+      connectPromise.catch(() => {});
+      throw error;
+    }
+  }
+
+  private getOrCreateStreamableHttpOAuthProvider(
+    config: MCPServerConfig
+  ): OpenCoworkMcpOAuthProvider {
+    if (!config.url) {
+      throw new Error(`Streamable HTTP server ${config.name} requires a URL`);
+    }
+
+    const existing = this.oauthProviders.get(config.id);
+    if (existing && existing.serverUrl === config.url) {
+      return existing.provider;
+    }
+
+    const provider = new OpenCoworkMcpOAuthProvider({
+      openExternal: async (url) => {
+        await this.openMcpAuthorizationUrl(config.name, url);
+      },
+    });
+
+    this.oauthProviders.set(config.id, {
+      provider,
+      serverUrl: config.url,
+    });
+
+    return provider;
+  }
+
+  private async openMcpAuthorizationUrl(serverName: string, url: string): Promise<void> {
+    const parsedUrl = new URL(url);
+    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+      throw new Error(
+        `MCP OAuth authorization URL for ${serverName} uses unsupported protocol: ${parsedUrl.protocol}`
+      );
+    }
+
+    log(`[MCPManager] Opening MCP OAuth authorization for ${serverName}: ${parsedUrl.origin}`);
+    await shell.openExternal(parsedUrl.toString());
   }
 
   /**
@@ -1455,9 +1514,7 @@ export class MCPManager {
           const usedToolNames = new Set<string>();
           const tools = sortedTools.map((tool) => {
             const originalToolName =
-              typeof tool.name === 'string' && tool.name.trim().length > 0
-                ? tool.name
-                : 'tool';
+              typeof tool.name === 'string' && tool.name.trim().length > 0 ? tool.name : 'tool';
             const sanitizedToolName = sanitizeMcpToolSegment(originalToolName, 'tool');
             const prefixedName = createUniqueMcpToolName(
               `mcp__${serverKey}__${sanitizedToolName}`,

--- a/src/main/mcp/mcp-oauth.ts
+++ b/src/main/mcp/mcp-oauth.ts
@@ -1,0 +1,324 @@
+import {
+  UnauthorizedError,
+  type OAuthClientProvider,
+  type OAuthDiscoveryState,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import type {
+  OAuthClientInformationMixed,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export const MCP_OAUTH_CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
+
+type OpenExternal = (url: string) => Promise<void> | void;
+
+type OAuthTransport = {
+  close(): Promise<void>;
+  finishAuth(authorizationCode: string): Promise<void>;
+};
+
+interface OAuthCallbackListener {
+  close(): Promise<void>;
+  redirectUrl: string;
+  waitForCode(): Promise<string>;
+}
+
+interface OAuthProviderOptions {
+  clientMetadataUrl?: string;
+  openExternal: OpenExternal;
+  redirectUrl?: string | URL;
+}
+
+interface ConnectWithOAuthOptions<TTransport extends OAuthTransport> {
+  callbackTimeoutMs?: number;
+  connect: (transport: TTransport) => Promise<void>;
+  createTransport: (provider: OpenCoworkMcpOAuthProvider) => TTransport;
+  provider: OpenCoworkMcpOAuthProvider;
+}
+
+function buildClientMetadata(redirectUrl: string): OAuthClientMetadata {
+  return {
+    client_name: 'Open Cowork MCP Connector',
+    grant_types: ['authorization_code', 'refresh_token'],
+    logo_uri: undefined,
+    redirect_uris: [redirectUrl],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+    tos_uri: undefined,
+  };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function safeCloseTransport(transport: OAuthTransport): Promise<void> {
+  try {
+    await transport.close();
+  } catch {
+    // Best effort cleanup only.
+  }
+}
+
+export class OpenCoworkMcpOAuthProvider implements OAuthClientProvider {
+  clientMetadataUrl?: string;
+
+  private _clientInformation?: OAuthClientInformationMixed;
+  private _codeVerifier?: string;
+  private _discoveryState?: OAuthDiscoveryState;
+  private _metadata: OAuthClientMetadata;
+  private _redirectUrl?: string | URL;
+  private readonly _openExternal: OpenExternal;
+  private _tokens?: OAuthTokens;
+
+  constructor({ clientMetadataUrl, openExternal, redirectUrl }: OAuthProviderOptions) {
+    this.clientMetadataUrl = clientMetadataUrl;
+    this._openExternal = openExternal;
+    this._redirectUrl = redirectUrl;
+    this._metadata = buildClientMetadata(String(redirectUrl ?? 'http://127.0.0.1/callback'));
+  }
+
+  get redirectUrl(): string | URL | undefined {
+    return this._redirectUrl;
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return this._metadata;
+  }
+
+  setRedirectUrl(redirectUrl: string | URL): void {
+    const nextRedirectUrl = String(redirectUrl);
+    const previousRedirectUrl =
+      this._redirectUrl === undefined ? undefined : String(this._redirectUrl);
+
+    if (previousRedirectUrl && previousRedirectUrl !== nextRedirectUrl) {
+      // Dynamic client registrations are tied to redirect URIs.
+      this._clientInformation = undefined;
+    }
+
+    this._redirectUrl = redirectUrl;
+    this._metadata = buildClientMetadata(nextRedirectUrl);
+  }
+
+  clientInformation(): OAuthClientInformationMixed | undefined {
+    return this._clientInformation;
+  }
+
+  saveClientInformation(clientInformation: OAuthClientInformationMixed): void {
+    this._clientInformation = clientInformation;
+  }
+
+  tokens(): OAuthTokens | undefined {
+    return this._tokens;
+  }
+
+  saveTokens(tokens: OAuthTokens): void {
+    this._tokens = tokens;
+  }
+
+  redirectToAuthorization(authorizationUrl: URL): void | Promise<void> {
+    return this._openExternal(authorizationUrl.toString());
+  }
+
+  saveCodeVerifier(codeVerifier: string): void {
+    this._codeVerifier = codeVerifier;
+  }
+
+  codeVerifier(): string {
+    if (!this._codeVerifier) {
+      throw new Error('No OAuth code verifier saved');
+    }
+
+    return this._codeVerifier;
+  }
+
+  saveDiscoveryState(state: OAuthDiscoveryState): void {
+    this._discoveryState = state;
+  }
+
+  discoveryState(): OAuthDiscoveryState | undefined {
+    return this._discoveryState;
+  }
+
+  invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier' | 'discovery'): void {
+    if (scope === 'all' || scope === 'client') {
+      this._clientInformation = undefined;
+    }
+    if (scope === 'all' || scope === 'tokens') {
+      this._tokens = undefined;
+    }
+    if (scope === 'all' || scope === 'verifier') {
+      this._codeVerifier = undefined;
+    }
+    if (scope === 'all' || scope === 'discovery') {
+      this._discoveryState = undefined;
+    }
+  }
+}
+
+export async function createOAuthCallbackListener(
+  timeoutMs: number = MCP_OAUTH_CALLBACK_TIMEOUT_MS
+): Promise<OAuthCallbackListener> {
+  let resolveCode!: (code: string) => void;
+  let rejectCode!: (error: Error) => void;
+  let closedPromise: Promise<void> | null = null;
+  let settled = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const codePromise = new Promise<string>((resolve, reject) => {
+    resolveCode = resolve;
+    rejectCode = reject;
+  });
+
+  const server = createServer((request, response) => {
+    if (request.url === '/favicon.ico') {
+      response.writeHead(404);
+      response.end();
+      return;
+    }
+
+    const address = server.address();
+    const port = address && typeof address === 'object' ? (address as AddressInfo).port : 0;
+    const parsedUrl = new URL(request.url ?? '', `http://127.0.0.1:${port}`);
+    const authorizationCode = parsedUrl.searchParams.get('code');
+    const error = parsedUrl.searchParams.get('error');
+    const errorDescription = parsedUrl.searchParams.get('error_description');
+
+    if (settled) {
+      response.writeHead(409, { 'Content-Type': 'text/plain; charset=utf-8' });
+      response.end('OAuth callback already handled.');
+      return;
+    }
+
+    if (authorizationCode) {
+      settled = true;
+      response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      response.end(
+        '<html><body><h1>Authorization complete</h1><p>You can return to Open Cowork now.</p><script>setTimeout(() => window.close(), 1200);</script></body></html>'
+      );
+      resolveCode(authorizationCode);
+      void closeServer(server);
+      return;
+    }
+
+    const failureMessage = error
+      ? `OAuth authorization failed: ${errorDescription || error}`
+      : 'OAuth authorization failed: missing authorization code';
+
+    settled = true;
+    response.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
+    response.end(`<html><body><h1>Authorization failed</h1><p>${failureMessage}</p></body></html>`);
+    rejectCode(new Error(failureMessage));
+    void closeServer(server);
+  });
+
+  const close = async (): Promise<void> => {
+    if (closedPromise) {
+      return closedPromise;
+    }
+
+    closedPromise = (async () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      await closeServer(server);
+    })();
+
+    return closedPromise;
+  };
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await close();
+    throw new Error('Could not determine OAuth callback server address');
+  }
+
+  const redirectUrl = `http://127.0.0.1:${address.port}/callback`;
+
+  timer = setTimeout(() => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    rejectCode(
+      new Error(
+        `Timed out waiting for MCP OAuth authorization after ${Math.floor(timeoutMs / 1000)}s`
+      )
+    );
+    void close();
+  }, timeoutMs);
+
+  return {
+    close,
+    redirectUrl,
+    waitForCode: () => codePromise,
+  };
+}
+
+export async function connectWithOAuthRetry<TTransport extends OAuthTransport>({
+  callbackTimeoutMs = MCP_OAUTH_CALLBACK_TIMEOUT_MS,
+  connect,
+  createTransport,
+  provider,
+}: ConnectWithOAuthOptions<TTransport>): Promise<TTransport> {
+  const listener = await createOAuthCallbackListener(callbackTimeoutMs);
+  provider.setRedirectUrl(listener.redirectUrl);
+
+  const initialTransport = createTransport(provider);
+  let connectedTransport: TTransport | null = null;
+
+  try {
+    try {
+      await connect(initialTransport);
+      connectedTransport = initialTransport;
+      return initialTransport;
+    } catch (error) {
+      if (!(error instanceof UnauthorizedError)) {
+        throw error;
+      }
+    }
+
+    const authorizationCode = await listener.waitForCode();
+    await initialTransport.finishAuth(authorizationCode);
+
+    const authenticatedTransport = createTransport(provider);
+    try {
+      await connect(authenticatedTransport);
+      connectedTransport = authenticatedTransport;
+      return authenticatedTransport;
+    } finally {
+      if (connectedTransport !== authenticatedTransport) {
+        await safeCloseTransport(authenticatedTransport);
+      }
+    }
+  } finally {
+    if (connectedTransport !== initialTransport) {
+      await safeCloseTransport(initialTransport);
+    }
+    await listener.close();
+  }
+}

--- a/tests/mcp-manager-streamable-http-oauth.test.ts
+++ b/tests/mcp-manager-streamable-http-oauth.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockState = vi.hoisted(() => ({
+  createdStreamableTransports: [] as Array<{
+    close: ReturnType<typeof vi.fn>;
+    finishAuth: ReturnType<typeof vi.fn>;
+    options: {
+      authProvider?: { redirectToAuthorization(url: URL): unknown; redirectUrl?: string | URL };
+    };
+    url: URL;
+  }>,
+  latestAuthProvider: null as {
+    redirectToAuthorization(url: URL): unknown;
+    redirectUrl?: string | URL;
+  } | null,
+  mockClientConnect: vi.fn(),
+  mockClientListTools: vi.fn(),
+  mockOpenExternal: vi.fn(),
+}));
+
+const MockUnauthorizedError = vi.hoisted(() => class MockUnauthorizedError extends Error {});
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => '/tmp/open-cowork-test',
+  },
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
+  shell: {
+    openExternal: mockState.mockOpenExternal,
+  },
+}));
+
+vi.mock('../src/main/utils/logger', () => ({
+  log: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+  logCtx: vi.fn(),
+  logCtxError: vi.fn(),
+  logTiming: vi.fn(),
+}));
+
+vi.mock('../src/main/utils/shell-resolver', () => ({
+  getDefaultShell: () => '/bin/bash',
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/auth.js', () => ({
+  UnauthorizedError: MockUnauthorizedError,
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class MockClient {
+    close = vi.fn().mockResolvedValue(undefined);
+    connect = mockState.mockClientConnect;
+    listTools = mockState.mockClientListTools;
+  },
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: class MockStdioClientTransport {},
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SSEClientTransport: class MockSSEClientTransport {},
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class MockStreamableHTTPClientTransport {
+    close = vi.fn().mockResolvedValue(undefined);
+    finishAuth = vi.fn().mockResolvedValue(undefined);
+    options: {
+      authProvider?: { redirectUrl?: string | URL; redirectToAuthorization(url: URL): unknown };
+    };
+    url: URL;
+
+    constructor(
+      url: URL,
+      options: {
+        authProvider?: { redirectUrl?: string | URL; redirectToAuthorization(url: URL): unknown };
+      }
+    ) {
+      this.url = url;
+      this.options = options;
+      mockState.createdStreamableTransports.push(this);
+    }
+  },
+}));
+
+import { MCPManager } from '../src/main/mcp/mcp-manager';
+import type { MCPServerConfig } from '../src/main/mcp/mcp-manager';
+
+describe('MCPManager streamable HTTP OAuth', () => {
+  beforeEach(() => {
+    mockState.createdStreamableTransports.length = 0;
+    mockState.latestAuthProvider = null;
+
+    mockState.mockOpenExternal.mockReset();
+    mockState.mockOpenExternal.mockImplementation(async () => {
+      if (!mockState.latestAuthProvider?.redirectUrl) {
+        throw new Error('OAuth redirect URL was not prepared');
+      }
+
+      await fetch(`${String(mockState.latestAuthProvider.redirectUrl)}?code=oauth-from-browser`);
+    });
+
+    mockState.mockClientListTools.mockReset();
+    mockState.mockClientListTools.mockResolvedValue({ tools: [] });
+
+    let connectAttempt = 0;
+    mockState.mockClientConnect.mockReset();
+    mockState.mockClientConnect.mockImplementation(async (transport) => {
+      connectAttempt += 1;
+
+      if (connectAttempt === 1) {
+        mockState.latestAuthProvider = transport.options.authProvider ?? null;
+        await transport.options.authProvider?.redirectToAuthorization(
+          new URL('https://auth.example.com/authorize')
+        );
+        throw new MockUnauthorizedError('Authorization required');
+      }
+    });
+  });
+
+  it('opens the browser, completes OAuth, and reconnects the streamable HTTP client', async () => {
+    const manager = new MCPManager();
+    const config: MCPServerConfig = {
+      enabled: true,
+      id: 'oauth-server',
+      name: 'OAuth MCP',
+      type: 'streamable-http',
+      url: 'https://mcp.example.com/v1/mcp',
+    };
+
+    await manager.initializeServers([config]);
+
+    expect(mockState.mockOpenExternal).toHaveBeenCalledWith('https://auth.example.com/authorize');
+    expect(mockState.mockClientConnect).toHaveBeenCalledTimes(2);
+    expect(mockState.createdStreamableTransports).toHaveLength(2);
+    expect(mockState.createdStreamableTransports[0].finishAuth).toHaveBeenCalledWith(
+      'oauth-from-browser'
+    );
+    expect(mockState.createdStreamableTransports[0].close).toHaveBeenCalledTimes(1);
+    expect(mockState.createdStreamableTransports[1].close).not.toHaveBeenCalled();
+
+    expect(manager.getServerStatus()).toEqual([
+      expect.objectContaining({
+        connected: true,
+        id: 'oauth-server',
+        status: 'connected',
+      }),
+    ]);
+  });
+});

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -1,0 +1,103 @@
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  connectWithOAuthRetry,
+  createOAuthCallbackListener,
+  OpenCoworkMcpOAuthProvider,
+} from '../src/main/mcp/mcp-oauth';
+
+describe('createOAuthCallbackListener', () => {
+  it('captures authorization codes from the loopback callback', async () => {
+    const listener = await createOAuthCallbackListener(1000);
+    const codePromise = listener.waitForCode();
+
+    const response = await fetch(`${listener.redirectUrl}?code=test-auth-code`);
+
+    expect(response.status).toBe(200);
+    expect(await codePromise).toBe('test-auth-code');
+
+    await listener.close();
+  });
+
+  it('rejects when the OAuth callback returns an error', async () => {
+    const listener = await createOAuthCallbackListener(1000);
+    const codePromise = listener.waitForCode();
+    codePromise.catch(() => {});
+
+    const response = await fetch(
+      `${listener.redirectUrl}?error=access_denied&error_description=user%20cancelled`
+    );
+
+    expect(response.status).toBe(400);
+    await expect(codePromise).rejects.toThrow('OAuth authorization failed: user cancelled');
+
+    await listener.close();
+  });
+});
+
+describe('OpenCoworkMcpOAuthProvider', () => {
+  it('updates redirect URIs, keeps tokens, and clears client registration when the port changes', async () => {
+    const openExternal = vi.fn();
+    const provider = new OpenCoworkMcpOAuthProvider({ openExternal });
+
+    provider.setRedirectUrl('http://127.0.0.1:3000/callback');
+    provider.saveClientInformation({ client_id: 'client-1' });
+    provider.saveTokens({ access_token: 'token-1', token_type: 'Bearer' });
+    provider.saveCodeVerifier('pkce-verifier');
+    provider.setRedirectUrl('http://127.0.0.1:4000/callback');
+
+    expect(provider.clientMetadata.redirect_uris).toEqual(['http://127.0.0.1:4000/callback']);
+    expect(provider.clientInformation()).toBeUndefined();
+    expect(provider.tokens()).toMatchObject({
+      access_token: 'token-1',
+      token_type: 'Bearer',
+    });
+    expect(provider.codeVerifier()).toBe('pkce-verifier');
+
+    await provider.redirectToAuthorization(new URL('https://auth.example.com/authorize'));
+    expect(openExternal).toHaveBeenCalledWith('https://auth.example.com/authorize');
+  });
+});
+
+describe('connectWithOAuthRetry', () => {
+  it('finishes the auth flow and reconnects with a new transport after UnauthorizedError', async () => {
+    const transports = [
+      {
+        close: vi.fn().mockResolvedValue(undefined),
+        finishAuth: vi.fn().mockResolvedValue(undefined),
+        id: 'initial',
+      },
+      {
+        close: vi.fn().mockResolvedValue(undefined),
+        finishAuth: vi.fn().mockResolvedValue(undefined),
+        id: 'authenticated',
+      },
+    ];
+    let createCount = 0;
+    let connectCount = 0;
+
+    const provider = new OpenCoworkMcpOAuthProvider({
+      openExternal: vi.fn(async () => {
+        await fetch(`${String(provider.redirectUrl)}?code=oauth-code`);
+      }),
+    });
+
+    const connectedTransport = await connectWithOAuthRetry({
+      connect: async () => {
+        connectCount += 1;
+        if (connectCount === 1) {
+          await provider.redirectToAuthorization(new URL('https://auth.example.com/authorize'));
+          throw new UnauthorizedError('Authorization required');
+        }
+      },
+      createTransport: () => transports[createCount++],
+      provider,
+    });
+
+    expect(connectedTransport).toBe(transports[1]);
+    expect(transports[0].finishAuth).toHaveBeenCalledWith('oauth-code');
+    expect(transports[0].close).toHaveBeenCalledTimes(1);
+    expect(transports[1].close).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable MCP OAuth helper for loopback callbacks, token state, and browser redirects
- wire Streamable HTTP connectors through OAuth-aware connect/retry flow in MCPManager
- cover the callback helper and manager reconnect path with focused tests

Fixes #215

## Testing
- 
px vitest run tests/mcp-oauth.test.ts tests/mcp-manager-streamable-http-oauth.test.ts src/tests/mcp/mcp-manager.test.ts
- 
pm run typecheck
- 
px eslint src/main/mcp/mcp-oauth.ts src/main/mcp/mcp-manager.ts tests/mcp-oauth.test.ts tests/mcp-manager-streamable-http-oauth.test.ts src/tests/mcp/mcp-manager.test.ts
