### PR TITLE
feat(config): add plaintext config file export/import with bidirectional sync

### DIFF
--- a/src/main/config/config-file-watcher.ts
+++ b/src/main/config/config-file-watcher.ts
@@ -1,0 +1,148 @@
+/**
+ * @module main/config/config-file-watcher
+ *
+ * Bidirectional sync between the encrypted config store and a plaintext
+ * config.public.json file in the user data directory.
+ *
+ * - On external file change: debounce 500ms, then import safe fields.
+ * - On config update from GUI: export safe fields to the file.
+ * - Race condition handling: skip import if the change was triggered by our own export.
+ */
+import * as fs from 'fs';
+import { configStore } from './config-store';
+import { log, logWarn } from '../utils/logger';
+
+const DEBOUNCE_MS = 500;
+const SKIP_IMPORT_WINDOW_MS = 1000;
+
+let watcher: fs.FSWatcher | null = null;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let lastExportTimestamp = 0;
+let started = false;
+
+/**
+ * Record that we just performed an export, so the next file-change event
+ * within the skip window will be ignored (it's our own write).
+ */
+function markOwnExport(): void {
+  lastExportTimestamp = Date.now();
+}
+
+/**
+ * Check whether a file change event should be skipped because it was
+ * triggered by our own export.
+ */
+function isOwnExport(): boolean {
+  return Date.now() - lastExportTimestamp < SKIP_IMPORT_WINDOW_MS;
+}
+
+/**
+ * Handle an external change to config.public.json.
+ * Debounced to avoid rapid-fire imports during multi-write saves.
+ */
+function handleFileChange(): void {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+  }
+
+  debounceTimer = setTimeout(() => {
+    debounceTimer = null;
+
+    if (isOwnExport()) {
+      log('[ConfigFileWatcher] Skipping import — change was triggered by own export');
+      return;
+    }
+
+    try {
+      const imported = configStore.importSafeConfig();
+      if (imported) {
+        log('[ConfigFileWatcher] Imported external changes from config.public.json');
+      }
+    } catch (err) {
+      logWarn('[ConfigFileWatcher] Error importing config file:', err);
+    }
+  }, DEBOUNCE_MS);
+}
+
+/**
+ * Export the safe config to the plaintext file.
+ * Called when the GUI updates config.
+ */
+export function exportOnConfigChange(): void {
+  if (!started) return;
+  try {
+    markOwnExport();
+    configStore.exportSafeConfig();
+  } catch (err) {
+    logWarn('[ConfigFileWatcher] Error exporting config:', err);
+  }
+}
+
+/**
+ * Start the bidirectional file watcher.
+ * - If config.public.json does not exist, creates it (initial export).
+ * - If it exists, imports it (file takes precedence for safe fields).
+ * - Sets up fs.watch() for ongoing external changes.
+ */
+export function startConfigFileWatcher(): void {
+  if (started) return;
+  started = true;
+
+  const filePath = configStore.getPublicConfigPath();
+  log('[ConfigFileWatcher] Starting watcher for:', filePath);
+
+  // Initial sync: if file exists, import; otherwise, export to create it.
+  if (fs.existsSync(filePath)) {
+    try {
+      const imported = configStore.importSafeConfig();
+      if (imported) {
+        log('[ConfigFileWatcher] Imported existing config.public.json on startup');
+      }
+    } catch (err) {
+      logWarn('[ConfigFileWatcher] Error importing config on startup:', err);
+    }
+  } else {
+    try {
+      markOwnExport();
+      configStore.exportSafeConfig();
+      log('[ConfigFileWatcher] Created initial config.public.json');
+    } catch (err) {
+      logWarn('[ConfigFileWatcher] Error creating initial config file:', err);
+    }
+  }
+
+  // Start watching the file for external changes
+  try {
+    watcher = fs.watch(filePath, (eventType) => {
+      if (eventType === 'change' || eventType === 'rename') {
+        handleFileChange();
+      }
+    });
+
+    watcher.on('error', (err) => {
+      logWarn('[ConfigFileWatcher] Watcher error:', err);
+    });
+  } catch (err) {
+    logWarn('[ConfigFileWatcher] Failed to start file watcher:', err);
+  }
+}
+
+/**
+ * Stop the file watcher and clean up resources.
+ */
+export function stopConfigFileWatcher(): void {
+  if (!started) return;
+  started = false;
+
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+
+  if (watcher) {
+    watcher.close();
+    watcher = null;
+  }
+
+  log('[ConfigFileWatcher] Stopped');
+}

--- a/src/main/config/config-file-watcher.ts
+++ b/src/main/config/config-file-watcher.ts
@@ -9,7 +9,8 @@
  * - Race condition handling: skip import if the change was triggered by our own export.
  */
 import * as fs from 'fs';
-import { configStore } from './config-store';
+import * as path from 'path';
+import { configStore, ConfigStore } from './config-store';
 import { log, logWarn } from '../utils/logger';
 
 const DEBOUNCE_MS = 500;
