### PR TITLE
fix(model): default synthetic models to text-only input to avoid image 400s

### DIFF
--- a/src/main/claude/pi-model-resolution.ts
+++ b/src/main/claude/pi-model-resolution.ts
@@ -139,7 +139,15 @@ export function buildSyntheticPiModel(
     provider,
     baseUrl: baseUrl || '',
     reasoning: autoReasoning,
-    input: ['text', 'image'],
+    // Default unknown/synthetic models to text-only input. We cannot know whether
+    // an arbitrary model supports image input, and falsely claiming vision support
+    // causes hard request failures rather than gracefully dropping images — e.g.
+    // Ollama returns HTTP 400 "this model does not support image input" for a
+    // text-only model like deepseek-v4-pro, which surfaces to the user as an
+    // opaque "invalid message format" error. Vision-capable models resolved from
+    // the pi-ai registry keep their real input modalities; only synthetic
+    // fallbacks are affected here.
+    input: ['text'],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: contextWindow || knownSpecs?.contextWindow || 128000,
     maxTokens: maxTokens || knownSpecs?.maxTokens || 16384,

--- a/tests/synthetic-model-input.test.ts
+++ b/tests/synthetic-model-input.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { buildSyntheticPiModel } from '../src/main/claude/pi-model-resolution';
+
+/**
+ * Regression guard for the text-only-model image bug.
+ *
+ * Synthetic models (built for ids not in the pi-ai registry) must NOT claim
+ * image input. Falsely advertising vision support means image content — e.g.
+ * screenshots from the GUI/computer-use tools — is sent to text-only endpoints,
+ * which hard-fail instead of gracefully dropping the images. For example Ollama
+ * returns HTTP 400 "this model does not support image input" for a text-only
+ * model like deepseek-v4-pro, which the app surfaces as an opaque
+ * "invalid message format" error.
+ */
+describe('buildSyntheticPiModel input modalities', () => {
+  it('defaults an unknown synthetic model to text-only input', () => {
+    const m = buildSyntheticPiModel('deepseek-v4-pro', 'openai', 'openai', 'https://ollama.com/v1');
+    expect(m.input).toEqual(['text']);
+    expect(m.input).not.toContain('image');
+  });
+
+  it('still resolves other core model fields normally', () => {
+    const m = buildSyntheticPiModel('some-custom-model', 'openai', 'openai', 'https://example.com/v1');
+    expect(m.id).toBe('some-custom-model');
+    expect(m.api).toBeTruthy();
+    expect(m.contextWindow).toBeGreaterThan(0);
+    expect(m.maxTokens).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #251.

Text-only models that aren't in pi-ai's registry (e.g. `deepseek-v4-pro` via Ollama Cloud) hard-fail with a provider 400 whenever the conversation includes an image (screenshots from the GUI/computer-use tools, pasted images). The app surfaces this as an opaque "invalid message format".

Root cause: `buildSyntheticPiModel` hard-coded `input: ['text', 'image']`, so synthetic models falsely advertise vision support. The `openai-completions` provider only filters image content when `!model.input.includes("image")`, so images were sent to text-only endpoints. Ollama rejects them with `HTTP 400 "this model does not support image input"`.

This PR defaults synthetic models to `input: ['text']`. We can't know whether an arbitrary unknown model supports vision, and a false vision claim hard-fails the entire request, whereas text-only just drops images gracefully. Vision-capable models resolved from the pi-ai registry keep their real modalities — only synthetic fallbacks change.

## Type of change

- [x] Bug fix (`fix`)

## Checklist

- [x] Code follows the project style (TypeScript strict, ESLint, Prettier) — changed lines only
- [x] Commit messages follow Conventional Commits
- [x] Self-review completed — no debug logs, no commented-out code
- [x] Tests added or updated for the changed behaviour
- [ ] `npm run test` passes locally — see Testing (new test + typecheck pass; full suite not run locally)
- [ ] `npm run lint` passes locally — see Testing (no new findings from this change)
- [ ] UI changes tested on both macOS and Windows — N/A, no UI; provider-agnostic model-resolution logic
- [ ] New user-facing strings added to i18n files — N/A

## Testing

Repro and root cause are in #251. Branch is based on `dev`.

Verified locally:
- Direct API check: posting `image_url` content to `deepseek-v4-pro` at `https://ollama.com/v1` returns `400 "this model does not support image input"`; text-only requests to the same model return `200`. With this change, the synthetic model reports `input: ['text']`, so `convertMessages` drops image content and the request stays text-only.
- New test `tests/synthetic-model-input.test.ts` (2 assertions) — passes via `npx vitest run`.
- `npx tsc --noEmit` — the change introduces no type errors (one unrelated pre-existing error remains on `dev`: `src/main/config/config-store.ts:369 'getConfigKey' is declared but never read`).
- `eslint src/main/claude/pi-model-resolution.ts` — no new findings on the changed lines (the file has one pre-existing `@typescript-eslint/no-explicit-any` at an unrelated location, left untouched to keep the diff focused).

Note: the full `npm run test` suite was not run locally (deps installed with `--ignore-scripts`, so native `better-sqlite3` isn't built). CI will run the complete suite.

## Trade-off

For a **custom vision endpoint** that happens to be resolved as a synthetic model (not in the pi-ai registry), images would now be filtered out rather than sent. That's a deliberate, conservative default: dropping images degrades gracefully, whereas the current false-positive vision claim hard-fails every request to text-only models. If desired, this could later be made configurable or driven by `KNOWN_MODEL_SPECS`.
