### PR TITLE
feat(compact): add custom compaction strategy with tool output pruning

### DIFF
--- a/src/main/agent/agent-runner.ts
+++ b/src/main/agent/agent-runner.ts
@@ -86,6 +86,7 @@ import {
 } from './tool-result-utils';
 import { fetchOllamaModelInfo } from '../config/ollama-api';
 import { createWindowsBashOperations } from './windows-bash-operations';
+import { createCompactionExtensionFactory } from './compaction-extension';
 
 // Virtual workspace path shown to the model (hides real sandbox path)
 const VIRTUAL_WORKSPACE_PATH = '/workspace';
@@ -2214,10 +2215,22 @@ Tool routing:
         // First query in this session — create new agent session
         // ResourceLoader + ModelRegistry only needed for session creation — skip on reuse
         const { DefaultResourceLoader } = await import('@mariozechner/pi-coding-agent');
+
+        // Per-session compaction instructions (from session metadata or global config)
+        const sessionCompactInstructions =
+          (session as { compactInstructions?: string }).compactInstructions || undefined;
+
         const resourceLoader = new DefaultResourceLoader({
           cwd: effectiveCwd,
           additionalSkillPaths: skillPaths,
           appendSystemPrompt: coworkAppendPrompt,
+          extensionFactories: [
+            createCompactionExtensionFactory({
+              customInstructions: sessionCompactInstructions,
+              pruneToolOutputAbove: 500,
+              keepRecentToolResults: 3,
+            }),
+          ],
         });
         await resourceLoader.reload();
 

--- a/src/main/agent/agent-runner.ts
+++ b/src/main/agent/agent-runner.ts
@@ -2216,12 +2216,17 @@ Tool routing:
         // ResourceLoader + ModelRegistry only needed for session creation — skip on reuse
         const { DefaultResourceLoader } = await import('@mariozechner/pi-coding-agent');
 
-        // Per-session compaction instructions (from session metadata if present)
-        const sessionCompactInstructions: string | undefined =
+        // Per-session compaction instructions (from session metadata if present).
+        // Capped at 2000 chars to limit prompt injection surface — this field
+        // is only set programmatically (not from external user input).
+        let sessionCompactInstructions: string | undefined =
           'compactInstructions' in session &&
           typeof (session as Record<string, unknown>).compactInstructions === 'string'
             ? ((session as Record<string, unknown>).compactInstructions as string)
             : undefined;
