### PR TITLE
fix(sandbox): enrich PATH before Lima detection so packaged macOS app finds limactl

### DIFF
--- a/src/main/claude/agent-runner.ts
+++ b/src/main/claude/agent-runner.ts
@@ -145,11 +145,14 @@ function resolveBundledToolsBinDir(): string | null {
  * 3. Deduplicates all entries
  * 4. Writes the result back to `process.env.PATH`
  *
- * Called once before the first `createCodingTools()` — subsequent calls are no-ops.
+ * Idempotent: enriches once and caches the result, so it is safe to call from
+ * multiple entry points. Call at app startup (before the sandbox bootstrap /
+ * Lima detection) and before the first `createCodingTools()` — subsequent calls
+ * are no-ops.
  */
 let pathEnriched = false;
 
-async function enrichProcessPathForBuild(): Promise<void> {
+export async function enrichProcessPathForBuild(): Promise<void> {
   if (pathEnriched) return;
   pathEnriched = true;
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,6 +38,7 @@ import { SandboxSync } from './sandbox/sandbox-sync';
 import { WSLBridge } from './sandbox/wsl-bridge';
 import { LimaBridge } from './sandbox/lima-bridge';
 import { getSandboxBootstrap } from './sandbox/sandbox-bootstrap';
+import { enrichProcessPathForBuild } from './claude/agent-runner';
 import type { MCPServerConfig } from './mcp/mcp-manager';
 import type {
   ClientEvent,
@@ -759,6 +760,14 @@ function sendToRenderer(event: ServerEvent) {
 app
   .whenReady()
   .then(async () => {
+    // Enrich PATH before anything else so Homebrew-installed CLIs (notably
+    // `limactl`) are discoverable by the sandbox bootstrap and the
+    // `sandbox.checkLima` IPC. In the packaged macOS app, GUI processes inherit
+    // a stripped launchd PATH that excludes /opt/homebrew/bin and
+    // /usr/local/bin, which otherwise makes `which limactl` fail and reports
+    // the sandbox as unavailable even when Lima is installed.
+    await enrichProcessPathForBuild();
+
     // Apply dev logs setting from config
     const enableDevLogs = configStore.get('enableDevLogs');
     setDevLogsEnabled(enableDevLogs);

--- a/tests/startup-path-enrichment.test.ts
+++ b/tests/startup-path-enrichment.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const read = (rel: string): string => readFileSync(path.resolve(process.cwd(), rel), 'utf8');
+
+/**
+ * Regression guard for the macOS sandbox-detection bug.
+ *
+ * In the packaged macOS app, GUI processes inherit a stripped launchd PATH that
+ * excludes /opt/homebrew/bin and /usr/local/bin. The sandbox/Lima detection
+ * (`which limactl`) runs at startup and from the `sandbox.checkLima` IPC, so it
+ * must run AFTER the login-shell PATH has been restored — otherwise Lima is
+ * reported as unavailable even when it is installed. The PATH enrichment used to
+ * run only before the first `createCodingTools()` call (an agent task), which is
+ * too late for the sandbox detection.
+ */
+describe('PATH enrichment is wired into app startup, before sandbox detection', () => {
+  const agentRunner = read('src/main/claude/agent-runner.ts');
+  const indexTs = read('src/main/index.ts');
+
+  it('exports enrichProcessPathForBuild so the startup path can reuse it', () => {
+    expect(agentRunner).toMatch(/export\s+async\s+function\s+enrichProcessPathForBuild/);
+  });
+
+  it('keeps the enrichment idempotent so repeated calls are safe', () => {
+    expect(agentRunner).toContain('let pathEnriched = false;');
+    expect(agentRunner).toContain('if (pathEnriched) return;');
+  });
+
+  it('imports the enrichment into the main entrypoint', () => {
+    expect(indexTs).toMatch(
+      /import\s*\{\s*enrichProcessPathForBuild\s*\}\s*from\s*['"]\.\/claude\/agent-runner['"]/
+    );
+  });
+
+  it('awaits the enrichment during the whenReady startup sequence', () => {
+    const readyIdx = indexTs.indexOf('.whenReady()');
+    const enrichIdx = indexTs.indexOf('await enrichProcessPathForBuild()');
+    expect(readyIdx).toBeGreaterThan(-1);
+    expect(enrichIdx).toBeGreaterThan(-1);
+    // The enrichment must be invoked from the startup sequence, not only from
+    // the lazy agent-task path, so it precedes any Lima detection.
+    expect(enrichIdx).toBeGreaterThan(readyIdx);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #248.

On the packaged macOS app the sandbox is reported as unavailable ("Lima not installed") even when Lima is installed, because the Lima detection runs with the stripped launchd PATH that GUI apps inherit (no `/opt/homebrew/bin` / `/usr/local/bin`).

The app already has an idempotent `enrichProcessPathForBuild()` that restores the login-shell PATH, but it only runs lazily before the first `createCodingTools()` (an agent task). The sandbox detection (`checkLimaStatus()` → `which limactl`) runs earlier — at startup via `startSandboxBootstrap()` and from the `sandbox.checkLima` IPC — so PATH was still stripped at detection time.

This PR exports `enrichProcessPathForBuild()` and `await`s it once at the top of the `app.whenReady()` handler, before the sandbox bootstrap and any IPC can run. Because the function is guarded by `pathEnriched`, the existing call before `createCodingTools()` becomes a no-op. Dev mode and the Windows registry-based PATH restore are unaffected.

## Type of change

- [x] Bug fix (`fix`)

## Checklist

- [x] Code follows the project style (TypeScript strict, ESLint, Prettier) — changed lines only
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, etc.)
- [x] Self-review completed — no debug logs, no commented-out code
- [x] Tests added or updated for the changed behaviour
- [ ] `npm run test` passes locally — see Testing (new test + typecheck pass; full suite not run locally)
- [ ] `npm run lint` passes locally — see Testing (no new errors from this change; pre-existing findings noted)
- [ ] UI changes tested on both macOS and Windows — N/A, no UI; macOS-specific startup wiring, Windows path untouched
- [ ] New user-facing strings added to i18n files — N/A, no user-facing strings

## Testing

Repro and root cause are detailed in #248. Branch is based on `dev`.

Verified locally:
- `npx tsc --noEmit` — the changed files type-check cleanly. (There is one unrelated pre-existing error on `dev`, `src/main/config/config-store.ts:369 'getConfigKey' is declared but never read`, untouched by this change.)
- New regression test `tests/startup-path-enrichment.test.ts` (4 assertions) — passes via `npx vitest run`. It follows the existing source-assertion style in `tests/agent-runner-pi.test.ts` and guards that the enrichment is exported, idempotent, imported by the entrypoint, and awaited within `whenReady()`.
- `eslint` on the two changed files — **no errors on the changed lines**. (These large files contain pre-existing `@typescript-eslint/no-explicit-any` findings unrelated to this change; left untouched to keep the diff minimal and focused.)

Note: the full `npm run test` suite was not run locally because dependencies were installed with `--ignore-scripts` (native `better-sqlite3` not rebuilt). CI will run the complete suite.

Manual verification on a real macOS install: before the change, Settings → Sandbox showed "Lima not installed" despite `which limactl` succeeding in Terminal (Homebrew `limactl`). Restoring the login-shell PATH at startup makes the detection resolve `limactl` correctly.
