### PR TITLE
fix(chat): keep composer Send button reachable with many attachments

### DIFF
--- a/src/renderer/components/ChatView.tsx
+++ b/src/renderer/components/ChatView.tsx
@@ -732,7 +732,7 @@ export function ChatView() {
           >
             {/* Image previews */}
             {pastedImages.length > 0 && (
-              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2 mb-3">
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2 mb-3 max-h-[28vh] overflow-y-auto pr-1">
                 {pastedImages.map((img, index) => (
                   <div key={img.url || `pasted-image-${index}`} className="relative group">
                     <img
@@ -754,7 +754,7 @@ export function ChatView() {
 
             {/* File attachments */}
             {attachedFiles.length > 0 && (
-              <div className="space-y-2 mb-3">
+              <div className="space-y-2 mb-3 max-h-[22vh] overflow-y-auto pr-1">
                 {attachedFiles.map((file, index) => (
                   <div
                     key={file.path || `attached-file-${index}`}


### PR DESCRIPTION
## Problem
When you add many attachments (pasted images and/or files), the composer's preview lists grow with no height limit. Because the chat view's root container is `overflow-hidden`, the growing lists push the input row and the **Send** button below the viewport — with no scrollbar, so there's no way to reach Send to submit.

## Fix
Cap both preview lists (`ChatView.tsx`) at a viewport-relative max height with their own vertical scrollbar:
- pasted-image grid → `max-h-[28vh] overflow-y-auto`
- attached-file list → `max-h-[22vh] overflow-y-auto`

Now attachments scroll *within* their own area, and the input + Send button stay visible and reachable regardless of how many files are attached or how small the window is.

Two-line change; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)