+        if (sessionCompactInstructions && sessionCompactInstructions.length > 2000) {
+          sessionCompactInstructions = sessionCompactInstructions.slice(0, 2000);
+        }
 
         const resourceLoader = new DefaultResourceLoader({
           cwd: effectiveCwd,

--- a/src/main/agent/agent-runner.ts
+++ b/src/main/agent/agent-runner.ts
@@ -2216,9 +2216,12 @@ Tool routing:
         // ResourceLoader + ModelRegistry only needed for session creation — skip on reuse
         const { DefaultResourceLoader } = await import('@mariozechner/pi-coding-agent');
 
-        // Per-session compaction instructions (from session metadata or global config)
-        const sessionCompactInstructions =
-          (session as { compactInstructions?: string }).compactInstructions || undefined;
+        // Per-session compaction instructions (from session metadata if present)
+        const sessionCompactInstructions: string | undefined =
+          'compactInstructions' in session &&
+          typeof (session as Record<string, unknown>).compactInstructions === 'string'
+            ? ((session as Record<string, unknown>).compactInstructions as string)
+            : undefined;
 
         const resourceLoader = new DefaultResourceLoader({
           cwd: effectiveCwd,

--- a/src/main/agent/compaction-extension.ts
+++ b/src/main/agent/compaction-extension.ts
@@ -1,0 +1,214 @@
+/**
+ * Custom compaction strategy extension.
+ *
+ * Hooks into the SDK's `session_before_compact` event to:
+ * 1. Pre-prune verbose tool outputs (file contents, long command output)
+ *    so the summarizer model processes less noise.
+ * 2. Inject custom summarization instructions that emphasize preserving
+ *    decisions and goals over raw tool output.
+ *
+ * This does NOT replace the SDK's summarization entirely — it mutates the
+ * preparation data and sets custom instructions, then lets the SDK's
+ * default compaction path run on the cleaned input.
+ */
+import type {
+  ExtensionFactory,
+  ExtensionAPI,
+  SessionBeforeCompactEvent,
+} from '@mariozechner/pi-coding-agent';
+
+/**
+ * Configuration for the custom compaction extension.
+ */
+export interface CompactionConfig {
+  /**
+   * Custom instructions appended to the SDK's summarization prompt.
+   * If not provided, DEFAULT_COMPACTION_INSTRUCTIONS is used.
+   */
+  customInstructions?: string;
+
+  /**
+   * Tool output character threshold. Outputs longer than this are
+   * replaced with a short placeholder noting the tool and outcome.
+   * Default: 500
+   */
+  pruneToolOutputAbove?: number;
+
+  /**
+   * Number of most-recent tool results to keep un-pruned, regardless
+   * of length. Helps preserve context for the model's immediate next steps.
+   * Default: 3
+   */
+  keepRecentToolResults?: number;
+}
+
+/**
+ * Default summarization instructions that guide the SDK's summarizer
+ * to focus on decisions rather than raw tool data.
+ */
+export const DEFAULT_COMPACTION_INSTRUCTIONS = `Focus on preserving:
+- Key decisions made during the conversation
+- Important file paths and what was done to them
+- Current goals and next steps
+- Error context that hasn't been resolved
+- User preferences and constraints mentioned
+
+Aggressively summarize:
+- File contents that were read (just note the filename and purpose)
+- Long command outputs (just note what command ran and the outcome)
+- Exploratory steps that didn't lead anywhere
+- Redundant back-and-forth about resolved issues`;
+
+/**
+ * Prune verbose tool outputs in a messages array (mutates in place).
+ *
+ * Walks through messages looking for tool result content blocks.
+ * Any tool result text exceeding `threshold` characters (except the
+ * last `keepRecent` results) is replaced with a short summary placeholder.
+ *
+ * The pruning is intentionally conservative: it only shortens text content
+ * in tool results, never removes messages entirely. The SDK's summarizer
+ * still sees all messages — just with less noise.
+ */
+export function pruneToolOutputs(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  messages: any[],
+  threshold: number,
+  keepRecent: number
+): { prunedCount: number; totalToolResults: number } {
+  // First pass: collect indices of all tool result content blocks
+  interface ToolResultLocation {
+    messageIndex: number;
+    contentIndex: number;
+    textLength: number;
+  }
+
+  const toolResultLocations: ToolResultLocation[] = [];
+
+  for (let mi = 0; mi < messages.length; mi++) {
+    const msg = messages[mi];
+    if (!msg || typeof msg !== 'object') continue;
+
+    // AgentMessage format: { role, content: ContentBlock[] }
+    const content = msg.content;
+    if (!Array.isArray(content)) continue;
+
+    for (let ci = 0; ci < content.length; ci++) {
+      const block = content[ci];
+      if (!block || typeof block !== 'object') continue;
+
+      // Tool results have type 'toolResult' in pi-agent-core
+      const blockType = block.type;
+      if (blockType === 'toolResult' || blockType === 'tool_result') {
+        // Content can be an array of text/image blocks or a string
+        const resultContent = block.content;
+        let textLength = 0;
+
+        if (typeof resultContent === 'string') {
+          textLength = resultContent.length;
+        } else if (Array.isArray(resultContent)) {
+          for (const item of resultContent) {
+            if (item && typeof item === 'object' && item.type === 'text' && item.text) {
+              textLength += String(item.text).length;
+            }
+          }
+        }
+
+        toolResultLocations.push({ messageIndex: mi, contentIndex: ci, textLength });
+      }
+    }
+  }
+
+  const totalToolResults = toolResultLocations.length;
+  let prunedCount = 0;
+
+  // Skip the last `keepRecent` tool results (preserve recent context)
+  const pruneUpTo = Math.max(0, toolResultLocations.length - keepRecent);
+
+  for (let i = 0; i < pruneUpTo; i++) {
+    const loc = toolResultLocations[i];
+    if (loc.textLength <= threshold) continue;
+
+    const block = messages[loc.messageIndex].content[loc.contentIndex];
+    // Extract a hint about what tool produced this
+    const toolUseId = block.toolUseId || block.tool_use_id || '';
+    const truncatedNote = `[Output truncated: ${loc.textLength} chars → see tool_use_id=${toolUseId || 'unknown'}]`;
+
+    // Replace the content with the truncated note
+    if (typeof block.content === 'string') {
+      block.content = truncatedNote;
+    } else if (Array.isArray(block.content)) {
+      block.content = [{ type: 'text', text: truncatedNote }];
+    }
+
+    prunedCount++;
+  }
+
+  return { prunedCount, totalToolResults };
+}
+
+/**
+ * Build the effective custom instructions string from config.
+ * Merges per-session instructions with the default template.
+ */
+export function buildCustomInstructions(config: CompactionConfig): string {
+  const base = DEFAULT_COMPACTION_INSTRUCTIONS;
+  const perSession = config.customInstructions?.trim();
+
+  if (!perSession) return base;
+
+  // If the user provided custom instructions, append them after the defaults
+  return `${base}\n\nAdditional context-specific instructions:\n${perSession}`;
+}
+
+/**
+ * Create the compaction extension factory.
+ *
+ * Returns an ExtensionFactory that registers a `session_before_compact`
+ * handler. The handler pre-prunes verbose tool outputs and injects
+ * custom summarization instructions before letting the SDK's default
+ * compaction path run.
+ */
+export function createCompactionExtensionFactory(config: CompactionConfig = {}): ExtensionFactory {
+  const threshold = config.pruneToolOutputAbove ?? 500;
+  const keepRecent = config.keepRecentToolResults ?? 3;
+
+  return (api: ExtensionAPI): void => {
+    api.on('session_before_compact', async (event: SessionBeforeCompactEvent) => {
+      const { preparation } = event;
+
+      // Phase 1: Pre-prune verbose tool outputs in messagesToSummarize.
+      // This reduces token count the summarizer model needs to process,
+      // leading to faster and cheaper compaction without losing key context.
+      const { prunedCount, totalToolResults } = pruneToolOutputs(
+        preparation.messagesToSummarize,
+        threshold,
+        keepRecent
+      );
+
+      if (prunedCount > 0) {
+        // Log is informational only — no access to app logger from extension context
+        // The SDK will reflect this in its own compaction metrics
+        void prunedCount;
+        void totalToolResults;
+      }
+
+      // Phase 2: Inject custom instructions for the summarizer.
+      // The SDK reads event.customInstructions after extension handlers return.
+      // If no instructions were already set (e.g., from a manual compact() call),
+      // inject our defaults. If instructions already exist (user-triggered compact
+      // with explicit instructions), merge them with ours.
+      const builtInstructions = buildCustomInstructions(config);
+      if (!event.customInstructions) {
+        event.customInstructions = builtInstructions;
+      } else {
+        // Merge: user's explicit instructions take priority (listed first)
+        event.customInstructions = `${event.customInstructions}\n\n${builtInstructions}`;
+      }
+
+      // Return empty object — let the SDK run its default summarization
+      // on the now-pruned messages with our custom instructions injected.
+      return {};
+    });
+  };
+}

--- a/src/main/agent/compaction-extension.ts
+++ b/src/main/agent/compaction-extension.ts
@@ -186,13 +186,6 @@ export function createCompactionExtensionFactory(config: CompactionConfig = {}):
         keepRecent
       );
 
-      if (prunedCount > 0) {
-        // Log is informational only — no access to app logger from extension context
-        // The SDK will reflect this in its own compaction metrics
-        void prunedCount;
-        void totalToolResults;
-      }
-
       // Phase 2: Inject custom instructions for the summarizer.
       // The SDK reads event.customInstructions after extension handlers return.
       // If no instructions were already set (e.g., from a manual compact() call),

--- a/src/main/agent/compaction-extension.ts
+++ b/src/main/agent/compaction-extension.ts
@@ -134,11 +134,14 @@ export function pruneToolOutputs(
     const toolUseId = block.toolUseId || block.tool_use_id || '';
     const truncatedNote = `[Output truncated: ${loc.textLength} chars → see tool_use_id=${toolUseId || 'unknown'}]`;
 
-    // Replace the content with the truncated note
+    // Replace the content with the truncated note. Only text-type blocks are
+    // replaced — non-text blocks (e.g., images) are preserved as-is.
     if (typeof block.content === 'string') {
       block.content = truncatedNote;
     } else if (Array.isArray(block.content)) {
-      block.content = [{ type: 'text', text: truncatedNote }];
+      block.content = block.content.map((item: { type: string; text?: string }) =>
+        item.type === 'text' ? { type: 'text', text: truncatedNote } : item
+      );
     }
 
     prunedCount++;

--- a/src/main/agent/compaction-extension.ts
+++ b/src/main/agent/compaction-extension.ts
@@ -180,11 +180,7 @@ export function createCompactionExtensionFactory(config: CompactionConfig = {}):
       // Phase 1: Pre-prune verbose tool outputs in messagesToSummarize.
       // This reduces token count the summarizer model needs to process,
       // leading to faster and cheaper compaction without losing key context.
-      const { prunedCount, totalToolResults } = pruneToolOutputs(
-        preparation.messagesToSummarize,
-        threshold,
-        keepRecent
-      );
+      pruneToolOutputs(preparation.messagesToSummarize, threshold, keepRecent);
 
       // Phase 2: Inject custom instructions for the summarizer.
       // The SDK reads event.customInstructions after extension handlers return.

--- a/src/tests/agent/compaction-extension.test.ts
+++ b/src/tests/agent/compaction-extension.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createCompactionExtensionFactory,
+  pruneToolOutputs,
+  buildCustomInstructions,
+  DEFAULT_COMPACTION_INSTRUCTIONS,
+  type CompactionConfig,
+} from '../../main/agent/compaction-extension';
+
+describe('compaction-extension', () => {
+  describe('createCompactionExtensionFactory', () => {
+    it('returns a valid extension factory function', () => {
+      const factory = createCompactionExtensionFactory();
+      expect(typeof factory).toBe('function');
+    });
+
+    it('factory accepts an ExtensionAPI-like object and registers handler', () => {
+      const factory = createCompactionExtensionFactory({ pruneToolOutputAbove: 200 });
+      const handlers: Record<string, unknown[]> = {};
+      const mockApi = {
+        on(event: string, handler: unknown) {
+          if (!handlers[event]) handlers[event] = [];
+          handlers[event].push(handler);
+        },
+      };
+
+      factory(mockApi as never);
+
+      expect(handlers['session_before_compact']).toBeDefined();
+      expect(handlers['session_before_compact'].length).toBe(1);
+      expect(typeof handlers['session_before_compact'][0]).toBe('function');
+    });
+
+    it('handler prunes messages and injects custom instructions', async () => {
+      const factory = createCompactionExtensionFactory({
+        pruneToolOutputAbove: 50,
+        keepRecentToolResults: 1,
+        customInstructions: 'Focus on the database schema changes.',
+      });
+
+      let capturedHandler: ((event: unknown) => Promise<unknown>) | undefined;
+      const mockApi = {
+        on(event: string, handler: unknown) {
+          if (event === 'session_before_compact') {
+            capturedHandler = handler as (event: unknown) => Promise<unknown>;
+          }
+        },
+      };
+
+      factory(mockApi as never);
+      expect(capturedHandler).toBeDefined();
+
+      // Create a mock event with messages containing long tool output
+      const mockEvent = {
+        type: 'session_before_compact',
+        preparation: {
+          firstKeptEntryId: 'entry-1',
+          messagesToSummarize: [
+            {
+              role: 'assistant',
+              content: [{ type: 'toolResult', toolUseId: 'tool-1', content: 'x'.repeat(200) }],
+            },
+            {
+              role: 'assistant',
+              content: [{ type: 'toolResult', toolUseId: 'tool-2', content: 'y'.repeat(100) }],
+            },
+          ],
+          tokensBefore: 50000,
+          isSplitTurn: false,
+          turnPrefixMessages: [],
+          fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+          settings: { enabled: true, reserveTokens: 8000, keepRecentTokens: 16000 },
+        },
+        branchEntries: [],
+        customInstructions: undefined,
+        signal: new AbortController().signal,
+      };
+
+      const result = await capturedHandler!(mockEvent);
+
+      // The first tool result should be pruned (over threshold and not recent)
+      expect(mockEvent.preparation.messagesToSummarize[0].content[0].content).toContain(
+        '[Output truncated:'
+      );
+      // The last tool result should be kept (it's the most recent one, keepRecent=1)
+      expect(mockEvent.preparation.messagesToSummarize[1].content[0].content).toBe('y'.repeat(100));
+
+      // Custom instructions should be injected
+      expect(mockEvent.customInstructions).toContain('Focus on preserving:');
+      expect(mockEvent.customInstructions).toContain('Focus on the database schema changes.');
+
+      // Should return empty object to let SDK handle summarization
+      expect(result).toEqual({});
+    });
+
+    it('handler preserves existing customInstructions from manual compact', async () => {
+      const factory = createCompactionExtensionFactory({});
+
+      let capturedHandler: ((event: unknown) => Promise<unknown>) | undefined;
+      const mockApi = {
+        on(event: string, handler: unknown) {
+          if (event === 'session_before_compact') {
+            capturedHandler = handler as (event: unknown) => Promise<unknown>;
+          }
+        },
+      };
+
+      factory(mockApi as never);
+
+      const mockEvent = {
+        type: 'session_before_compact',
+        preparation: {
+          firstKeptEntryId: 'entry-1',
+          messagesToSummarize: [],
+          tokensBefore: 50000,
+          isSplitTurn: false,
+          turnPrefixMessages: [],
+          fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+          settings: { enabled: true, reserveTokens: 8000, keepRecentTokens: 16000 },
+        },
+        branchEntries: [],
+        customInstructions: 'User explicitly said: focus on the API refactor.',
+        signal: new AbortController().signal,
+      };
+
+      await capturedHandler!(mockEvent);
+
+      // User's instructions should come first (they take priority)
+      expect(mockEvent.customInstructions).toMatch(
+        /^User explicitly said: focus on the API refactor\./
+      );
+      // Our defaults should be appended
+      expect(mockEvent.customInstructions).toContain('Focus on preserving:');
+    });
+  });
+
+  describe('pruneToolOutputs', () => {
+    it('returns zero counts for empty messages', () => {
+      const messages: unknown[] = [];
+      const result = pruneToolOutputs(messages, 500, 3);
+      expect(result).toEqual({ prunedCount: 0, totalToolResults: 0 });
+    });
+
+    it('does not prune tool outputs below threshold', () => {
+      const messages = [
+        {
+          role: 'assistant',
+          content: [{ type: 'toolResult', toolUseId: 't-1', content: 'short output' }],
+        },
+      ];
+
+      const result = pruneToolOutputs(messages, 500, 3);
+      expect(result.prunedCount).toBe(0);
+      expect(result.totalToolResults).toBe(1);
+      expect(messages[0].content[0].content).toBe('short output');
+    });
+
+    it('prunes tool outputs above threshold', () => {
+      const longOutput = 'x'.repeat(1000);
+      const messages = [
+        {
+          role: 'assistant',
+          content: [{ type: 'toolResult', toolUseId: 'tool-abc', content: longOutput }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'toolResult', toolUseId: 'tool-def', content: 'kept' }],
+        },
+      ];
+
+      const result = pruneToolOutputs(messages, 500, 1);
+      expect(result.prunedCount).toBe(1);
+      expect(result.totalToolResults).toBe(2);
+      // First result is pruned
+      expect(messages[0].content[0].content).toContain('[Output truncated:');
+      expect(messages[0].content[0].content).toContain('1000 chars');
+      expect(messages[0].content[0].content).toContain('tool-abc');
+      // Second result is kept (it's the most recent one)
+      expect(messages[1].content[0].content).toBe('kept');
+    });
+
+    it('keeps the last N tool results regardless of length', () => {
+      const longOutput = 'x'.repeat(1000);
+      const messages = [
+        {
+          role: 'assistant',
+          content: [{ type: 'toolResult', toolUseId: 't-1', content: longOutput }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'toolResult', toolUseId: 't-2', content: longOutput }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'toolResult', toolUseId: 't-3', content: longOutput }],
+        },
+      ];
+
+      // keepRecent=2 means last 2 are preserved
+      const result = pruneToolOutputs(messages, 500, 2);
+      expect(result.prunedCount).toBe(1);
+      // Only first is pruned
+      expect(messages[0].content[0].content).toContain('[Output truncated:');
+      // Last two are kept
+      expect(messages[1].content[0].content).toBe(longOutput);
+      expect(messages[2].content[0].content).toBe(longOutput);
+    });
+
+    it('handles array-style tool result content', () => {
+      const longText = 'x'.repeat(1000);
+      const messages = [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'toolResult',
+              toolUseId: 't-1',
+              content: [{ type: 'text', text: longText }],
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'toolResult', toolUseId: 't-2', content: 'short' }],
+        },
+      ];
+
+      const result = pruneToolOutputs(messages, 500, 1);
+      expect(result.prunedCount).toBe(1);
+      // Array content is replaced with single-element array
+      expect(messages[0].content[0].content).toEqual([
+        { type: 'text', text: expect.stringContaining('[Output truncated:') },
+      ]);
+    });
+
+    it('handles tool_result type (underscore variant)', () => {
+      const longOutput = 'x'.repeat(600);
+      const messages = [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_result', tool_use_id: 'tu-1', content: longOutput }],
+        },
+      ];
+
+      const result = pruneToolOutputs(messages, 500, 0);
+      expect(result.prunedCount).toBe(1);
+      expect(messages[0].content[0].content).toContain('[Output truncated:');
+    });
+
+    it('handles messages without content array gracefully', () => {
+      const messages = [{ role: 'user', content: 'just text' }, null, { role: 'assistant' }];
+
+      const result = pruneToolOutputs(messages, 500, 3);
+      expect(result.prunedCount).toBe(0);
+      expect(result.totalToolResults).toBe(0);
+    });
+
+    it('handles multiple tool results in a single message', () => {
+      const longOutput = 'x'.repeat(1000);
+      const messages = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'toolResult', toolUseId: 't-1', content: longOutput },
+            { type: 'toolResult', toolUseId: 't-2', content: longOutput },
+            { type: 'toolResult', toolUseId: 't-3', content: longOutput },
+          ],
+        },
+      ];
+
+      const result = pruneToolOutputs(messages, 500, 1);
+      // 3 total tool results, keep last 1, so prune first 2
+      expect(result.prunedCount).toBe(2);
+      expect(result.totalToolResults).toBe(3);
+      expect(messages[0].content[0].content).toContain('[Output truncated:');
+      expect(messages[0].content[1].content).toContain('[Output truncated:');
+      expect(messages[0].content[2].content).toBe(longOutput); // kept (most recent)
+    });
+  });
+
+  describe('buildCustomInstructions', () => {
+    it('returns default instructions when no custom instructions provided', () => {
+      const config: CompactionConfig = {};
+      const result = buildCustomInstructions(config);
+      expect(result).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+    });
+
+    it('returns default instructions when custom instructions is empty', () => {
+      const config: CompactionConfig = { customInstructions: '  ' };
+      const result = buildCustomInstructions(config);
+      expect(result).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+    });
+
+    it('appends custom instructions after defaults', () => {
+      const config: CompactionConfig = {
+        customInstructions: 'Preserve all database migration details.',
+      };
+      const result = buildCustomInstructions(config);
+      expect(result).toContain(DEFAULT_COMPACTION_INSTRUCTIONS);
+      expect(result).toContain('Additional context-specific instructions:');
+      expect(result).toContain('Preserve all database migration details.');
+    });
+  });
+
+  describe('DEFAULT_COMPACTION_INSTRUCTIONS', () => {
+    it('contains key preservation guidelines', () => {
+      expect(DEFAULT_COMPACTION_INSTRUCTIONS).toContain('Key decisions');
+      expect(DEFAULT_COMPACTION_INSTRUCTIONS).toContain('Important file paths');
+      expect(DEFAULT_COMPACTION_INSTRUCTIONS).toContain('Current goals');
+      expect(DEFAULT_COMPACTION_INSTRUCTIONS).toContain('Error context');
+    });
+
+    it('contains aggressive summarization guidelines', () => {
+      expect(DEFAULT_COMPACTION_INSTRUCTIONS).toContain('File contents that were read');
+      expect(DEFAULT_COMPACTION_INSTRUCTIONS).toContain('Long command outputs');
+      expect(DEFAULT_COMPACTION_INSTRUCTIONS).toContain('Exploratory steps');
+    });
+  });
+});

