### PR TITLE
feat: add TokenMix as a built-in OpenAI-compatible API provider

### DIFF
--- a/src/main/config/config-store.ts
+++ b/src/main/config/config-store.ts
@@ -34,10 +34,11 @@ import { API_PROVIDER_PRESETS, PI_AI_CURATED_PRESETS } from '../../shared/api-mo
 /**
  * Application configuration schema
  */
-export type ProviderType = 'openrouter' | 'anthropic' | 'custom' | 'openai' | 'gemini' | 'ollama';
+export type ProviderType = 'tokenmix' | 'openrouter' | 'anthropic' | 'custom' | 'openai' | 'gemini' | 'ollama';
 export type CustomProtocolType = 'anthropic' | 'openai' | 'gemini';
 export type AppTheme = 'dark' | 'light' | 'system';
 export type ProviderProfileKey =
+  | 'tokenmix'
   | 'openrouter'
   | 'anthropic'
   | 'openai'
@@ -174,9 +175,12 @@ const DIRECT_READ_KEYS = new Set<keyof AppConfig>([
 ]);
 
 const defaultProfiles: Record<ProviderProfileKey, ProviderProfile> = {
-  openrouter: {
+  tokenmix: {
     apiKey: '',
-    baseUrl: 'https://openrouter.ai/api/v1',
+    baseUrl: 'https://api.tokenmix.ai/v1',
+    model: 'claude-sonnet-4-6',
+  },
+  openrouter: {
     model: 'anthropic/claude-sonnet-4-6',
   },
   anthropic: {
@@ -331,6 +335,7 @@ export async function getPiAiModelPresets(): Promise<typeof PROVIDER_PRESETS> {
 }
 
 const PROFILE_KEYS: ProviderProfileKey[] = [
+  'tokenmix',
   'openrouter',
   'anthropic',
   'openai',
@@ -344,6 +349,7 @@ const VALID_THEMES: AppTheme[] = ['dark', 'light', 'system'];
 
 function isProviderType(value: unknown): value is ProviderType {
   return (
+    value === 'tokenmix' ||
     value === 'openrouter' ||
     value === 'anthropic' ||
     value === 'custom' ||

--- a/src/main/config/config-store.ts
+++ b/src/main/config/config-store.ts
@@ -181,6 +181,8 @@ const defaultProfiles: Record<ProviderProfileKey, ProviderProfile> = {
     model: 'claude-sonnet-4-6',
   },
   openrouter: {
+    apiKey: '',
+    baseUrl: 'https://openrouter.ai/api/v1',
     model: 'anthropic/claude-sonnet-4-6',
   },
   anthropic: {

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -574,10 +574,18 @@ export interface ExecutionContext {
 }
 
 // App Config types
-export type ProviderType = 'openrouter' | 'anthropic' | 'custom' | 'openai' | 'gemini' | 'ollama';
+export type ProviderType =
+  | 'tokenmix'
+  | 'openrouter'
+  | 'anthropic'
+  | 'custom'
+  | 'openai'
+  | 'gemini'
+  | 'ollama';
 export type CustomProtocolType = 'anthropic' | 'openai' | 'gemini';
 export type AppTheme = 'dark' | 'light' | 'system';
 export type ProviderProfileKey =
+  | 'tokenmix'
   | 'openrouter'
   | 'anthropic'
   | 'openai'
@@ -670,6 +678,7 @@ export interface ProviderPreset {
 }
 
 export interface ProviderPresets {
+  tokenmix: ProviderPreset;
   openrouter: ProviderPreset;
   anthropic: ProviderPreset;
   custom: ProviderPreset;

--- a/src/shared/api-model-presets.ts
+++ b/src/shared/api-model-presets.ts
@@ -52,6 +52,7 @@ export const API_PROVIDER_PRESETS: SharedProviderPresets = {
     keyHint: '从 tokenmix.ai 获取',
   },
   openrouter: {
+    name: 'OpenRouter',
     baseUrl: 'https://openrouter.ai/api/v1',
     models: [
       { id: 'anthropic/claude-opus-4-6', name: 'anthropic/claude-opus-4-6' },
@@ -152,6 +153,7 @@ export const PI_AI_CURATED_PRESETS: Record<string, { piProvider: string; pick: s
     ],
   },
   openrouter: {
+    piProvider: 'openrouter',
     pick: [
       'anthropic/claude-opus-4-6',
       'anthropic/claude-sonnet-4-6',

--- a/src/shared/api-model-presets.ts
+++ b/src/shared/api-model-presets.ts
@@ -1,4 +1,5 @@
 export type SharedProviderType =
+  | 'tokenmix'
   | 'openrouter'
   | 'anthropic'
   | 'custom'
@@ -17,6 +18,7 @@ export interface SharedProviderPreset {
 }
 
 export interface SharedProviderPresets {
+  tokenmix: SharedProviderPreset;
   openrouter: SharedProviderPreset;
   anthropic: SharedProviderPreset;
   custom: SharedProviderPreset;
@@ -31,8 +33,25 @@ export interface ModelInputGuidance {
 }
 
 export const API_PROVIDER_PRESETS: SharedProviderPresets = {
+  tokenmix: {
+    name: 'TokenMix',
+    baseUrl: 'https://api.tokenmix.ai/v1',
+    models: [
+      { id: 'claude-opus-4-6', name: 'claude-opus-4-6' },
+      { id: 'claude-sonnet-4-6', name: 'claude-sonnet-4-6' },
+      { id: 'claude-haiku-4-5', name: 'claude-haiku-4-5' },
+      { id: 'gpt-5.4', name: 'gpt-5.4' },
+      { id: 'gpt-5.4-mini', name: 'gpt-5.4-mini' },
+      { id: 'gemini-2.5-pro', name: 'gemini-2.5-pro' },
+      { id: 'gemini-2.5-flash', name: 'gemini-2.5-flash' },
+      { id: 'deepseek-chat', name: 'deepseek-chat' },
+      { id: 'deepseek-reasoner', name: 'deepseek-reasoner' },
+      { id: 'qwen-max', name: 'qwen-max' },
+    ],
+    keyPlaceholder: 'sk-...',
+    keyHint: '从 tokenmix.ai 获取',
+  },
   openrouter: {
-    name: 'OpenRouter',
     baseUrl: 'https://openrouter.ai/api/v1',
     models: [
       { id: 'anthropic/claude-opus-4-6', name: 'anthropic/claude-opus-4-6' },
@@ -120,8 +139,19 @@ export const API_PROVIDER_PRESETS: SharedProviderPresets = {
 };
 
 export const PI_AI_CURATED_PRESETS: Record<string, { piProvider: string; pick: string[] }> = {
+  tokenmix: {
+    piProvider: 'openai',
+    pick: [
+      'claude-sonnet-4-6',
+      'claude-opus-4-6',
+      'gpt-5.4',
+      'gpt-5.4-mini',
+      'gemini-2.5-flash',
+      'deepseek-chat',
+      'qwen-max',
+    ],
+  },
   openrouter: {
-    piProvider: 'openrouter',
     pick: [
       'anthropic/claude-opus-4-6',
       'anthropic/claude-sonnet-4-6',
@@ -172,6 +202,13 @@ export function getModelInputGuidance(
   provider: SharedProviderType,
   customProtocol: SharedCustomProtocolType = 'anthropic'
 ): ModelInputGuidance {
+  if (provider === 'tokenmix') {
+    return {
+      placeholder: 'claude-sonnet-4-6, gpt-5.4, gemini-2.5-flash, deepseek-chat',
+      hint: 'Use the exact model ID. TokenMix supports 171+ models — see tokenmix.ai/models for the full list.',
+    };
+  }
+
   if (provider === 'openrouter') {
     return {
       placeholder: 'openai/gpt-5.4, anthropic/claude-sonnet-4-6, google/gemini-3-flash-preview',


### PR DESCRIPTION
Closes #238

## Summary

This PR adds **TokenMix** as a first-class built-in provider alongside OpenRouter, following the same pattern.

TokenMix is an OpenAI-compatible API aggregator (171 models, 14 providers) — functionally similar to OpenRouter, so integration is straightforward.

### Changes

**src/shared/api-model-presets.ts**
- Add 'tokenmix' to SharedProviderType
- Add 	okenmix field to SharedProviderPresets interface
- Add 	okenmix preset in API_PROVIDER_PRESETS (10 curated models: Claude, GPT, Gemini, DeepSeek, Qwen)
- Add 	okenmix entry in PI_AI_CURATED_PRESETS
- Add 	okenmix case in getModelInputGuidance()

**src/main/config/config-store.ts**
- Add 'tokenmix' to ProviderType
- Add 'tokenmix' to ProviderProfileKey
- Add 	okenmix default profile (aseUrl: https://api.tokenmix.ai/v1, default model: claude-sonnet-4-6)
- Add 'tokenmix' to PROFILE_KEYS array
- Add 	okenmix guard in isProviderType()

### Provider details

| Field | Value |
|-------|-------|
| Base URL | https://api.tokenmix.ai/v1 |
| Protocol | OpenAI-compatible |
| Key format | sk-... |
| Models | 171 (Claude, GPT, Gemini, DeepSeek, Qwen, Mistral, and more) |
| Pricing | Pay-as-you-go, no monthly subscription |

### Compatibility

The tool-call formatting issue reported in #233 has been resolved on the TokenMix side. The OpenAI protocol path in pi-ai SDK now works seamlessly with this endpoint.