@@ -79,10 +80,41 @@ export function exportOnConfigChange(): void {
 }
 
 /**
+ * Import config from the public file on startup, retrying on failure.
+ *
+ * The initial read happens synchronously during app startup. If another
+ * process (e.g. an editor doing an atomic save) is mid-write, the read can
+ * hit a partially-written file. Retry with a short synchronous delay to
+ * give the concurrent writer time to finish, rather than silently
+ * corrupting config from a torn read.
+ */
+function tryImportWithRetry(store: ConfigStore, retries = 2, delayMs = 200): void {
+  for (let i = 0; i <= retries; i++) {
+    try {
+      const imported = store.importSafeConfig();
+      if (imported) {
+        log('[ConfigFileWatcher] Imported existing config.public.json on startup');
+      }
+      return;
+    } catch (err) {
+      if (i === retries) {
+        logWarn('[ConfigFileWatcher] Error importing config on startup after retries:', err);
+        return;
+      }
+      // Synchronous delay for startup path — busy wait, only runs on startup.
+      const start = Date.now();
+      while (Date.now() - start < delayMs) {
+        /* busy wait */
+      }
+    }
+  }
+}
+
+/**
  * Start the bidirectional file watcher.
  * - If config.public.json does not exist, creates it (initial export).
  * - If it exists, imports it (file takes precedence for safe fields).
- * - Sets up fs.watch() for ongoing external changes.
+ * - Sets up fs.watch() on the parent directory for ongoing external changes.
  */
 export function startConfigFileWatcher(): void {
   if (started) return;
@@ -93,14 +125,7 @@ export function startConfigFileWatcher(): void {
 
   // Initial sync: if file exists, import; otherwise, export to create it.
   if (fs.existsSync(filePath)) {
-    try {
-      const imported = configStore.importSafeConfig();
-      if (imported) {
-        log('[ConfigFileWatcher] Imported existing config.public.json on startup');
-      }
-    } catch (err) {
-      logWarn('[ConfigFileWatcher] Error importing config on startup:', err);
-    }
+    tryImportWithRetry(configStore);
   } else {
     try {
       markOwnExport();
@@ -111,12 +136,17 @@ export function startConfigFileWatcher(): void {
     }
   }
 
-  // Start watching the file for external changes
+  // Start watching the parent directory rather than the file itself.
+  // fs.watch() on Linux (inotify) tracks the file by inode: if an editor
+  // replaces the file atomically (write to temp file, rename over the
+  // original), the watch on the old inode goes silently dead. Watching the
+  // directory and filtering by basename survives atomic replacement.
+  const parentDir = path.dirname(filePath);
+  const basename = path.basename(filePath);
   try {
-    watcher = fs.watch(filePath, (eventType) => {
-      if (eventType === 'change' || eventType === 'rename') {
-        handleFileChange();
-      }
+    watcher = fs.watch(parentDir, (_eventType, filename) => {
+      if (filename !== basename) return;
+      handleFileChange();
     });
 
     watcher.on('error', (err) => {

--- a/src/main/config/config-file-watcher.ts
+++ b/src/main/config/config-file-watcher.ts
@@ -82,13 +82,13 @@ export function exportOnConfigChange(): void {
 /**
  * Import config from the public file on startup, retrying on failure.
  *
- * The initial read happens synchronously during app startup. If another
- * process (e.g. an editor doing an atomic save) is mid-write, the read can
- * hit a partially-written file. Retry with a short synchronous delay to
- * give the concurrent writer time to finish, rather than silently
- * corrupting config from a torn read.
+ * The initial read happens during app startup. If another process (e.g. an
+ * editor doing an atomic save) is mid-write, the read can hit a
+ * partially-written file. Retry with a short async delay to give the
+ * concurrent writer time to finish, rather than silently corrupting config
+ * from a torn read.
  */
-function tryImportWithRetry(store: ConfigStore, retries = 2, delayMs = 200): void {
+async function tryImportWithRetry(store: ConfigStore, retries = 2, delayMs = 200): Promise<void> {
   for (let i = 0; i <= retries; i++) {
     try {
       const imported = store.importSafeConfig();
@@ -101,11 +101,7 @@ function tryImportWithRetry(store: ConfigStore, retries = 2, delayMs = 200): voi
         logWarn('[ConfigFileWatcher] Error importing config on startup after retries:', err);
         return;
       }
-      // Synchronous delay for startup path — busy wait, only runs on startup.
-      const start = Date.now();
-      while (Date.now() - start < delayMs) {
-        /* busy wait */
-      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
   }
 }
@@ -116,7 +112,7 @@ function tryImportWithRetry(store: ConfigStore, retries = 2, delayMs = 200): voi
  * - If it exists, imports it (file takes precedence for safe fields).
  * - Sets up fs.watch() on the parent directory for ongoing external changes.
  */
-export function startConfigFileWatcher(): void {
+export async function startConfigFileWatcher(): Promise<void> {
   if (started) return;
   started = true;
 
@@ -125,7 +121,7 @@ export function startConfigFileWatcher(): void {
 
   // Initial sync: if file exists, import; otherwise, export to create it.
   if (fs.existsSync(filePath)) {
-    tryImportWithRetry(configStore);
+    await tryImportWithRetry(configStore);
   } else {
     try {
       markOwnExport();

--- a/src/main/config/config-store.ts
+++ b/src/main/config/config-store.ts
@@ -1713,10 +1713,30 @@ export class ConfigStore {
       return false;
     }
 
-    // Only apply fields that are in the exportable set
+    // Only apply fields that are in the exportable set AND pass type validation
     const updates: Partial<AppConfig> = {};
+    const FIELD_VALIDATORS: Record<string, (v: unknown) => boolean> = {
+      defaultWorkdir: (v) => typeof v === 'string',
+      globalSkillsPath: (v) => typeof v === 'string',
+      theme: (v) => v === 'dark' || v === 'light' || v === 'system',
+      enableDevLogs: (v) => typeof v === 'boolean',
+      sandboxEnabled: (v) => typeof v === 'boolean',
+      enableThinking: (v) => typeof v === 'boolean',
+      memoryEnabled: (v) => typeof v === 'boolean',
+      model: (v) => typeof v === 'string',
+      provider: (v) =>
+        typeof v === 'string' &&
+        ['openrouter', 'anthropic', 'custom', 'openai', 'gemini', 'ollama'].includes(v),
+      contextWindow: (v) => typeof v === 'number' && v > 0,
+      maxTokens: (v) => typeof v === 'number' && v > 0,
+    };
     for (const key of EXPORTABLE_FIELDS) {
       if (key in parsed && parsed[key] !== undefined) {
+        const validator = FIELD_VALIDATORS[key];
+        if (validator && !validator(parsed[key])) {
+          logWarn(`[ConfigStore] Skipping invalid value for "${key}":`, parsed[key]);
+          continue;
+        }
         (updates as Record<string, unknown>)[key] = parsed[key];
       }
     }

--- a/src/main/config/config-store.ts
+++ b/src/main/config/config-store.ts
@@ -11,6 +11,8 @@
  *
  * Dependencies: electron-store, auth-utils, api-model-presets
  */
+import * as fs from 'fs';
+import * as path from 'path';
 import Store, { type Options as StoreOptions } from 'electron-store';
 import { log, logWarn } from '../utils/logger';
 import {
@@ -172,6 +174,24 @@ const DIRECT_READ_KEYS = new Set<keyof AppConfig>([
   'enableThinking',
   'isConfigured',
 ]);
+
+/**
+ * Fields safe to expose in the plaintext config file.
+ * NEVER include API keys, tokens, or other secrets.
+ */
+export const EXPORTABLE_FIELDS: (keyof AppConfig)[] = [
+  'defaultWorkdir',
+  'globalSkillsPath',
+  'theme',
+  'enableDevLogs',
+  'sandboxEnabled',
+  'enableThinking',
+  'memoryEnabled',
+  'model',
+  'provider',
+  'contextWindow',
+  'maxTokens',
+];
 
 const defaultProfiles: Record<ProviderProfileKey, ProviderProfile> = {
   openrouter: {
@@ -1645,6 +1665,75 @@ export class ConfigStore {
       GEMINI_API_KEY: process.env.GEMINI_API_KEY ? '✓ Set' : '(empty/unset)',
       GEMINI_BASE_URL: process.env.GEMINI_BASE_URL || '(default)',
     });
+  }
+
+  /**
+   * Export non-sensitive config to a plaintext JSON file.
+   * File location: {userData}/config.public.json
+   */
+  exportSafeConfig(): void {
+    const config = this.getAll();
+    const safeSubset: Partial<AppConfig> = {};
+    for (const key of EXPORTABLE_FIELDS) {
+      if (config[key] !== undefined) {
+        (safeSubset as Record<string, unknown>)[key] = config[key];
+      }
+    }
+    const filePath = this.getPublicConfigPath();
+    fs.writeFileSync(filePath, JSON.stringify(safeSubset, null, 2), 'utf-8');
+    log('[ConfigStore] Exported safe config to:', filePath);
+  }
+
+  /**
+   * Import config from the plaintext JSON file, applying only safe fields.
+   * Returns true if any fields were applied, false otherwise.
+   */
+  importSafeConfig(): boolean {
+    const filePath = this.getPublicConfigPath();
+    if (!fs.existsSync(filePath)) return false;
+
+    let raw: string;
+    try {
+      raw = fs.readFileSync(filePath, 'utf-8');
+    } catch (err) {
+      logWarn('[ConfigStore] Failed to read public config file:', err);
+      return false;
+    }
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      logWarn('[ConfigStore] Public config file contains malformed JSON, skipping import:', err);
+      return false;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      logWarn('[ConfigStore] Public config file root is not an object, skipping import');
+      return false;
+    }
+
+    // Only apply fields that are in the exportable set
+    const updates: Partial<AppConfig> = {};
+    for (const key of EXPORTABLE_FIELDS) {
+      if (key in parsed && parsed[key] !== undefined) {
+        (updates as Record<string, unknown>)[key] = parsed[key];
+      }
+    }
+
+    if (Object.keys(updates).length > 0) {
+      this.update(updates);
+      log('[ConfigStore] Imported safe config from:', filePath, 'fields:', Object.keys(updates));
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Get the path to the public plaintext config file.
+   */
+  getPublicConfigPath(): string {
+    return path.join(path.dirname(this.getPath()), 'config.public.json');
   }
 
   /**

--- a/src/main/config/config-store.ts
+++ b/src/main/config/config-store.ts
@@ -193,6 +193,26 @@ export const EXPORTABLE_FIELDS: (keyof AppConfig)[] = [
   'maxTokens',
 ];
 
+/**
+ * Per-field type/value validators applied when importing the plaintext config
+ * file (see `importSafeConfig`). Fields not listed here are accepted as-is.
+ */
+export const FIELD_VALIDATORS: Record<string, (v: unknown) => boolean> = {
+  defaultWorkdir: (v) => typeof v === 'string',
+  globalSkillsPath: (v) => typeof v === 'string',
+  theme: (v) => v === 'dark' || v === 'light' || v === 'system',
+  enableDevLogs: (v) => typeof v === 'boolean',
+  sandboxEnabled: (v) => typeof v === 'boolean',
+  enableThinking: (v) => typeof v === 'boolean',
+  memoryEnabled: (v) => typeof v === 'boolean',
+  model: (v) => typeof v === 'string',
+  provider: (v) =>
+    typeof v === 'string' &&
+    ['openrouter', 'anthropic', 'custom', 'openai', 'gemini', 'ollama'].includes(v),
+  contextWindow: (v) => typeof v === 'number' && v > 0,
+  maxTokens: (v) => typeof v === 'number' && v > 0,
+};
+
 const defaultProfiles: Record<ProviderProfileKey, ProviderProfile> = {
   openrouter: {
     apiKey: '',
@@ -1715,21 +1735,6 @@ export class ConfigStore {
 
     // Only apply fields that are in the exportable set AND pass type validation
     const updates: Partial<AppConfig> = {};
-    const FIELD_VALIDATORS: Record<string, (v: unknown) => boolean> = {
-      defaultWorkdir: (v) => typeof v === 'string',
-      globalSkillsPath: (v) => typeof v === 'string',
-      theme: (v) => v === 'dark' || v === 'light' || v === 'system',
-      enableDevLogs: (v) => typeof v === 'boolean',
-      sandboxEnabled: (v) => typeof v === 'boolean',
-      enableThinking: (v) => typeof v === 'boolean',
-      memoryEnabled: (v) => typeof v === 'boolean',
-      model: (v) => typeof v === 'string',
-      provider: (v) =>
-        typeof v === 'string' &&
-        ['openrouter', 'anthropic', 'custom', 'openai', 'gemini', 'ollama'].includes(v),
-      contextWindow: (v) => typeof v === 'number' && v > 0,
-      maxTokens: (v) => typeof v === 'number' && v > 0,
-    };
     for (const key of EXPORTABLE_FIELDS) {
       if (key in parsed && parsed[key] !== undefined) {
         const validator = FIELD_VALIDATORS[key];

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1898,7 +1898,7 @@ ipcMain.handle('config.discover-local', async (_event, payload?: { baseUrl?: str
 // Config file export/import IPC handlers
 ipcMain.handle('config.exportFile', () => {
   try {
-    configStore.exportSafeConfig();
+    exportOnConfigChange();
     return { success: true, path: configStore.getPublicConfigPath() };
   } catch (error) {
     logError('[Config] Error exporting config file:', error);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,6 +32,11 @@ import {
   type AppTheme,
   type CreateConfigSetPayload,
 } from './config/config-store';
+import {
+  startConfigFileWatcher,
+  stopConfigFileWatcher,
+  exportOnConfigChange,
+} from './config/config-file-watcher';
 import { runConfigApiTest } from './config/config-test-routing';
 import { listOllamaModels } from './config/ollama-api';
 import { setPermissionRules } from './config/permission-rules-store';
@@ -852,7 +857,8 @@ app
       // Apply dev logs setting
       setDevLogsEnabled(configStore.get('enableDevLogs'));
 
-      // Initialize core systems (same as GUI path, minus window/tray/menu/updater)
+      // Start config file watcher for bidirectional sync
+      startConfigFileWatcher();
       const db = initDatabase();
 
       pluginRuntimeService = new PluginRuntimeService(new PluginCatalogService());
@@ -943,6 +949,7 @@ app
       // Headless cleanup on exit signals
       const headlessCleanup = async () => {
         log('[Headless] Cleaning up...');
+        stopConfigFileWatcher();
         scheduledTaskManager?.stop();
         try {
           const mcpManager = sessionManager?.getMCPManager();
@@ -1103,6 +1110,9 @@ app
     // Apply dev logs setting from config
     const enableDevLogs = configStore.get('enableDevLogs');
     setDevLogsEnabled(enableDevLogs);
+
+    // Start config file watcher for bidirectional sync
+    startConfigFileWatcher();
 
     // Log environment variables for debugging
     log('=== Open Cowork Starting ===');
@@ -1338,6 +1348,7 @@ async function cleanupSandboxResources(): Promise<void> {
   isCleaningUp = true;
 
   stopNavServer();
+  stopConfigFileWatcher();
   skillsManager?.stopStorageMonitoring();
   scheduledTaskManager?.stop();
   tray?.destroy();
@@ -1759,6 +1770,10 @@ const syncConfigAfterMutation = async (previousConfig: AppConfig) => {
     },
   });
   log('[Config] Notified renderer of config update, isConfigured:', isConfigured);
+
+  // Sync plaintext config file with updated safe fields
+  exportOnConfigChange();
+
   return updatedConfig;
 };
 
@@ -1877,6 +1892,40 @@ ipcMain.handle('config.discover-local', async (_event, payload?: { baseUrl?: str
   } catch (error) {
     logError('[Config] Error discovering local services:', error);
     return [];
+  }
+});
+
+// Config file export/import IPC handlers
+ipcMain.handle('config.exportFile', () => {
+  try {
+    configStore.exportSafeConfig();
+    return { success: true, path: configStore.getPublicConfigPath() };
+  } catch (error) {
+    logError('[Config] Error exporting config file:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+});
+
+ipcMain.handle('config.importFile', async () => {
+  try {
+    const previousConfig = configStore.getAll();
+    const imported = configStore.importSafeConfig();
+    if (imported) {
+      await syncConfigAfterMutation(previousConfig);
+    }
+    return { success: true, imported };
+  } catch (error) {
+    logError('[Config] Error importing config file:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+});
+
+ipcMain.handle('config.getPublicPath', () => {
+  try {
+    return configStore.getPublicConfigPath();
+  } catch (error) {
+    logError('[Config] Error getting public config path:', error);
+    return null;
   }
 });
 

--- a/src/tests/config/config-file-sync.test.ts
+++ b/src/tests/config/config-file-sync.test.ts
@@ -2,30 +2,16 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { EXPORTABLE_FIELDS, FIELD_VALIDATORS } from '../../main/config/config-store';
 
 /**
  * Test the config file export/import logic.
  *
  * Since ConfigStore has heavy Electron dependencies (electron-store, encryption),
  * we test the underlying logic directly: field filtering, JSON parsing, error handling.
- * The EXPORTABLE_FIELDS list is duplicated here to keep tests independent of module loading.
+ * EXPORTABLE_FIELDS and FIELD_VALIDATORS are imported directly from config-store.ts
+ * (rather than duplicated here) so these tests fail loudly if the source changes.
  */
-
-// Mirror of the EXPORTABLE_FIELDS from config-store.ts — tests will fail if the
-// source list changes, prompting an update here.
-const EXPORTABLE_FIELDS = [
-  'defaultWorkdir',
-  'globalSkillsPath',
-  'theme',
-  'enableDevLogs',
-  'sandboxEnabled',
-  'enableThinking',
-  'memoryEnabled',
-  'model',
-  'provider',
-  'contextWindow',
-  'maxTokens',
-] as const;
 
 type ExportableKey = (typeof EXPORTABLE_FIELDS)[number];
 
@@ -43,7 +29,9 @@ function buildSafeSubset(config: Record<string, unknown>): Record<string, unknow
 }
 
 /**
- * Simulate importSafeConfig logic: parse JSON and extract only exportable fields.
+ * Simulate importSafeConfig logic: parse JSON, extract only exportable fields, and
+ * apply the same per-field FIELD_VALIDATORS used by the real importSafeConfig so
+ * these tests exercise the actual validation rules rather than a re-implementation.
  * Returns null on error, empty object if no valid fields found.
  */
 function parseAndFilterImport(raw: string): Record<string, unknown> | null {
@@ -62,6 +50,10 @@ function parseAndFilterImport(raw: string): Record<string, unknown> | null {
   const updates: Record<string, unknown> = {};
   for (const key of EXPORTABLE_FIELDS) {
     if (key in obj && obj[key] !== undefined) {
+      const validator = FIELD_VALIDATORS[key];
+      if (validator && !validator(obj[key])) {
+        continue; // Reject invalid values, mirroring importSafeConfig
+      }
       updates[key] = obj[key];
     }
   }
@@ -228,15 +220,126 @@ describe('Config File Sync', () => {
       expect(Object.keys(updates!)).toHaveLength(0);
     });
 
-    it('ignores fields with undefined values', () => {
-      // JSON.parse of {"theme": null} gives null, which we should skip
+    it('rejects a value that fails field validation (e.g., null theme)', () => {
+      // theme's validator requires 'dark' | 'light' | 'system'; null fails validation
+      // and must be skipped, matching importSafeConfig's real behavior.
       const updates = parseAndFilterImport('{"theme": null}');
       expect(updates).not.toBeNull();
-      // null is not undefined, so it would be included (JSON has no undefined)
-      // But the actual importSafeConfig checks `parsed[key] !== undefined`
-      // and JSON.parse never produces `undefined` values, so null would pass through
-      // This tests that the filtering logic works at the boundary
-      expect(updates!.theme).toBeNull();
+      expect('theme' in updates!).toBe(false);
+    });
+  });
+
+  describe('FIELD_VALIDATORS enforcement', () => {
+    it('rejects an out-of-whitelist theme value', () => {
+      const updates = parseAndFilterImport(JSON.stringify({ theme: 'neon' }));
+      expect(updates).not.toBeNull();
+      expect('theme' in updates!).toBe(false);
+    });
+
+    it('accepts every whitelisted theme value', () => {
+      for (const theme of ['dark', 'light', 'system']) {
+        const updates = parseAndFilterImport(JSON.stringify({ theme }));
+        expect(updates!.theme).toBe(theme);
+      }
+    });
+
+    it('rejects an out-of-whitelist provider value', () => {
+      const updates = parseAndFilterImport(JSON.stringify({ provider: 'evil-provider' }));
+      expect(updates).not.toBeNull();
+      expect('provider' in updates!).toBe(false);
+    });
+
+    it('accepts every whitelisted provider value', () => {
+      const validProviders = ['openrouter', 'anthropic', 'custom', 'openai', 'gemini', 'ollama'];
+      for (const provider of validProviders) {
+        const updates = parseAndFilterImport(JSON.stringify({ provider }));
+        expect(updates!.provider).toBe(provider);
+      }
+    });
+
+    it('rejects non-positive or non-numeric values for contextWindow and maxTokens', () => {
+      const invalidNumbers: unknown[] = [0, -1, -200000, 'not-a-number', null, true];
+      for (const value of invalidNumbers) {
+        const updates = parseAndFilterImport(
+          JSON.stringify({ contextWindow: value, maxTokens: value })
+        );
+        expect(updates).not.toBeNull();
+        expect('contextWindow' in updates!).toBe(false);
+        expect('maxTokens' in updates!).toBe(false);
+      }
+    });
+
+    it('accepts positive numeric values for contextWindow and maxTokens', () => {
+      const updates = parseAndFilterImport(
+        JSON.stringify({ contextWindow: 128000, maxTokens: 4096 })
+      );
+      expect(updates!.contextWindow).toBe(128000);
+      expect(updates!.maxTokens).toBe(4096);
+    });
+
+    it('rejects non-boolean values for boolean fields', () => {
+      const booleanFields = [
+        'enableDevLogs',
+        'sandboxEnabled',
+        'enableThinking',
+        'memoryEnabled',
+      ] as const;
+      const invalidValues: unknown[] = ['true', 1, 0, null, 'yes'];
+      for (const field of booleanFields) {
+        for (const value of invalidValues) {
+          const updates = parseAndFilterImport(JSON.stringify({ [field]: value }));
+          expect(updates).not.toBeNull();
+          expect(field in updates!).toBe(false);
+        }
+      }
+    });
+
+    it('accepts boolean values for boolean fields', () => {
+      const booleanFields = [
+        'enableDevLogs',
+        'sandboxEnabled',
+        'enableThinking',
+        'memoryEnabled',
+      ] as const;
+      for (const field of booleanFields) {
+        for (const value of [true, false]) {
+          const updates = parseAndFilterImport(JSON.stringify({ [field]: value }));
+          expect(updates![field]).toBe(value);
+        }
+      }
+    });
+
+    it('rejects non-string values for string fields', () => {
+      const stringFields = ['defaultWorkdir', 'globalSkillsPath', 'model'] as const;
+      const invalidValues: unknown[] = [123, true, null, {}, []];
+      for (const field of stringFields) {
+        for (const value of invalidValues) {
+          const updates = parseAndFilterImport(JSON.stringify({ [field]: value }));
+          expect(updates).not.toBeNull();
+          expect(field in updates!).toBe(false);
+        }
+      }
+    });
+
+    it('drops only the invalid fields while keeping valid ones in the same payload', () => {
+      const fileContent = JSON.stringify({
+        theme: 'not-a-real-theme', // invalid, should be dropped
+        provider: 'anthropic', // valid
+        contextWindow: -1, // invalid, should be dropped
+        maxTokens: 8192, // valid
+        enableDevLogs: 'yes', // invalid, should be dropped
+        sandboxEnabled: true, // valid
+      });
+
+      const updates = parseAndFilterImport(fileContent);
+
+      expect(updates).not.toBeNull();
+      expect('theme' in updates!).toBe(false);
+      expect('contextWindow' in updates!).toBe(false);
+      expect('enableDevLogs' in updates!).toBe(false);
+      expect(updates!.provider).toBe('anthropic');
+      expect(updates!.maxTokens).toBe(8192);
+      expect(updates!.sandboxEnabled).toBe(true);
     });
   });
 

--- a/src/tests/config/config-file-sync.test.ts
+++ b/src/tests/config/config-file-sync.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Test the config file export/import logic.
+ *
+ * Since ConfigStore has heavy Electron dependencies (electron-store, encryption),
+ * we test the underlying logic directly: field filtering, JSON parsing, error handling.
+ * The EXPORTABLE_FIELDS list is duplicated here to keep tests independent of module loading.
+ */
+
+// Mirror of the EXPORTABLE_FIELDS from config-store.ts — tests will fail if the
+// source list changes, prompting an update here.
+const EXPORTABLE_FIELDS = [
+  'defaultWorkdir',
+  'globalSkillsPath',
+  'theme',
+  'enableDevLogs',
+  'sandboxEnabled',
+  'enableThinking',
+  'memoryEnabled',
+  'model',
+  'provider',
+  'contextWindow',
+  'maxTokens',
+] as const;
+
+type ExportableKey = (typeof EXPORTABLE_FIELDS)[number];
+
+/**
+ * Simulate exportSafeConfig logic: extract only exportable fields from a full config.
+ */
+function buildSafeSubset(config: Record<string, unknown>): Record<string, unknown> {
+  const safeSubset: Record<string, unknown> = {};
+  for (const key of EXPORTABLE_FIELDS) {
+    if (config[key] !== undefined) {
+      safeSubset[key] = config[key];
+    }
+  }
+  return safeSubset;
+}
+
+/**
+ * Simulate importSafeConfig logic: parse JSON and extract only exportable fields.
+ * Returns null on error, empty object if no valid fields found.
+ */
+function parseAndFilterImport(raw: string): Record<string, unknown> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null; // Malformed JSON
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return null; // Wrong root type
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const updates: Record<string, unknown> = {};
+  for (const key of EXPORTABLE_FIELDS) {
+    if (key in obj && obj[key] !== undefined) {
+      updates[key] = obj[key];
+    }
+  }
+  return updates;
+}
+
+describe('Config File Sync', () => {
+  let tmpDir: string;
+  let publicConfigPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-file-sync-test-'));
+    publicConfigPath = path.join(tmpDir, 'config.public.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('EXPORTABLE_FIELDS safety', () => {
+    it('does not contain sensitive fields', () => {
+      const sensitiveFields = [
+        'apiKey',
+        'baseUrl',
+        'profiles',
+        'configSets',
+        'activeConfigSetId',
+        'activeProfileKey',
+        'customProtocol',
+        'isConfigured',
+        'memoryRuntime',
+        'agentCliPath',
+      ];
+      for (const field of sensitiveFields) {
+        expect(EXPORTABLE_FIELDS as readonly string[]).not.toContain(field);
+      }
+    });
+
+    it('contains expected safe fields', () => {
+      const expectedFields: ExportableKey[] = [
+        'theme',
+        'defaultWorkdir',
+        'globalSkillsPath',
+        'enableDevLogs',
+        'sandboxEnabled',
+        'enableThinking',
+        'memoryEnabled',
+        'model',
+        'provider',
+      ];
+      for (const field of expectedFields) {
+        expect(EXPORTABLE_FIELDS as readonly string[]).toContain(field);
+      }
+    });
+  });
+
+  describe('export writes only safe fields', () => {
+    it('exports only EXPORTABLE_FIELDS from a full config', () => {
+      const fullConfig: Record<string, unknown> = {
+        provider: 'anthropic',
+        apiKey: 'sk-ant-secret-key-12345',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-6',
+        theme: 'dark',
+        enableDevLogs: true,
+        sandboxEnabled: false,
+        enableThinking: true,
+        memoryEnabled: true,
+        defaultWorkdir: '/home/user/projects',
+        globalSkillsPath: '/home/user/skills',
+        contextWindow: 200000,
+        maxTokens: 8192,
+        profiles: { openrouter: { apiKey: 'secret' } },
+        configSets: [{ id: 'default', name: 'test' }],
+        activeConfigSetId: 'default',
+        isConfigured: true,
+      };
+
+      const safeSubset = buildSafeSubset(fullConfig);
+      fs.writeFileSync(publicConfigPath, JSON.stringify(safeSubset, null, 2), 'utf-8');
+      const written = JSON.parse(fs.readFileSync(publicConfigPath, 'utf-8'));
+
+      // Should contain safe fields
+      expect(written.theme).toBe('dark');
+      expect(written.model).toBe('claude-sonnet-4-6');
+      expect(written.provider).toBe('anthropic');
+      expect(written.enableDevLogs).toBe(true);
+      expect(written.defaultWorkdir).toBe('/home/user/projects');
+      expect(written.globalSkillsPath).toBe('/home/user/skills');
+      expect(written.contextWindow).toBe(200000);
+      expect(written.maxTokens).toBe(8192);
+      expect(written.sandboxEnabled).toBe(false);
+      expect(written.enableThinking).toBe(true);
+      expect(written.memoryEnabled).toBe(true);
+
+      // Should NOT contain sensitive fields
+      expect(written.apiKey).toBeUndefined();
+      expect(written.baseUrl).toBeUndefined();
+      expect(written.profiles).toBeUndefined();
+      expect(written.configSets).toBeUndefined();
+      expect(written.activeConfigSetId).toBeUndefined();
+      expect(written.isConfigured).toBeUndefined();
+    });
+
+    it('produces human-readable indented JSON', () => {
+      const data = { theme: 'light', enableDevLogs: false };
+      const content = JSON.stringify(data, null, 2);
+      fs.writeFileSync(publicConfigPath, content, 'utf-8');
+      const raw = fs.readFileSync(publicConfigPath, 'utf-8');
+
+      // Should be indented (multi-line) with 2-space indent
+      expect(raw).toContain('\n');
+      expect(raw).toContain('  "theme"');
+    });
+
+    it('skips undefined fields', () => {
+      const config: Record<string, unknown> = {
+        theme: 'light',
+        // contextWindow and maxTokens are undefined
+      };
+      const safeSubset = buildSafeSubset(config);
+
+      expect(safeSubset.theme).toBe('light');
+      expect('contextWindow' in safeSubset).toBe(false);
+      expect('maxTokens' in safeSubset).toBe(false);
+    });
+  });
+
+  describe('import applies only safe fields', () => {
+    it('imports only EXPORTABLE_FIELDS from file content', () => {
+      const fileContent = JSON.stringify({
+        theme: 'dark',
+        model: 'claude-opus-4',
+        enableDevLogs: true,
+        sandboxEnabled: true,
+        // These should be ignored:
+        apiKey: 'stolen-secret-key',
+        baseUrl: 'https://evil.com',
+        profiles: { openrouter: { apiKey: 'hacked' } },
+        unknownField: 'should-be-ignored',
+        configSets: [{ id: 'injected' }],
+      });
+
+      const updates = parseAndFilterImport(fileContent);
+
+      expect(updates).not.toBeNull();
+      // Should have safe fields
+      expect(updates!.theme).toBe('dark');
+      expect(updates!.model).toBe('claude-opus-4');
+      expect(updates!.enableDevLogs).toBe(true);
+      expect(updates!.sandboxEnabled).toBe(true);
+
+      // Should NOT have sensitive or unknown fields
+      expect(updates!.apiKey).toBeUndefined();
+      expect(updates!.baseUrl).toBeUndefined();
+      expect(updates!.profiles).toBeUndefined();
+      expect(updates!.unknownField).toBeUndefined();
+      expect(updates!.configSets).toBeUndefined();
+    });
+
+    it('returns empty object for empty JSON object', () => {
+      const updates = parseAndFilterImport('{}');
+      expect(updates).not.toBeNull();
+      expect(Object.keys(updates!)).toHaveLength(0);
+    });
+
+    it('ignores fields with undefined values', () => {
+      // JSON.parse of {"theme": null} gives null, which we should skip
+      const updates = parseAndFilterImport('{"theme": null}');
+      expect(updates).not.toBeNull();
+      // null is not undefined, so it would be included (JSON has no undefined)
+      // But the actual importSafeConfig checks `parsed[key] !== undefined`
+      // and JSON.parse never produces `undefined` values, so null would pass through
+      // This tests that the filtering logic works at the boundary
+      expect(updates!.theme).toBeNull();
+    });
+  });
+
+  describe('malformed JSON handling', () => {
+    it('returns null for invalid JSON syntax', () => {
+      const cases = [
+        'this is not json {{{',
+        '{theme: "dark"}', // unquoted key
+        "{'theme': 'dark'}", // single quotes
+        '', // empty string
+        '   ', // whitespace only
+      ];
+
+      for (const raw of cases) {
+        const result = parseAndFilterImport(raw);
+        expect(result).toBeNull();
+      }
+    });
+
+    it('returns null for JSON array (wrong root type)', () => {
+      const result = parseAndFilterImport('[1, 2, 3]');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for JSON null', () => {
+      const result = parseAndFilterImport('null');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for JSON primitives', () => {
+      expect(parseAndFilterImport('42')).toBeNull();
+      expect(parseAndFilterImport('"hello"')).toBeNull();
+      expect(parseAndFilterImport('true')).toBeNull();
+    });
+  });
+
+  describe('file watcher debounce logic', () => {
+    it('debounce window prevents rapid-fire imports', async () => {
+      const DEBOUNCE_MS = 500;
+      let importCount = 0;
+
+      const debouncedImport = (() => {
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        return () => {
+          if (timer) clearTimeout(timer);
+          timer = setTimeout(() => {
+            importCount++;
+            timer = null;
+          }, DEBOUNCE_MS);
+        };
+      })();
+
+      // Fire 5 rapid changes
+      debouncedImport();
+      debouncedImport();
+      debouncedImport();
+      debouncedImport();
+      debouncedImport();
+
+      // Before debounce expires, count should be 0
+      expect(importCount).toBe(0);
+
+      // Wait for debounce to complete
+      await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_MS + 100));
+      expect(importCount).toBe(1);
+    });
+
+    it('skip-own-writes pattern prevents import after export', () => {
+      const SKIP_WINDOW_MS = 1000;
+      let lastExportTimestamp = 0;
+
+      const markOwnExport = () => {
+        lastExportTimestamp = Date.now();
+      };
+
+      const isOwnExport = () => {
+        return Date.now() - lastExportTimestamp < SKIP_WINDOW_MS;
+      };
+
+      // Before export, should not be "own"
+      expect(isOwnExport()).toBe(false);
+
+      // After marking export, should be "own"
+      markOwnExport();
+      expect(isOwnExport()).toBe(true);
+    });
+
+    it('skip-own-writes window expires after timeout', async () => {
+      const SKIP_WINDOW_MS = 100; // Short window for testing
+      let lastExportTimestamp = 0;
+
+      const markOwnExport = () => {
+        lastExportTimestamp = Date.now();
+      };
+
+      const isOwnExport = () => {
+        return Date.now() - lastExportTimestamp < SKIP_WINDOW_MS;
+      };
+
+      markOwnExport();
+      expect(isOwnExport()).toBe(true);
+
+      // Wait for window to expire
+      await new Promise((resolve) => setTimeout(resolve, SKIP_WINDOW_MS + 50));
+      expect(isOwnExport()).toBe(false);
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    it('export then import produces same subset', () => {
+      const config: Record<string, unknown> = {
+        provider: 'openrouter',
+        model: 'anthropic/claude-sonnet-4-6',
+        theme: 'system',
+        enableDevLogs: false,
+        sandboxEnabled: true,
+        enableThinking: false,
+        memoryEnabled: true,
+        defaultWorkdir: '/tmp/workspace',
+        globalSkillsPath: '',
+        contextWindow: 128000,
+        maxTokens: 4096,
+      };
+
+      // Export
+      const exported = buildSafeSubset(config);
+      const json = JSON.stringify(exported, null, 2);
+
+      // Import
+      const imported = parseAndFilterImport(json);
+
+      expect(imported).toEqual(exported);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `config.public.json` plaintext file in userData directory containing all non-sensitive settings
- Bidirectional sync: GUI changes → file export, external file edits → import into encrypted store
- File watcher with 500ms debounce and skip-own-writes pattern to avoid loops
- IPC handlers: `config.exportFile`, `config.importFile`, `config.getPublicPath`
- Works in both GUI and headless mode

## Changes
- `src/main/config/config-store.ts` — `exportSafeConfig()`, `importSafeConfig()`, `getPublicConfigPath()`, `EXPORTABLE_FIELDS` constant
- `src/main/config/config-file-watcher.ts` — new file watcher with debounce + skip-own-writes
- `src/main/index.ts` — wire watcher in both GUI/headless lifecycle, add IPC handlers
- `src/tests/config/config-file-sync.test.ts` — 16 tests

## Security
- Only fields in `EXPORTABLE_FIELDS` allowlist are written to the plaintext file
- API keys, tokens, secrets are NEVER exported
- Import validates and filters — unknown/sensitive keys in the file are ignored

## Test plan
- [ ] Verify `config.public.json` is created on first launch
- [ ] Edit the file externally → config updates in the app
- [ ] Change settings in GUI → file updates on disk
- [ ] Put API key in the file → verify it's ignored on import
- [ ] Malformed JSON in file → no crash, warning logged
- [ ] `npm run test` — all 16 new tests pass

Part of Roadmap #274 (Config 文件化 Phase 2)