--- a/src/tests/agent/compaction-extension.test.ts
+++ b/src/tests/agent/compaction-extension.test.ts
@@ -233,6 +233,33 @@ describe('compaction-extension', () => {
       ]);
     });
 
+    it('preserves non-text content blocks during pruning', () => {
+      const messages = [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'toolResult',
+              toolUseId: 'tool-1',
+              content: [
+                { type: 'text', text: 'a'.repeat(600) },
+                { type: 'image', source: { data: 'base64data' } },
+              ],
+            },
+          ],
+        },
+      ];
+
+      pruneToolOutputs(messages, 500, 0);
+
+      const resultContent = messages[0].content[0].content;
+      expect(resultContent).toHaveLength(2);
+      expect(resultContent[0].type).toBe('text');
+      expect(resultContent[0].text).toContain('[Output truncated');
+      expect(resultContent[1].type).toBe('image');
+      expect(resultContent[1].source).toEqual({ data: 'base64data' });
+    });
+
     it('handles tool_result type (underscore variant)', () => {
       const longOutput = 'x'.repeat(600);
       const messages = [


### PR DESCRIPTION
## Summary
- Hook into SDK's `session_before_compact` via `extensionFactories` to customize compaction behavior
- Pre-prune verbose tool outputs (>500 chars) before the SDK's summarizer processes them, preserving the 3 most recent tool results
- Inject custom instructions that guide the summarizer to focus on decisions/goals over raw output
- Support per-session `compactInstructions` for targeted summarization

## How it works
```
Auto-compaction triggers
    │
    ▼
session_before_compact hook fires
    │
    ├─ 1. Prune: walk messagesToSummarize, replace tool outputs
    │      >500 chars with "[Output truncated: N chars]"
    │      (keep 3 most recent results untouched)
    │
    ├─ 2. Inject custom instructions into event.customInstructions
    │      "Focus on decisions, goals, file paths; aggressively
    │       summarize raw file contents and command output"
    │
    └─ 3. Return {} → SDK runs its default summarizer on cleaned input
```

## Changes
- `src/main/agent/compaction-extension.ts` — new module: `createCompactionExtensionFactory`, `pruneToolOutputs`, `buildCustomInstructions`, `DEFAULT_COMPACTION_INSTRUCTIONS`
- `src/main/agent/agent-runner.ts` — wire extension into `DefaultResourceLoader`
- `src/tests/agent/compaction-extension.test.ts` — 17 tests

## Test plan
- [ ] Verify extension factory creates valid ExtensionFactory
- [ ] Verify tool outputs >500 chars are replaced with placeholders
- [ ] Verify 3 most recent tool results are preserved
- [ ] Verify custom instructions merge correctly (per-session + defaults)
- [ ] Run `npm run test` — all 17 new tests pass
- [ ] Run `npm run lint` — no new errors
- [ ] Verify auto-compaction still works end-to-end (no regressions)

Part of Roadmap #274 (Compact 增强 Phase 2)