### PR TITLE
feat(config): add agent config awareness with config_read tool

### DIFF
--- a/src/main/agent/agent-runner.ts
+++ b/src/main/agent/agent-runner.ts
@@ -2098,6 +2098,18 @@ This is an isolated sandbox environment. Use ${VIRTUAL_WORKSPACE_PATH} as the ro
             ? `<workspace_info>Your current workspace is: ${workingDir}</workspace_info>`
             : '';
 
+      // Build a concise summary of the agent's own runtime configuration.
+      // Intentionally excludes API keys, base URLs, and any other sensitive data.
+      const configSummaryPrompt = `<your_configuration>
+- Model: ${piModel.id}
+- Provider: ${provider}
+- Context Window: ${piModel.contextWindow || 'unknown'} tokens
+- Max Output Tokens: ${piModel.maxTokens || 'default'}
+- Thinking: ${enableThinking ? 'enabled' : 'disabled'}
+- Sandbox: ${runtimeConfig.sandboxEnabled ? 'enabled' : 'disabled'}
+- Memory: ${runtimeConfig.memoryEnabled ? 'enabled' : 'disabled'}
+</your_configuration>`;
+
       const coworkAppendPrompt = [
         'You are an Open Cowork assistant. Be concise, accurate, and tool-capable.',
         `CRITICAL BEHAVIORAL RULES:
@@ -2106,6 +2118,7 @@ This is an isolated sandbox environment. Use ${VIRTUAL_WORKSPACE_PATH} as the ro
 3. For relative time windows like "within two days" in browsing or research tasks, assume the most recent two relevant publication days unless the user explicitly defines another date range.
 4. For bracketed placeholders like [Agent], [Topic], etc., treat the word inside brackets as the literal search keyword unless the user says otherwise.
 5. When given a task, START DOING IT. Do not restate the task, do not list what you will do, do not ask for confirmation. Just execute.`,
+        configSummaryPrompt,
         workspaceInfoPrompt,
         `<citation_requirements>
 If your answer uses linkable content from MCP tools, include a "Sources:" section and otherwise use standard Markdown links: [Title](https://claude.ai/chat/URL).

--- a/src/main/config/config-extension.ts
+++ b/src/main/config/config-extension.ts
@@ -109,7 +109,7 @@ function createConfigReadTool(configStore: ConfigStore): AgentRuntimeCustomTool 
             content: [
               {
                 type: 'text' as const,
-                text: `Error: field "${key}" is either sensitive, does not exist, or is not readable.`,
+                text: `Error: field "${key}" is not readable.`,
               },
             ],
             details: undefined as unknown,

--- a/src/main/config/config-extension.ts
+++ b/src/main/config/config-extension.ts
@@ -54,7 +54,8 @@ export function buildSafeConfigSnapshot(config: AppConfig): Record<string, unkno
   for (const key of SAFE_TOP_LEVEL_KEYS) {
     if (key in config) {
       const value = config[key];
-      // Defense-in-depth: skip string values that look like credentials
+      // Defense-in-depth: skip this field if its key name matches the
+      // sensitive pattern (checks the key name, not the value content).
       if (typeof value === 'string' && SENSITIVE_KEY_PATTERN.test(key)) {
         continue;
       }
@@ -112,7 +113,7 @@ function createConfigReadTool(configStore: ConfigStore): AgentRuntimeCustomTool 
                 text: `Error: field "${key}" is not readable.`,
               },
             ],
-            details: undefined as unknown,
+            details: undefined,
           };
         }
 
@@ -124,7 +125,7 @@ function createConfigReadTool(configStore: ConfigStore): AgentRuntimeCustomTool 
               text: JSON.stringify({ [key]: value }, null, 2),
             },
           ],
-          details: undefined as unknown,
+          details: undefined,
         };
       }
 
@@ -137,7 +138,7 @@ function createConfigReadTool(configStore: ConfigStore): AgentRuntimeCustomTool 
             text: JSON.stringify(snapshot, null, 2),
           },
         ],
-        details: undefined as unknown,
+        details: undefined,
       };
     },
   };

--- a/src/main/config/config-extension.ts
+++ b/src/main/config/config-extension.ts
@@ -16,17 +16,13 @@ import type {
 import type { ConfigStore, AppConfig } from './config-store';
 
 /**
- * Pattern that matches config field names considered sensitive.
- * Used as a defense-in-depth check in buildSafeConfigSnapshot to
- * guard against accidentally adding a sensitive key to SAFE_TOP_LEVEL_KEYS.
- */
-const SENSITIVE_KEY_PATTERN = /key|token|secret|password|credential/i;
-
-/**
- * Top-level keys that are safe to expose to the agent.
- * Keys containing sensitive patterns (checked by SENSITIVE_KEY_PATTERN)
- * can still be in this list if they are genuinely non-secret numeric/boolean
- * values (e.g. `maxTokens` is a numeric limit, not a credential).
+ * Top-level keys that are safe to expose to the agent. This allow-list is
+ * the sole trust boundary for both buildSafeConfigSnapshot and
+ * isKeyReadable below — every entry has been manually vetted as
+ * non-sensitive, even when its name coincidentally contains a
+ * credential-like substring (e.g. `maxTokens` is a numeric limit,
+ * `activeProfileKey` is a profile identifier like "anthropic" — neither
+ * is a credential).
  */
 const SAFE_TOP_LEVEL_KEYS = new Set<keyof AppConfig>([
   'provider',
@@ -46,20 +42,15 @@ const SAFE_TOP_LEVEL_KEYS = new Set<keyof AppConfig>([
 
 /**
  * Build a filtered view of the config that excludes sensitive data.
- * Defense-in-depth: even if a key is in SAFE_TOP_LEVEL_KEYS, we still
- * verify its runtime value isn't a string that looks like a credential.
+ * Every key in SAFE_TOP_LEVEL_KEYS has already been manually vetted as
+ * non-sensitive (see the set's docstring above), so no further
+ * name-pattern filtering is applied here.
  */
 export function buildSafeConfigSnapshot(config: AppConfig): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const key of SAFE_TOP_LEVEL_KEYS) {
     if (key in config) {
-      const value = config[key];
-      // Defense-in-depth: skip this field if its key name matches the
-      // sensitive pattern (checks the key name, not the value content).
-      if (typeof value === 'string' && SENSITIVE_KEY_PATTERN.test(key)) {
-        continue;
-      }
-      result[key] = value;
+      result[key] = config[key];
     }
   }
   return result;

--- a/src/main/config/config-extension.ts
+++ b/src/main/config/config-extension.ts
@@ -1,0 +1,156 @@
+/**
+ * @module main/config/config-extension
+ *
+ * Agent runtime extension that exposes a read-only `config_read` tool,
+ * allowing the agent to inspect its own non-sensitive configuration.
+ *
+ * Sensitive fields (API keys, tokens, secrets, passwords) are always
+ * filtered out — they are never returned to the agent.
+ */
+import { Type } from '@sinclair/typebox';
+import type {
+  AgentRuntimeExtension,
+  BeforeSessionRunResult,
+  AgentRuntimeCustomTool,
+} from '../extensions/agent-runtime-extension';
+import type { ConfigStore, AppConfig } from './config-store';
+
+/**
+ * Pattern that matches config field names considered sensitive.
+ * Used as a defense-in-depth check in buildSafeConfigSnapshot to
+ * guard against accidentally adding a sensitive key to SAFE_TOP_LEVEL_KEYS.
+ */
+const SENSITIVE_KEY_PATTERN = /key|token|secret|password|credential/i;
+
+/**
+ * Top-level keys that are safe to expose to the agent.
+ * Keys containing sensitive patterns (checked by SENSITIVE_KEY_PATTERN)
+ * can still be in this list if they are genuinely non-secret numeric/boolean
+ * values (e.g. `maxTokens` is a numeric limit, not a credential).
+ */
+const SAFE_TOP_LEVEL_KEYS = new Set<keyof AppConfig>([
+  'provider',
+  'model',
+  'contextWindow',
+  'maxTokens',
+  'enableThinking',
+  'sandboxEnabled',
+  'memoryEnabled',
+  'theme',
+  'enableDevLogs',
+  'defaultWorkdir',
+  'activeProfileKey',
+  'activeConfigSetId',
+  'isConfigured',
+]);
+
+/**
+ * Build a filtered view of the config that excludes sensitive data.
+ * Defense-in-depth: even if a key is in SAFE_TOP_LEVEL_KEYS, we still
+ * verify its runtime value isn't a string that looks like a credential.
+ */
+export function buildSafeConfigSnapshot(config: AppConfig): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of SAFE_TOP_LEVEL_KEYS) {
+    if (key in config) {
+      const value = config[key];
+      // Defense-in-depth: skip string values that look like credentials
+      if (typeof value === 'string' && SENSITIVE_KEY_PATTERN.test(key)) {
+        continue;
+      }
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Check whether a specific key is safe to read.
+ * Keys in the explicit SAFE_TOP_LEVEL_KEYS set always pass, even if
+ * their name happens to match the sensitive pattern (e.g. `maxTokens`
+ * contains "token" but is a numeric limit, not a secret).
+ */
+export function isKeyReadable(key: string): boolean {
+  // Explicit safe list takes precedence
+  if (SAFE_TOP_LEVEL_KEYS.has(key as keyof AppConfig)) {
+    return true;
+  }
+  // Everything else is blocked
+  return false;
+}
+
+/**
+ * Build the config_read tool definition.
+ */
+function createConfigReadTool(configStore: ConfigStore): AgentRuntimeCustomTool {
+  return {
+    name: 'config_read',
+    label: 'config_read',
+    description:
+      'Read the current application configuration. Returns non-sensitive config fields. ' +
+      'Provide an optional `key` parameter to read a specific field, or omit to get all readable fields.',
+    parameters: Type.Object({
+      key: Type.Optional(
+        Type.String({
+          description:
+            'A specific config field name to read (e.g. "provider", "model", "sandboxEnabled"). ' +
+            'Omit to read all non-sensitive fields.',
+        })
+      ),
+    }),
+    async execute(_toolCallId: string, params: unknown) {
+      const { key } = (params || {}) as { key?: string };
+      const config = configStore.getAll();
+
+      if (key) {
+        // Single key read
+        if (!isKeyReadable(key)) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Error: field "${key}" is either sensitive, does not exist, or is not readable.`,
+              },
+            ],
+            details: undefined as unknown,
+          };
+        }
+
+        const value = config[key as keyof AppConfig];
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ [key]: value }, null, 2),
+            },
+          ],
+          details: undefined as unknown,
+        };
+      }
+
+      // Full snapshot
+      const snapshot = buildSafeConfigSnapshot(config);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(snapshot, null, 2),
+          },
+        ],
+        details: undefined as unknown,
+      };
+    },
+  };
+}
+
+export class ConfigExtension implements AgentRuntimeExtension {
+  readonly name = 'config';
+
+  constructor(private readonly configStore: ConfigStore) {}
+
+  async beforeSessionRun(): Promise<BeforeSessionRunResult> {
+    return {
+      customTools: [createConfigReadTool(this.configStore)],
+    };
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -24,6 +24,7 @@ import { PluginCatalogService } from './skills/plugin-catalog-service';
 import { PluginRuntimeService } from './skills/plugin-runtime-service';
 import { MemoryService } from './memory/memory-service';
 import { MemoryExtension } from './memory/memory-extension';
+import { ConfigExtension } from './config/config-extension';
 import { AgentRuntimeExtensionManager } from './extensions/agent-runtime-extension-manager';
 import {
   configStore,
@@ -859,6 +860,7 @@ app
       memoryService = new MemoryService(db);
       const headlessExtensionManager = new AgentRuntimeExtensionManager([
         new MemoryExtension(memoryService),
+        new ConfigExtension(configStore),
       ]);
 
       // Build the JSONL sender with permission interception BEFORE constructing SessionManager
@@ -1132,7 +1134,10 @@ app
 
     pluginRuntimeService = new PluginRuntimeService(new PluginCatalogService());
     memoryService = new MemoryService(db);
-    const extensionManager = new AgentRuntimeExtensionManager([new MemoryExtension(memoryService)]);
+    const extensionManager = new AgentRuntimeExtensionManager([
+      new MemoryExtension(memoryService),
+      new ConfigExtension(configStore),
+    ]);
 
     // Initialize session manager before creating an interactive window.
     // This avoids session.start racing the startup path and hitting a null manager.

--- a/src/tests/config/config-extension.test.ts
+++ b/src/tests/config/config-extension.test.ts
@@ -260,7 +260,6 @@ describe('config-extension', () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.content[0].text).toContain('sensitive');
       expect(result.content[0].text).toContain('not readable');
     });
 
@@ -269,7 +268,6 @@ describe('config-extension', () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.content[0].text).toContain('sensitive');
       expect(result.content[0].text).toContain('not readable');
     });
 
