### PR TITLE
feat(compact): wire manual compact trigger and surface compaction results

### DIFF
--- a/src/main/agent/agent-runner.ts
+++ b/src/main/agent/agent-runner.ts
@@ -2855,8 +2855,8 @@ Tool routing:
                 event.willRetry
               );
 
-              // Surface compaction result details to the renderer
-              if (event.result) {
+              // Surface compaction result details to the renderer (skip if retrying)
+              if (event.result && !event.willRetry) {
                 const compactionDetails = event.result.details as
                   | { readFiles?: string[]; modifiedFiles?: string[] }
                   | undefined;
@@ -3121,15 +3121,20 @@ Tool routing:
       return null;
     }
     log('[CoworkAgentRunner] Manual compact triggered for session:', sessionId);
-    const result = await cached.session.compact(customInstructions);
-    log(
-      '[CoworkAgentRunner] Manual compact completed:',
-      JSON.stringify({
-        summaryLen: result.summary.length,
-        tokensBefore: result.tokensBefore,
-      })
-    );
-    return result;
+    try {
+      const result = await cached.session.compact(customInstructions);
+      log(
+        '[CoworkAgentRunner] Manual compact completed:',
+        JSON.stringify({
+          summaryLen: result.summary.length,
+          tokensBefore: result.tokensBefore,
+        })
+      );
+      return result;
+    } catch (err) {
+      logError('[CoworkAgentRunner] compact error:', err);
+      return null;
+    }
   }
 
   /**
@@ -3145,8 +3150,14 @@ Tool routing:
     if (!cached) {
       return null;
     }
-    const usage = cached.session.getContextUsage();
-    return usage ?? null;
+    try {
+      const usage = cached.session.getContextUsage();
+      log('[CoworkAgentRunner] getContextUsage:', sessionId, JSON.stringify(usage));
+      return usage ?? null;
+    } catch (err) {
+      logError('[CoworkAgentRunner] getContextUsage error:', err);
+      return null;
+    }
   }
 
   cancel(sessionId: string): void {

--- a/src/main/agent/agent-runner.ts
+++ b/src/main/agent/agent-runner.ts
@@ -2854,6 +2854,33 @@ Tool routing:
                 'willRetry:',
                 event.willRetry
               );
+
+              // Surface compaction result details to the renderer
+              if (event.result) {
+                const compactionDetails = event.result.details as
+                  | { readFiles?: string[]; modifiedFiles?: string[] }
+                  | undefined;
+                this.sendToRenderer({
+                  type: 'compaction.result',
+                  payload: {
+                    sessionId: session.id,
+                    summary: event.result.summary,
+                    tokensBefore: event.result.tokensBefore,
+                    readFiles: compactionDetails?.readFiles || [],
+                    modifiedFiles: compactionDetails?.modifiedFiles || [],
+                  },
+                });
+                log(
+                  '[CoworkAgentRunner] Compaction result surfaced:',
+                  JSON.stringify({
+                    summaryLen: event.result.summary.length,
+                    tokensBefore: event.result.tokensBefore,
+                    readFiles: compactionDetails?.readFiles?.length || 0,
+                    modifiedFiles: compactionDetails?.modifiedFiles?.length || 0,
+                  })
+                );
+              }
+
               if (compactionStepId) {
                 this.sendTraceUpdate(session.id, compactionStepId, { status, title });
                 compactionStepId = undefined;
@@ -3071,6 +3098,55 @@ Tool routing:
         }
       }
     }
+  }
+
+  /**
+   * Manually trigger context compaction for a session.
+   * Delegates to the SDK's AgentSession.compact() method.
+   *
+   * @returns CompactionResult if successful, null if no session cached
+   */
+  async compact(
+    sessionId: string,
+    customInstructions?: string
+  ): Promise<{
+    summary: string;
+    firstKeptEntryId: string;
+    tokensBefore: number;
+    details?: unknown;
+  } | null> {
+    const cached = this.piSessions.get(sessionId);
+    if (!cached) {
+      logWarn('[CoworkAgentRunner] No cached pi session for compact:', sessionId);
+      return null;
+    }
+    log('[CoworkAgentRunner] Manual compact triggered for session:', sessionId);
+    const result = await cached.session.compact(customInstructions);
+    log(
+      '[CoworkAgentRunner] Manual compact completed:',
+      JSON.stringify({
+        summaryLen: result.summary.length,
+        tokensBefore: result.tokensBefore,
+      })
+    );
+    return result;
+  }
+
+  /**
+   * Get current context usage for a session.
+   * Delegates to the SDK's AgentSession.getContextUsage() method.
+   *
+   * @returns ContextUsage { tokens, contextWindow, percent } or null
+   */
+  getContextUsage(
+    sessionId: string
+  ): { tokens: number | null; contextWindow: number; percent: number | null } | null {
+    const cached = this.piSessions.get(sessionId);
+    if (!cached) {
+      return null;
+    }
+    const usage = cached.session.getContextUsage();
+    return usage ?? null;
   }
 
   cancel(sessionId: string): void {

--- a/src/main/client-event-utils.ts
+++ b/src/main/client-event-utils.ts
@@ -10,6 +10,8 @@ export function eventRequiresSessionManager(event: ClientEvent): boolean {
     case 'session.list':
     case 'session.getMessages':
     case 'session.getTraceSteps':
+    case 'session.compact':
+    case 'session.getContextUsage':
     case 'permission.response':
       return true;
     default:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3028,6 +3028,12 @@ async function handleClientEvent(event: ClientEvent): Promise<unknown> {
     case 'session.getTraceSteps':
       return sm.getTraceSteps(event.payload.sessionId);
 
+    case 'session.compact':
+      return sm.compactSession(event.payload.sessionId, event.payload.customInstructions);
+
+    case 'session.getContextUsage':
+      return sm.getContextUsage(event.payload.sessionId);
+
     case 'permission.response':
       return sm.handlePermissionResponse(event.payload.toolUseId, event.payload.result);
 

--- a/src/main/session/session-manager.ts
+++ b/src/main/session/session-manager.ts
@@ -63,6 +63,18 @@ interface AgentRunner {
   cancel(sessionId: string): void;
   clearSdkSession?(sessionId: string): void;
   clearAllSdkSessions?(): void;
+  compact?(
+    sessionId: string,
+    customInstructions?: string
+  ): Promise<{
+    summary: string;
+    firstKeptEntryId: string;
+    tokensBefore: number;
+    details?: unknown;
+  } | null>;
+  getContextUsage?(
+    sessionId: string
+  ): { tokens: number | null; contextWindow: number; percent: number | null } | null;
 }
 
 const WORKSPACE_MOUNT_VIRTUAL_PATH = '/mnt/workspace';
@@ -1081,6 +1093,39 @@ export class SessionManager {
 
   clearAllCachedAgentSessions(): void {
     this.agentRunner?.clearAllSdkSessions?.();
+  }
+
+  /**
+   * Manually trigger context compaction for a session.
+   * Delegates to the agent runner's compact() method.
+   */
+  async compactSession(
+    sessionId: string,
+    customInstructions?: string
+  ): Promise<{
+    summary: string;
+    firstKeptEntryId: string;
+    tokensBefore: number;
+    details?: unknown;
+  } | null> {
+    if (!this.agentRunner?.compact) {
+      logWarn('[SessionManager] Agent runner does not support compact()');
+      return null;
+    }
+    return this.agentRunner.compact(sessionId, customInstructions);
+  }
+
+  /**
+   * Get current context usage for a session.
+   * Delegates to the agent runner's getContextUsage() method.
+   */
+  getContextUsage(
+    sessionId: string
+  ): { tokens: number | null; contextWindow: number; percent: number | null } | null {
+    if (!this.agentRunner?.getContextUsage) {
+      return null;
+    }
+    return this.agentRunner.getContextUsage(sessionId);
   }
 
   // Save message to database

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -54,6 +54,8 @@ const ALLOWED_CLIENT_EVENTS: ReadonlySet<string> = new Set<ClientEvent['type']>(
   'session.list',
   'session.getMessages',
   'session.getTraceSteps',
+  'session.compact',
+  'session.getContextUsage',
   'permission.response',
   'sudo.password.response',
   'settings.update',
@@ -114,6 +116,34 @@ contextBridge.exposeInMainWorld('electronAPI', {
     }
     console.log('[Preload] Invoking:', event.type);
     return ipcRenderer.invoke('client-invoke', event);
+  },
+
+  // Session compaction and context usage
+  session: {
+    compact: (
+      sessionId: string,
+      customInstructions?: string
+    ): Promise<{
+      summary: string;
+      firstKeptEntryId: string;
+      tokensBefore: number;
+      details?: unknown;
+    } | null> =>
+      ipcRenderer.invoke('client-invoke', {
+        type: 'session.compact',
+        payload: { sessionId, customInstructions },
+      }),
+    getContextUsage: (
+      sessionId: string
+    ): Promise<{
+      tokens: number | null;
+      contextWindow: number;
+      percent: number | null;
+    } | null> =>
+      ipcRenderer.invoke('client-invoke', {
+        type: 'session.getContextUsage',
+        payload: { sessionId },
+      }),
   },
 
   // Platform info
@@ -411,7 +441,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   memory: {
-    getOverview: (cwd?: string): Promise<MemoryOverview> => ipcRenderer.invoke('memory.getOverview', cwd),
+    getOverview: (cwd?: string): Promise<MemoryOverview> =>
+      ipcRenderer.invoke('memory.getOverview', cwd),
     search: (payload: {
       query: string;
       cwd?: string;
@@ -424,7 +455,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('memory.rebuildWorkspace', cwd),
     clearWorkspace: (cwd: string): Promise<{ success: boolean; workspaceKey: string }> =>
       ipcRenderer.invoke('memory.clearWorkspace', cwd),
-    clearCoreMemory: (): Promise<{ success: boolean }> => ipcRenderer.invoke('memory.clearCoreMemory'),
+    clearCoreMemory: (): Promise<{ success: boolean }> =>
+      ipcRenderer.invoke('memory.clearCoreMemory'),
     rebuildAll: (): Promise<{ success: boolean; workspaceCount: number; sessionCount: number }> =>
       ipcRenderer.invoke('memory.rebuildAll'),
     listFiles: (): Promise<MemoryDebugFileInfo[]> => ipcRenderer.invoke('memory.listFiles'),
@@ -447,6 +479,22 @@ declare global {
       send: (event: ClientEvent) => void;
       on: (callback: (event: ServerEvent) => void) => () => void;
       invoke: <T>(event: ClientEvent) => Promise<T>;
+      session: {
+        compact: (
+          sessionId: string,
+          customInstructions?: string
+        ) => Promise<{
+          summary: string;
+          firstKeptEntryId: string;
+          tokensBefore: number;
+          details?: unknown;
+        } | null>;
+        getContextUsage: (sessionId: string) => Promise<{
+          tokens: number | null;
+          contextWindow: number;
+          percent: number | null;
+        } | null>;
+      };
       platform: NodeJS.Platform;
       getSystemTheme: () => Promise<{ shouldUseDarkColors: boolean }>;
       getVersion: () => Promise<string>;
@@ -665,7 +713,11 @@ declare global {
         rebuildWorkspace: (cwd: string) => Promise<{ success: boolean; workspaceKey: string }>;
         clearWorkspace: (cwd: string) => Promise<{ success: boolean; workspaceKey: string }>;
         clearCoreMemory: () => Promise<{ success: boolean }>;
-        rebuildAll: () => Promise<{ success: boolean; workspaceCount: number; sessionCount: number }>;
+        rebuildAll: () => Promise<{
+          success: boolean;
+          workspaceCount: number;
+          sessionCount: number;
+        }>;
         listFiles: () => Promise<MemoryDebugFileInfo[]>;
         readFile: (filePath: string) => Promise<MemoryDebugFileContent>;
         inspectSession: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -65,6 +65,19 @@ const ALLOWED_CLIENT_EVENTS: ReadonlySet<string> = new Set<ClientEvent['type']>(
   'workdir.select',
 ]);
 
+// Invoke a whitelisted ClientEvent and wait for the response. Defined once at
+// module scope so both the generic `invoke()` API and the typed `session.*`
+// helpers below share the same ALLOWED_CLIENT_EVENTS check instead of one of
+// them bypassing it via a raw ipcRenderer.invoke('client-invoke', ...) call.
+const invoke = async <T>(event: ClientEvent): Promise<T> => {
+  if (!ALLOWED_CLIENT_EVENTS.has(event.type)) {
+    console.warn('[Preload] Blocked unauthorized invoke type:', event.type);
+    throw new Error(`Unauthorized event type: ${event.type}`);
+  }
+  console.log('[Preload] Invoking:', event.type);
+  return ipcRenderer.invoke('client-invoke', event);
+};
+
 // Expose protected methods that allow the renderer process to use
 // the ipcRenderer without exposing the entire object
 contextBridge.exposeInMainWorld('electronAPI', {
@@ -109,14 +122,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   // Invoke and wait for response
-  invoke: async <T>(event: ClientEvent): Promise<T> => {
-    if (!ALLOWED_CLIENT_EVENTS.has(event.type)) {
-      console.warn('[Preload] Blocked unauthorized invoke type:', event.type);
-      throw new Error(`Unauthorized event type: ${event.type}`);
-    }
-    console.log('[Preload] Invoking:', event.type);
-    return ipcRenderer.invoke('client-invoke', event);
-  },
+  invoke,
 
   // Session compaction and context usage
   session: {
@@ -129,7 +135,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       tokensBefore: number;
       details?: unknown;
     } | null> =>
-      ipcRenderer.invoke('client-invoke', {
+      invoke({
         type: 'session.compact',
         payload: { sessionId, customInstructions },
       }),
@@ -140,7 +146,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       contextWindow: number;
       percent: number | null;
     } | null> =>
-      ipcRenderer.invoke('client-invoke', {
+      invoke({
         type: 'session.getContextUsage',
         payload: { sessionId },
       }),

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -470,6 +470,11 @@ export type ClientEvent =
   | { type: 'session.list'; payload: Record<string, never> }
   | { type: 'session.getMessages'; payload: { sessionId: string } }
   | { type: 'session.getTraceSteps'; payload: { sessionId: string } }
+  | {
+      type: 'session.compact';
+      payload: { sessionId: string; customInstructions?: string };
+    }
+  | { type: 'session.getContextUsage'; payload: { sessionId: string } }
   | { type: 'permission.response'; payload: { toolUseId: string; result: PermissionResult } }
   | { type: 'sudo.password.response'; payload: { toolUseId: string; password: string | null } }
   | { type: 'settings.update'; payload: Record<string, unknown> }
@@ -550,6 +555,16 @@ export type ServerEvent =
     }
   | { type: 'workdir.changed'; payload: { path: string } }
   | { type: 'session.contextInfo'; payload: { sessionId: string; contextWindow: number } }
+  | {
+      type: 'compaction.result';
+      payload: {
+        sessionId: string;
+        summary: string;
+        tokensBefore: number;
+        readFiles: string[];
+        modifiedFiles: string[];
+      };
+    }
   | {
       type: 'navigate.to';
       payload: { page: 'welcome' | 'settings' | 'session'; tab?: string; sessionId?: string };

--- a/src/tests/agent/compact-integration.test.ts
+++ b/src/tests/agent/compact-integration.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Tests for the compact/context-usage plumbing added in Phase 1.
+ *
+ * Verifies:
+ * - CoworkAgentRunner.compact() delegates to piSession.compact()
+ * - CoworkAgentRunner.getContextUsage() delegates to piSession.getContextUsage()
+ * - The auto_compaction_end event handler surfaces CompactionResult via
+ *   the 'compaction.result' ServerEvent
+ * - SessionManager.compactSession() and getContextUsage() delegate to the runner
+ * - The 'compaction.result' ServerEvent has the correct shape
+ *
+ * These are unit-level tests; the actual SDK is mocked.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { ServerEvent } from '../../renderer/types';
+
+// ── SessionManager delegation tests ──
+
+describe('SessionManager compact delegation', () => {
+  it('compactSession delegates to agentRunner.compact', async () => {
+    const mockCompactResult = {
+      summary: 'Summarized conversation about file editing',
+      firstKeptEntryId: 'entry-42',
+      tokensBefore: 50000,
+      details: { readFiles: ['src/index.ts'], modifiedFiles: ['src/app.ts'] },
+    };
+
+    const mockRunner = {
+      run: vi.fn(),
+      cancel: vi.fn(),
+      compact: vi.fn().mockResolvedValue(mockCompactResult),
+      getContextUsage: vi.fn(),
+    };
+
+    // Create a minimal SessionManager-like object to test delegation logic
+    // without pulling in the full dependency tree
+    const compactSession = async (sessionId: string, customInstructions?: string) => {
+      if (!mockRunner.compact) return null;
+      return mockRunner.compact(sessionId, customInstructions);
+    };
+
+    const result = await compactSession('session-123', 'Focus on code changes');
+
+    expect(mockRunner.compact).toHaveBeenCalledWith('session-123', 'Focus on code changes');
+    expect(result).toEqual(mockCompactResult);
+    expect(result?.summary).toBe('Summarized conversation about file editing');
+    expect(result?.tokensBefore).toBe(50000);
+  });
+
+  it('compactSession returns null when runner has no compact method', async () => {
+    const mockRunner = {
+      run: vi.fn(),
+      cancel: vi.fn(),
+    };
+
+    const compactSession = async (_sessionId: string) => {
+      if (!(mockRunner as { compact?: unknown }).compact) return null;
+      return null;
+    };
+
+    const result = await compactSession('session-456');
+    expect(result).toBeNull();
+  });
+
+  it('getContextUsage delegates to agentRunner.getContextUsage', () => {
+    const mockUsage = { tokens: 45000, contextWindow: 128000, percent: 35.2 };
+    const mockRunner = {
+      run: vi.fn(),
+      cancel: vi.fn(),
+      getContextUsage: vi.fn().mockReturnValue(mockUsage),
+    };
+
+    const getContextUsage = (sessionId: string) => {
+      if (!mockRunner.getContextUsage) return null;
+      return mockRunner.getContextUsage(sessionId);
+    };
+
+    const result = getContextUsage('session-789');
+
+    expect(mockRunner.getContextUsage).toHaveBeenCalledWith('session-789');
+    expect(result).toEqual(mockUsage);
+    expect(result?.tokens).toBe(45000);
+    expect(result?.contextWindow).toBe(128000);
+    expect(result?.percent).toBe(35.2);
+  });
+
+  it('getContextUsage returns null when no cached session', () => {
+    const mockRunner = {
+      run: vi.fn(),
+      cancel: vi.fn(),
+      getContextUsage: vi.fn().mockReturnValue(null),
+    };
+
+    const getContextUsage = (sessionId: string) => {
+      if (!mockRunner.getContextUsage) return null;
+      return mockRunner.getContextUsage(sessionId);
+    };
+
+    const result = getContextUsage('nonexistent-session');
+    expect(result).toBeNull();
+  });
+});
+
+// ── compaction.result event shape tests ──
+
+describe('compaction.result event format', () => {
+  it('has the correct shape with all fields populated', () => {
+    const event: ServerEvent = {
+      type: 'compaction.result',
+      payload: {
+        sessionId: 'session-abc',
+        summary: 'The user asked about TypeScript generics and received detailed examples.',
+        tokensBefore: 85000,
+        readFiles: ['src/types.ts', 'src/utils.ts'],
+        modifiedFiles: ['src/generics.ts'],
+      },
+    };
+
+    expect(event.type).toBe('compaction.result');
+    expect(event.payload.sessionId).toBe('session-abc');
+    expect(event.payload.summary).toContain('TypeScript generics');
+    expect(event.payload.tokensBefore).toBe(85000);
+    expect(event.payload.readFiles).toHaveLength(2);
+    expect(event.payload.modifiedFiles).toHaveLength(1);
+  });
+
+  it('accepts empty file lists', () => {
+    const event: ServerEvent = {
+      type: 'compaction.result',
+      payload: {
+        sessionId: 'session-def',
+        summary: 'Conversation about design patterns.',
+        tokensBefore: 40000,
+        readFiles: [],
+        modifiedFiles: [],
+      },
+    };
+
+    expect(event.payload.readFiles).toHaveLength(0);
+    expect(event.payload.modifiedFiles).toHaveLength(0);
+  });
+});
+
+// ── CoworkAgentRunner compact/getContextUsage method tests ──
+
+describe('CoworkAgentRunner compact and getContextUsage', () => {
+  it('compact returns null when no cached session exists', async () => {
+    // Simulate the behavior: piSessions.get returns undefined
+    const piSessions = new Map<string, { session: { compact: () => Promise<unknown> } }>();
+
+    const compact = async (sessionId: string, _customInstructions?: string) => {
+      const cached = piSessions.get(sessionId);
+      if (!cached) return null;
+      return cached.session.compact();
+    };
+
+    const result = await compact('no-such-session');
+    expect(result).toBeNull();
+  });
+
+  it('compact delegates to piSession.compact when session exists', async () => {
+    const mockResult = {
+      summary: 'Test summary',
+      firstKeptEntryId: 'entry-1',
+      tokensBefore: 60000,
+    };
+
+    const piSessions = new Map([
+      [
+        'session-1',
+        {
+          session: {
+            compact: vi.fn().mockResolvedValue(mockResult),
+          },
+        },
+      ],
+    ]);
+
+    const compact = async (_sessionId: string, customInstructions?: string) => {
+      const cached = piSessions.get('session-1');
+      if (!cached) return null;
+      return cached.session.compact(customInstructions);
+    };
+
+    const result = await compact('session-1', 'Focus on API changes');
+
+    expect(piSessions.get('session-1')!.session.compact).toHaveBeenCalledWith(
+      'Focus on API changes'
+    );
+    expect(result).toEqual(mockResult);
+  });
+
+  it('getContextUsage returns null when no cached session exists', () => {
+    const piSessions = new Map<string, { session: { getContextUsage: () => unknown } }>();
+
+    const getContextUsage = (sessionId: string) => {
+      const cached = piSessions.get(sessionId);
+      if (!cached) return null;
+      return cached.session.getContextUsage() ?? null;
+    };
+
+    expect(getContextUsage('no-such-session')).toBeNull();
+  });
+
+  it('getContextUsage returns SDK result when session exists', () => {
+    const mockUsage = { tokens: 30000, contextWindow: 200000, percent: 15.0 };
+
+    const piSessions = new Map([
+      [
+        'session-2',
+        {
+          session: {
+            getContextUsage: vi.fn().mockReturnValue(mockUsage),
+          },
+        },
+      ],
+    ]);
+
+    const getContextUsage = (sessionId: string) => {
+      const cached = piSessions.get(sessionId);
+      if (!cached) return null;
+      return cached.session.getContextUsage() ?? null;
+    };
+
+    const result = getContextUsage('session-2');
+    expect(result).toEqual(mockUsage);
+  });
+
+  it('getContextUsage returns null when SDK returns undefined', () => {
+    const piSessions = new Map([
+      [
+        'session-3',
+        {
+          session: {
+            getContextUsage: vi.fn().mockReturnValue(undefined),
+          },
+        },
+      ],
+    ]);
+
+    const getContextUsage = (sessionId: string) => {
+      const cached = piSessions.get(sessionId);
+      if (!cached) return null;
+      return cached.session.getContextUsage() ?? null;
+    };
+
+    expect(getContextUsage('session-3')).toBeNull();
+  });
+});
+
+// ── auto_compaction_end event surfacing tests ──
+
+describe('auto_compaction_end event surfacing', () => {
+  it('surfaces compaction result when event.result is present', () => {
+    const events: ServerEvent[] = [];
+    const sendToRenderer = (event: ServerEvent) => events.push(event);
+    const sessionId = 'session-compact-1';
+
+    // Simulate the event handler logic from agent-runner.ts
+    const event = {
+      type: 'auto_compaction_end' as const,
+      result: {
+        summary: 'User discussed file operations and TypeScript refactoring.',
+        firstKeptEntryId: 'entry-99',
+        tokensBefore: 75000,
+        details: {
+          readFiles: ['src/main.ts', 'src/config.ts'],
+          modifiedFiles: ['src/app.ts'],
+        },
+      },
+      aborted: false,
+      willRetry: false,
+    };
+
+    // Replicate the surfacing logic
+    if (event.result) {
+      const compactionDetails = event.result.details as
+        | { readFiles?: string[]; modifiedFiles?: string[] }
+        | undefined;
+      sendToRenderer({
+        type: 'compaction.result',
+        payload: {
+          sessionId,
+          summary: event.result.summary,
+          tokensBefore: event.result.tokensBefore,
+          readFiles: compactionDetails?.readFiles || [],
+          modifiedFiles: compactionDetails?.modifiedFiles || [],
+        },
+      });
+    }
+
+    expect(events).toHaveLength(1);
+    const emitted = events[0];
+    expect(emitted.type).toBe('compaction.result');
+    if (emitted.type === 'compaction.result') {
+      expect(emitted.payload.sessionId).toBe(sessionId);
+      expect(emitted.payload.summary).toContain('TypeScript refactoring');
+      expect(emitted.payload.tokensBefore).toBe(75000);
+      expect(emitted.payload.readFiles).toEqual(['src/main.ts', 'src/config.ts']);
+      expect(emitted.payload.modifiedFiles).toEqual(['src/app.ts']);
+    }
+  });
+
+  it('does not emit compaction.result when event.result is undefined', () => {
+    const events: ServerEvent[] = [];
+    const sendToRenderer = (event: ServerEvent) => events.push(event);
+
+    const event = {
+      type: 'auto_compaction_end' as const,
+      result: undefined,
+      aborted: true,
+      willRetry: false,
+      errorMessage: 'Compaction was aborted',
+    };
+
+    if (event.result) {
+      const compactionDetails = event.result.details as
+        | { readFiles?: string[]; modifiedFiles?: string[] }
+        | undefined;
+      sendToRenderer({
+        type: 'compaction.result',
+        payload: {
+          sessionId: 'session-x',
+          summary: event.result.summary,
+          tokensBefore: event.result.tokensBefore,
+          readFiles: compactionDetails?.readFiles || [],
+          modifiedFiles: compactionDetails?.modifiedFiles || [],
+        },
+      });
+    }
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('handles missing details gracefully (defaults to empty arrays)', () => {
+    const events: ServerEvent[] = [];
+    const sendToRenderer = (event: ServerEvent) => events.push(event);
+
+    const event = {
+      type: 'auto_compaction_end' as const,
+      result: {
+        summary: 'Simple conversation.',
+        firstKeptEntryId: 'entry-1',
+        tokensBefore: 20000,
+        // details is undefined — no readFiles/modifiedFiles tracked
+      },
+      aborted: false,
+      willRetry: false,
+    };
+
+    if (event.result) {
+      const compactionDetails = event.result.details as
+        | { readFiles?: string[]; modifiedFiles?: string[] }
+        | undefined;
+      sendToRenderer({
+        type: 'compaction.result',
+        payload: {
+          sessionId: 'session-y',
+          summary: event.result.summary,
+          tokensBefore: event.result.tokensBefore,
+          readFiles: compactionDetails?.readFiles || [],
+          modifiedFiles: compactionDetails?.modifiedFiles || [],
+        },
+      });
+    }
+
+    expect(events).toHaveLength(1);
+    if (events[0].type === 'compaction.result') {
+      expect(events[0].payload.readFiles).toEqual([]);
+      expect(events[0].payload.modifiedFiles).toEqual([]);
+    }
+  });
+});

--- a/src/tests/agent/compact-integration.test.ts
+++ b/src/tests/agent/compact-integration.test.ts
@@ -308,7 +308,9 @@ describe('auto_compaction_end event surfacing', () => {
 
     const event = {
       type: 'auto_compaction_end' as const,
-      result: undefined,
+      result: undefined as
+        | { summary: string; firstKeptEntryId: string; tokensBefore: number; details?: unknown }
+        | undefined,
       aborted: true,
       willRetry: false,
       errorMessage: 'Compaction was aborted',
@@ -343,8 +345,7 @@ describe('auto_compaction_end event surfacing', () => {
         summary: 'Simple conversation.',
         firstKeptEntryId: 'entry-1',
         tokensBefore: 20000,
-        // details is undefined — no readFiles/modifiedFiles tracked
-      },
+      } as { summary: string; firstKeptEntryId: string; tokensBefore: number; details?: unknown },
       aborted: false,
       willRetry: false,
     };


### PR DESCRIPTION
## Summary
- Wire `AgentSession.compact()` as a manual trigger via IPC (`session.compact`)
- Surface `auto_compaction_end.result` — previously the app discarded the `CompactionResult` (only read pass/fail)
- Expose `AgentSession.getContextUsage()` via IPC (`session.getContextUsage`) for real-time token tracking
- All new APIs accessible from both GUI (preload + renderer types) and headless mode

## Changes
- `src/main/agent/agent-runner.ts` — new `compact()` and `getContextUsage()` methods on `CoworkAgentRunner`; `auto_compaction_end` handler now emits `compaction.result` event with summary + file lists
- `src/main/session/session-manager.ts` — `compactSession()` and `getContextUsage()` delegation
- `src/main/index.ts` — `session.compact` and `session.getContextUsage` in `handleClientEvent`
- `src/main/client-event-utils.ts` — new events in `eventRequiresSessionManager()`
- `src/renderer/types/index.ts` — `compaction.result` ServerEvent, new ClientEvent types
- `src/preload/index.ts` — expose `session.compact()` and `session.getContextUsage()` to renderer
- `src/tests/agent/compact-integration.test.ts` — 14 tests

## Test plan
- [ ] Verify `session.compact` IPC triggers compaction on the SDK session
- [ ] Verify `compaction.result` event includes summary, tokensBefore, file lists
- [ ] Verify `session.getContextUsage` returns `{ tokens, contextWindow, percent }`
- [ ] Run `npm run test` — all compact-integration tests pass
- [ ] Run `npm run lint` — no new errors
- [ ] Verify existing GUI behavior is unaffected (no UI changes in this PR)

Part of Roadmap #274 (Compact 增强 Phase 1)