@@ -294,7 +292,7 @@ describe('config-extension', () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.content[0].text).toContain('sensitive');
+      expect(result.content[0].text).toContain('not readable');
     });
 
     it('handles null/undefined params gracefully', async () => {

--- a/src/tests/config/config-extension.test.ts
+++ b/src/tests/config/config-extension.test.ts
@@ -70,7 +70,6 @@ function createMockConfigStore(overrides: Partial<AppConfig> = {}) {
 
   return {
     getAll: vi.fn(() => defaults),
-    get: vi.fn((key: keyof AppConfig) => defaults[key]),
   };
 }
 
@@ -229,12 +228,32 @@ describe('config-extension', () => {
       expect(parsed).toHaveProperty('sandboxEnabled', true);
       expect(parsed).toHaveProperty('memoryEnabled', true);
       expect(parsed).toHaveProperty('enableThinking', true);
+      expect(parsed).toHaveProperty('activeProfileKey', 'anthropic');
+      expect(parsed).toHaveProperty('activeConfigSetId', 'default');
 
       // Should NOT include sensitive fields
       expect(parsed).not.toHaveProperty('apiKey');
       expect(parsed).not.toHaveProperty('profiles');
       expect(parsed).not.toHaveProperty('configSets');
       expect(parsed).not.toHaveProperty('memoryRuntime');
+    });
+
+    it('reads activeProfileKey individually', async () => {
+      const result = (await configReadTool.execute('test-call', { key: 'activeProfileKey' })) as {
+        content: { type: string; text: string }[];
+      };
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toEqual({ activeProfileKey: 'anthropic' });
+    });
+
+    it('reads activeConfigSetId individually', async () => {
+      const result = (await configReadTool.execute('test-call', {
+        key: 'activeConfigSetId',
+      })) as {
+        content: { type: string; text: string }[];
+      };
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toEqual({ activeConfigSetId: 'default' });
     });
 
     it('returns a specific field when key is provided', async () => {

--- a/src/tests/config/config-extension.test.ts
+++ b/src/tests/config/config-extension.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for src/main/config/config-extension.
+ *
+ * Focus areas:
+ *   - config_read tool returns non-sensitive fields when called without a key
+ *   - config_read filters out API keys, tokens, profiles, and other secrets
+ *   - config_read with a specific key returns that field's value
+ *   - config_read rejects requests for sensitive keys
+ *   - ConfigExtension.beforeSessionRun registers the config_read tool
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ConfigExtension,
+  buildSafeConfigSnapshot,
+  isKeyReadable,
+} from '../../main/config/config-extension';
+import type { AppConfig } from '../../main/config/config-store';
+
+// Minimal mock of ConfigStore — only getAll() is used by the extension
+function createMockConfigStore(overrides: Partial<AppConfig> = {}) {
+  const defaults: AppConfig = {
+    provider: 'anthropic',
+    apiKey: 'sk-ant-secret-key-12345',
+    baseUrl: 'https://api.anthropic.com',
+    customProtocol: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    contextWindow: 200000,
+    maxTokens: 8192,
+    activeProfileKey: 'anthropic',
+    profiles: {
+      anthropic: {
+        apiKey: 'sk-ant-secret-key-12345',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-6',
+      },
+    },
+    activeConfigSetId: 'default',
+    configSets: [],
+    agentCliPath: '',
+    defaultWorkdir: '/home/user/projects',
+    globalSkillsPath: '',
+    enableDevLogs: false,
+    theme: 'dark',
+    sandboxEnabled: true,
+    memoryEnabled: true,
+    memoryRuntime: {
+      llm: {
+        inheritFromActive: true,
+        apiKey: 'secret-llm-key',
+        baseUrl: '',
+        model: '',
+        timeoutMs: 180000,
+      },
+      embedding: {
+        inheritFromActive: true,
+        apiKey: 'secret-embedding-key',
+        baseUrl: '',
+        model: 'text-embedding-3-small',
+        timeoutMs: 180000,
+      },
+      useEmbedding: false,
+      maxNavSteps: 2,
+      ingestionConcurrency: 4,
+      storageRoot: '',
+    },
+    enableThinking: true,
+    isConfigured: true,
+    ...overrides,
+  };
+
+  return {
+    getAll: vi.fn(() => defaults),
+    get: vi.fn((key: keyof AppConfig) => defaults[key]),
+  };
+}
+
+describe('config-extension', () => {
+  describe('buildSafeConfigSnapshot', () => {
+    it('includes only safe top-level keys', () => {
+      const config = createMockConfigStore().getAll();
+      const snapshot = buildSafeConfigSnapshot(config);
+
+      // Should include these safe keys
+      expect(snapshot).toHaveProperty('provider', 'anthropic');
+      expect(snapshot).toHaveProperty('model', 'claude-sonnet-4-6');
+      expect(snapshot).toHaveProperty('sandboxEnabled', true);
+      expect(snapshot).toHaveProperty('memoryEnabled', true);
+      expect(snapshot).toHaveProperty('enableThinking', true);
+      expect(snapshot).toHaveProperty('theme', 'dark');
+      expect(snapshot).toHaveProperty('isConfigured', true);
+      expect(snapshot).toHaveProperty('defaultWorkdir', '/home/user/projects');
+    });
+
+    it('excludes API key from snapshot', () => {
+      const config = createMockConfigStore().getAll();
+      const snapshot = buildSafeConfigSnapshot(config);
+
+      expect(snapshot).not.toHaveProperty('apiKey');
+    });
+
+    it('excludes profiles (contains API keys) from snapshot', () => {
+      const config = createMockConfigStore().getAll();
+      const snapshot = buildSafeConfigSnapshot(config);
+
+      expect(snapshot).not.toHaveProperty('profiles');
+    });
+
+    it('excludes configSets from snapshot', () => {
+      const config = createMockConfigStore().getAll();
+      const snapshot = buildSafeConfigSnapshot(config);
+
+      expect(snapshot).not.toHaveProperty('configSets');
+    });
+
+    it('excludes baseUrl from snapshot', () => {
+      const config = createMockConfigStore().getAll();
+      const snapshot = buildSafeConfigSnapshot(config);
+
+      expect(snapshot).not.toHaveProperty('baseUrl');
+    });
+
+    it('excludes memoryRuntime (contains API keys) from snapshot', () => {
+      const config = createMockConfigStore().getAll();
+      const snapshot = buildSafeConfigSnapshot(config);
+
+      expect(snapshot).not.toHaveProperty('memoryRuntime');
+    });
+  });
+
+  describe('isKeyReadable', () => {
+    it('returns true for safe keys', () => {
+      expect(isKeyReadable('provider')).toBe(true);
+      expect(isKeyReadable('model')).toBe(true);
+      expect(isKeyReadable('sandboxEnabled')).toBe(true);
+      expect(isKeyReadable('memoryEnabled')).toBe(true);
+      expect(isKeyReadable('enableThinking')).toBe(true);
+      expect(isKeyReadable('theme')).toBe(true);
+      expect(isKeyReadable('enableDevLogs')).toBe(true);
+      expect(isKeyReadable('contextWindow')).toBe(true);
+      expect(isKeyReadable('maxTokens')).toBe(true);
+    });
+
+    it('returns false for apiKey', () => {
+      expect(isKeyReadable('apiKey')).toBe(false);
+    });
+
+    it('returns false for profiles', () => {
+      expect(isKeyReadable('profiles')).toBe(false);
+    });
+
+    it('returns false for configSets', () => {
+      expect(isKeyReadable('configSets')).toBe(false);
+    });
+
+    it('returns false for memoryRuntime', () => {
+      expect(isKeyReadable('memoryRuntime')).toBe(false);
+    });
+
+    it('returns false for any key containing "key"', () => {
+      expect(isKeyReadable('someApiKey')).toBe(false);
+      expect(isKeyReadable('encryptionKey')).toBe(false);
+    });
+
+    it('returns false for any key containing "token"', () => {
+      expect(isKeyReadable('authToken')).toBe(false);
+      expect(isKeyReadable('refreshToken')).toBe(false);
+    });
+
+    it('returns false for any key containing "secret"', () => {
+      expect(isKeyReadable('clientSecret')).toBe(false);
+    });
+
+    it('returns false for any key containing "password"', () => {
+      expect(isKeyReadable('userPassword')).toBe(false);
+    });
+
+    it('returns false for unknown keys not in safe list', () => {
+      expect(isKeyReadable('nonExistentField')).toBe(false);
+      expect(isKeyReadable('internalState')).toBe(false);
+    });
+  });
+
+  describe('ConfigExtension', () => {
+    let mockConfigStore: ReturnType<typeof createMockConfigStore>;
+
+    beforeEach(() => {
+      mockConfigStore = createMockConfigStore();
+    });
+
+    it('has name "config"', () => {
+      // Cast is needed because mock only implements getAll/get, not full ConfigStore
+      const ext = new ConfigExtension(mockConfigStore as never);
+      expect(ext.name).toBe('config');
+    });
+
+    it('beforeSessionRun returns config_read tool', async () => {
+      const ext = new ConfigExtension(mockConfigStore as never);
+      const result = await ext.beforeSessionRun();
+
+      expect(result).toBeDefined();
+      expect(result.customTools).toHaveLength(1);
+      expect(result.customTools![0].name).toBe('config_read');
+    });
+  });
+
+  describe('config_read tool execution', () => {
+    let configReadTool: {
+      execute: (id: string, params: unknown, ...rest: unknown[]) => Promise<unknown>;
+    };
+
+    beforeEach(async () => {
+      const mockStore = createMockConfigStore();
+      const ext = new ConfigExtension(mockStore as never);
+      const result = await ext.beforeSessionRun();
+      configReadTool = result.customTools![0] as unknown as typeof configReadTool;
+    });
+
+    it('returns all non-sensitive fields when no key is specified', async () => {
+      const result = (await configReadTool.execute('test-call', {})) as {
+        content: { type: string; text: string }[];
+      };
+
+      expect(result.content).toHaveLength(1);
+      const parsed = JSON.parse(result.content[0].text);
+
+      // Should include safe fields
+      expect(parsed).toHaveProperty('provider', 'anthropic');
+      expect(parsed).toHaveProperty('model', 'claude-sonnet-4-6');
+      expect(parsed).toHaveProperty('sandboxEnabled', true);
+      expect(parsed).toHaveProperty('memoryEnabled', true);
+      expect(parsed).toHaveProperty('enableThinking', true);
+
+      // Should NOT include sensitive fields
+      expect(parsed).not.toHaveProperty('apiKey');
+      expect(parsed).not.toHaveProperty('profiles');
+      expect(parsed).not.toHaveProperty('configSets');
+      expect(parsed).not.toHaveProperty('memoryRuntime');
+    });
+
+    it('returns a specific field when key is provided', async () => {
+      const result = (await configReadTool.execute('test-call', { key: 'provider' })) as {
+        content: { type: string; text: string }[];
+      };
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toEqual({ provider: 'anthropic' });
+    });
+
+    it('returns contextWindow when requested', async () => {
+      const result = (await configReadTool.execute('test-call', { key: 'contextWindow' })) as {
+        content: { type: string; text: string }[];
+      };
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toEqual({ contextWindow: 200000 });
+    });
+
+    it('rejects reading apiKey', async () => {
+      const result = (await configReadTool.execute('test-call', { key: 'apiKey' })) as {
+        content: { type: string; text: string }[];
+      };
+
+      expect(result.content[0].text).toContain('sensitive');
+      expect(result.content[0].text).toContain('not readable');
+    });
+
+    it('rejects reading profiles', async () => {
+      const result = (await configReadTool.execute('test-call', { key: 'profiles' })) as {
+        content: { type: string; text: string }[];
+      };
+
+      expect(result.content[0].text).toContain('sensitive');
+      expect(result.content[0].text).toContain('not readable');
+    });
+
+    it('rejects reading configSets', async () => {
+      const result = (await configReadTool.execute('test-call', { key: 'configSets' })) as {
+        content: { type: string; text: string }[];
+      };
+
+      expect(result.content[0].text).toContain('not readable');
+    });
+
+    it('rejects reading memoryRuntime', async () => {
+      const result = (await configReadTool.execute('test-call', { key: 'memoryRuntime' })) as {
+        content: { type: string; text: string }[];
+      };
+
+      expect(result.content[0].text).toContain('not readable');
+    });
+
+    it('rejects reading keys with sensitive patterns', async () => {
+      const result = (await configReadTool.execute('test-call', { key: 'authToken' })) as {
+        content: { type: string; text: string }[];
+      };
+
+      expect(result.content[0].text).toContain('sensitive');
+    });
+
+    it('handles null/undefined params gracefully', async () => {
+      const result = (await configReadTool.execute('test-call', null)) as {
+        content: { type: string; text: string }[];
+      };
+
+      // Should return full snapshot without crashing
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveProperty('provider');
+      expect(parsed).not.toHaveProperty('apiKey');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Inject current model/provider/context window/thinking/sandbox/memory config into the agent's system prompt so it knows its own capabilities
- Add `config_read` custom tool via new `ConfigExtension` (same pattern as `MemoryExtension`)
- Uses an explicit **allowlist** of safe keys — sensitive fields (apiKey, tokens, secrets) are never exposed
- Registered in both GUI and headless startup paths

## Changes
- `src/main/config/config-extension.ts` — new extension with `config_read` tool definition
- `src/main/agent/agent-runner.ts` — `<your_configuration>` block in system prompt
- `src/main/index.ts` — register `ConfigExtension` in both paths
- `src/tests/config/config-extension.test.ts` — 27 tests

## Test plan
- [ ] Verify `config_read` returns non-sensitive fields correctly
- [ ] Verify sensitive keys (apiKey, tokens) are blocked by allowlist
- [ ] Verify system prompt includes config info (check agent-runner)
- [ ] Run `npm run test` — all config-extension tests pass
- [ ] Run `npm run lint` — no new errors

Part of Roadmap #274 (Config 文件化 Phase 1)