### PR TITLE
feat(agent): add spawn_subagent tool for in-process child sessions

### DIFF
--- a/src/main/agent/subagent-extension.ts
+++ b/src/main/agent/subagent-extension.ts
@@ -1,0 +1,251 @@
+import { Type } from '@sinclair/typebox';
+import {
+  createAgentSession,
+  SessionManager as PiSessionManager,
+  SettingsManager as PiSettingsManager,
+  createCodingTools,
+  DefaultResourceLoader,
+  type ToolDefinition,
+} from '@mariozechner/pi-coding-agent';
+import type {
+  AgentRuntimeExtension,
+  BeforeSessionRunResult,
+  AgentRuntimeCustomTool,
+} from '../extensions/agent-runtime-extension';
+import { getSharedAuthStorage, ModelRegistry } from './shared-auth';
+import { MCPManager } from '../mcp/mcp-manager';
+import { configStore } from '../config/config-store';
+import { log, logError } from '../utils/logger';
+import { resolvePiRegistryModel, resolvePiRouteProtocol } from './pi-model-resolution';
+
+const MAX_TIMEOUT_MS = 300_000; // 5 minutes
+const DEFAULT_TIMEOUT_MS = 120_000; // 2 minutes
+
+interface SubagentParams {
+  task: string;
+  result_format?: string;
+  allowed_tools?: string[];
+  timeout_seconds?: number;
+}
+
+function buildChildSystemPrompt(task: string, resultFormat?: string): string {
+  const parts = [
+    'You are a focused sub-agent. Complete the task below and return ONLY the result.',
+    'Do not ask questions. Do not provide commentary beyond what is needed for the result.',
+    '',
+    `## Task`,
+    task,
+  ];
+  if (resultFormat) {
+    parts.push('', `## Expected Output Format`, resultFormat);
+  }
+  return parts.join('\n');
+}
+
+function createSpawnSubagentTool(mcpManager: MCPManager | null): AgentRuntimeCustomTool {
+  return {
+    name: 'spawn_subagent',
+    label: 'spawn_subagent',
+    description:
+      'Spawn a child agent to complete a focused sub-task in its own context. ' +
+      'The child inherits your tools and config but not your conversation history. ' +
+      'It cannot spawn further subagents. Use for tasks that benefit from isolated context.',
+    parameters: Type.Object({
+      task: Type.String({
+        description:
+          'A clear, self-contained description of what the child agent should accomplish. ' +
+          'Include all necessary context since the child has no access to your conversation.',
+      }),
+      result_format: Type.Optional(
+        Type.String({
+          description:
+            'Description of the desired output format. If omitted, the child returns free-form text.',
+        })
+      ),
+      allowed_tools: Type.Optional(
+        Type.Array(Type.String(), {
+          description:
+            'Restrict tools available to the child. If omitted, the child inherits all parent tools except spawn_subagent.',
+        })
+      ),
+      timeout_seconds: Type.Optional(
+        Type.Number({
+          description: 'Maximum execution time in seconds. Default: 120, max: 300.',
+          minimum: 10,
+          maximum: 300,
+        })
+      ),
+    }),
+    async execute(_toolCallId: string, params: unknown) {
+      const { task, result_format, allowed_tools, timeout_seconds } = (params ||
+        {}) as SubagentParams;
+
+      if (!task || typeof task !== 'string' || task.trim().length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: task parameter is required.' }],
+          details: undefined as unknown,
+        };
+      }
+
+      const timeoutMs = Math.min(
+        (timeout_seconds || DEFAULT_TIMEOUT_MS / 1000) * 1000,
+        MAX_TIMEOUT_MS
+      );
+
+      log(`[SubagentExtension] Spawning child for task: "${task.slice(0, 100)}..."`);
+      const startTime = Date.now();
+
+      try {
+        const config = configStore.getAll();
+        const authStorage = getSharedAuthStorage();
+        const modelRegistry = new ModelRegistry(authStorage);
+
+        const modelString = config.model?.trim() || 'anthropic/claude-sonnet-4-6';
+        const configProtocol = resolvePiRouteProtocol(config.provider, config.customProtocol);
+        const piModel = resolvePiRegistryModel(modelString, {
+          configProvider: configProtocol,
+          customBaseUrl: config.baseUrl?.trim() || undefined,
+          rawProvider: config.provider,
+          customProtocol: config.customProtocol,
+        });
+        if (!piModel) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: could not resolve model for subagent. Check provider/model config.',
+              },
+            ],
+            details: undefined as unknown,
+          };
+        }
+
+        // Build MCP tools (minus spawn_subagent)
+        let mcpCustomTools: ToolDefinition[] = [];
+        if (mcpManager) {
+          const mcpTools = mcpManager.getTools();
+          mcpCustomTools = mcpTools.map((mcpTool) => {
+            const parameters = Type.Unsafe<Record<string, unknown>>(
+              mcpTool.inputSchema as Record<string, unknown>
+            );
+            return {
+              name: mcpTool.name,
+              label: `${mcpTool.serverName} → ${mcpTool.originalName || mcpTool.name}`,
+              description: mcpTool.description || `MCP tool from ${mcpTool.serverName}`,
+              parameters,
+              async execute(_id: string, p: unknown) {
+                const result = await mcpManager.callTool(
+                  mcpTool.name,
+                  p as Record<string, unknown>
+                );
+                const resultContent = (
+                  result as { content?: Array<{ type: string; text?: string }> }
+                )?.content;
+                const text =
+                  resultContent?.map((c) => (c.type === 'text' ? c.text : '')).join('') || '';
+                return { content: [{ type: 'text' as const, text }], details: undefined };
+              },
+            } as ToolDefinition;
+          });
+        }
+
+        // Filter allowed_tools if specified
+        if (allowed_tools && allowed_tools.length > 0) {
+          const allowSet = new Set(allowed_tools);
+          mcpCustomTools = mcpCustomTools.filter((t) => allowSet.has(t.name));
+        }
+
+        const cwd = config.defaultWorkdir || process.cwd();
+        const codingTools = createCodingTools(cwd);
+
+        const childSystemPrompt = buildChildSystemPrompt(task, result_format);
+        const resourceLoader = new DefaultResourceLoader({
+          cwd,
+          appendSystemPrompt: childSystemPrompt,
+        });
+        await resourceLoader.reload();
+
+        const { session: childSession } = await createAgentSession({
+          model: piModel,
+          authStorage,
+          modelRegistry,
+          tools: codingTools,
+          customTools: mcpCustomTools,
+          sessionManager: PiSessionManager.inMemory(),
+          settingsManager: PiSettingsManager.inMemory({
+            compaction: { enabled: false },
+            retry: { enabled: true, maxRetries: 1 },
+          }),
+          resourceLoader,
+          cwd,
+        });
+
+        let finalText = '';
+        const unsubscribe = childSession.subscribe((event) => {
+          if (event.type === 'agent_end') {
+            const messages = (event as { messages?: unknown[] }).messages || [];
+            for (let i = messages.length - 1; i >= 0; i--) {
+              const msg = messages[i] as { role?: string; content?: unknown } | undefined;
+              if (msg && msg.role === 'assistant' && Array.isArray(msg.content)) {
+                finalText = (msg.content as Array<{ type: string; text?: string }>)
+                  .filter((b) => b.type === 'text' && b.text)
+                  .map((b) => b.text)
+                  .join('');
+                break;
+              }
+            }
+          }
+        });
+
+        try {
+          const timeoutPromise = new Promise<never>((_, reject) => {
+            setTimeout(() => reject(new Error('Subagent timed out')), timeoutMs);
+          });
+          await Promise.race([childSession.prompt(task), timeoutPromise]);
+        } finally {
+          unsubscribe();
+          childSession.dispose();
+        }
+
+        const durationMs = Date.now() - startTime;
+        log(`[SubagentExtension] Child completed in ${durationMs}ms`);
+
+        return {
+          content: [
+            { type: 'text' as const, text: finalText || '(subagent produced no text output)' },
+          ],
+          details: undefined as unknown,
+        };
+      } catch (err: unknown) {
+        const durationMs = Date.now() - startTime;
+        const message = err instanceof Error ? err.message : String(err);
+        logError(`[SubagentExtension] Child failed after ${durationMs}ms:`, message);
+
+        const isTimeout = message.includes('timed out') || message.includes('abort');
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: isTimeout
+                ? `Subagent timed out after ${Math.round(durationMs / 1000)}s. Consider simplifying the task or increasing timeout_seconds.`
+                : `Subagent error: ${message}`,
+            },
+          ],
+          details: undefined as unknown,
+        };
+      }
+    },
+  };
+}
+
+export class SubagentExtension implements AgentRuntimeExtension {
+  readonly name = 'subagent';
+
+  constructor(private readonly getMcpManager: () => MCPManager | null) {}
+
+  async beforeSessionRun(): Promise<BeforeSessionRunResult> {
+    return {
+      customTools: [createSpawnSubagentTool(this.getMcpManager())],
+    };
+  }
+}

--- a/src/main/agent/subagent-extension.ts
+++ b/src/main/agent/subagent-extension.ts
@@ -66,7 +66,7 @@ function createSpawnSubagentTool(mcpManager: MCPManager | null): AgentRuntimeCus
       allowed_tools: Type.Optional(
         Type.Array(Type.String(), {
           description:
-            'Restrict tools available to the child. If omitted, the child inherits all parent tools except spawn_subagent.',
+            'Restrict MCP tools available to the child. Standard coding tools (read, write, edit, bash) are always available. If omitted, the child inherits all parent MCP tools.',
         })
       ),
       timeout_seconds: Type.Optional(

--- a/src/main/agent/subagent-extension.ts
+++ b/src/main/agent/subagent-extension.ts
@@ -20,6 +20,7 @@ import { resolvePiRegistryModel, resolvePiRouteProtocol } from './pi-model-resol
 
 const MAX_TIMEOUT_MS = 300_000; // 5 minutes
 const DEFAULT_TIMEOUT_MS = 120_000; // 2 minutes
+const TIMEOUT_MESSAGE = 'Subagent timed out';
 
 interface SubagentParams {
   task: string;
@@ -197,12 +198,14 @@ function createSpawnSubagentTool(mcpManager: MCPManager | null): AgentRuntimeCus
           }
         });
 
+        let timeoutId: NodeJS.Timeout | undefined;
         try {
           const timeoutPromise = new Promise<never>((_, reject) => {
-            setTimeout(() => reject(new Error('Subagent timed out')), timeoutMs);
+            timeoutId = setTimeout(() => reject(new Error(TIMEOUT_MESSAGE)), timeoutMs);
           });
           await Promise.race([childSession.prompt(task), timeoutPromise]);
         } finally {
+          if (timeoutId) clearTimeout(timeoutId);
           unsubscribe();
           childSession.dispose();
         }
@@ -221,7 +224,7 @@ function createSpawnSubagentTool(mcpManager: MCPManager | null): AgentRuntimeCus
         const message = err instanceof Error ? err.message : String(err);
         logError(`[SubagentExtension] Child failed after ${durationMs}ms:`, message);
 
-        const isTimeout = message.includes('timed out') || message.includes('abort');
+        const isTimeout = message === TIMEOUT_MESSAGE;
         return {
           content: [
             {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,6 +25,7 @@ import { PluginRuntimeService } from './skills/plugin-runtime-service';
 import { MemoryService } from './memory/memory-service';
 import { MemoryExtension } from './memory/memory-extension';
 import { ConfigExtension } from './config/config-extension';
+import { SubagentExtension } from './agent/subagent-extension';
 import { AgentRuntimeExtensionManager } from './extensions/agent-runtime-extension-manager';
 import {
   configStore,
@@ -861,6 +862,7 @@ app
       const headlessExtensionManager = new AgentRuntimeExtensionManager([
         new MemoryExtension(memoryService),
         new ConfigExtension(configStore),
+        new SubagentExtension(() => sessionManager?.getMCPManager() ?? null),
       ]);
 
       // Build the JSONL sender with permission interception BEFORE constructing SessionManager
@@ -1137,6 +1139,7 @@ app
     const extensionManager = new AgentRuntimeExtensionManager([
       new MemoryExtension(memoryService),
       new ConfigExtension(configStore),
+      new SubagentExtension(() => sessionManager?.getMCPManager() ?? null),
     ]);
 
     // Initialize session manager before creating an interactive window.

--- a/src/tests/agent/subagent-extension.test.ts
+++ b/src/tests/agent/subagent-extension.test.ts
@@ -1,4 +1,18 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock configStore so the error-path test can force a deterministic model
+// resolution failure instead of depending on whatever auth/config happens to
+// be present in the test environment.
+// `vi.mock` factories are hoisted above imports/const declarations, so the
+// mock function must be created via `vi.hoisted` to avoid a TDZ reference error.
+const { mockGetAll } = vi.hoisted(() => ({ mockGetAll: vi.fn() }));
+vi.mock('../../main/config/config-store', () => ({
+  configStore: {
+    getAll: mockGetAll,
+    get: vi.fn(),
+  },
+}));
+
 import { SubagentExtension } from '../../main/agent/subagent-extension';
 
 type ToolExecuteFn = (id: string, params: unknown) => Promise<unknown>;
@@ -55,21 +69,27 @@ describe('SubagentExtension', () => {
       expect(execResult.content[0].text).toContain('task parameter is required');
     });
 
-    it('returns structured error when execution fails', async () => {
+    it('returns structured error when model cannot be resolved', async () => {
+      // Force configStore to hand back a model/provider combination that
+      // cannot resolve to any known pi-ai registry model. This makes the
+      // failure deterministic (no dependency on real auth being configured)
+      // and lets us assert the exact error surfaced to the caller.
+      mockGetAll.mockReturnValue({
+        model: 'nonexistent-provider/fake-model-xyz',
+        provider: 'nonexistent-provider',
+      });
+
       const extension = new SubagentExtension(() => null);
       const result = await extension.beforeSessionRun();
       const execute = result.customTools![0].execute as unknown as ToolExecuteFn;
 
-      // With the real configStore and no valid auth configured in the test
-      // environment, session creation/execution is expected to fail. The tool
-      // must surface that failure as a structured error result, not throw.
       const execResult = (await execute('test-call', { task: 'test task' })) as {
         content: { type: string; text: string }[];
       };
 
       expect(execResult.content).toBeDefined();
       expect(execResult.content[0].type).toBe('text');
-      expect(execResult.content[0].text.length).toBeGreaterThan(0);
+      expect(execResult.content[0].text).toContain('could not resolve model');
     });
 
     it('tool has correct parameter schema', async () => {

--- a/src/tests/agent/subagent-extension.test.ts
+++ b/src/tests/agent/subagent-extension.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SubagentExtension } from '../../main/agent/subagent-extension';
+
+type ToolExecuteFn = (id: string, params: unknown) => Promise<unknown>;
+
+describe('SubagentExtension', () => {
+  it('registers spawn_subagent tool via beforeSessionRun', async () => {
+    const extension = new SubagentExtension(() => null);
+    const result = await extension.beforeSessionRun();
+
+    expect(result.customTools).toHaveLength(1);
+    expect(result.customTools![0].name).toBe('spawn_subagent');
+    expect(result.customTools![0].description).toContain('child agent');
+  });
+
+  it('has correct extension name', () => {
+    const extension = new SubagentExtension(() => null);
+    expect(extension.name).toBe('subagent');
+  });
+
+  describe('spawn_subagent tool', () => {
+    it('rejects empty task parameter', async () => {
+      const extension = new SubagentExtension(() => null);
+      const result = await extension.beforeSessionRun();
+      const execute = result.customTools![0].execute as unknown as ToolExecuteFn;
+
+      const execResult = (await execute('test-call', { task: '' })) as {
+        content: { type: string; text: string }[];
+      };
+
+      expect(execResult.content[0].text).toContain('task parameter is required');
+    });
+
+    it('rejects null params', async () => {
+      const extension = new SubagentExtension(() => null);
+      const result = await extension.beforeSessionRun();
+      const execute = result.customTools![0].execute as unknown as ToolExecuteFn;
+
+      const execResult = (await execute('test-call', null)) as {
+        content: { type: string; text: string }[];
+      };
+
+      expect(execResult.content[0].text).toContain('task parameter is required');
+    });
+
+    it('rejects whitespace-only task', async () => {
+      const extension = new SubagentExtension(() => null);
+      const result = await extension.beforeSessionRun();
+      const execute = result.customTools![0].execute as unknown as ToolExecuteFn;
+
+      const execResult = (await execute('test-call', { task: '   ' })) as {
+        content: { type: string; text: string }[];
+      };
+
+      expect(execResult.content[0].text).toContain('task parameter is required');
+    });
+
+    it('returns error when model cannot be resolved', async () => {
+      // Mock configStore to return empty config (no model configured)
+      vi.doMock('../../main/config/config-store', () => ({
+        configStore: {
+          getAll: () => ({ model: '', provider: '' }),
+          get: () => undefined,
+        },
+      }));
+
+      const extension = new SubagentExtension(() => null);
+      const result = await extension.beforeSessionRun();
+      const execute = result.customTools![0].execute as unknown as ToolExecuteFn;
+
+      const execResult = (await execute('test-call', { task: 'test task' })) as {
+        content: { type: string; text: string }[];
+      };
+
+      // Should either error about model resolution or proceed with default model
+      expect(execResult.content[0].text).toBeTruthy();
+    });
+
+    it('tool has correct parameter schema', async () => {
+      const extension = new SubagentExtension(() => null);
+      const result = await extension.beforeSessionRun();
+      const tool = result.customTools![0];
+
+      const schema = tool.parameters;
+      expect(schema).toBeDefined();
+      // The schema should have task as required and other optional params
+      expect(schema.properties).toBeDefined();
+    });
+  });
+});

--- a/src/tests/agent/subagent-extension.test.ts
+++ b/src/tests/agent/subagent-extension.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { SubagentExtension } from '../../main/agent/subagent-extension';
 
 type ToolExecuteFn = (id: string, params: unknown) => Promise<unknown>;
@@ -55,25 +55,21 @@ describe('SubagentExtension', () => {
       expect(execResult.content[0].text).toContain('task parameter is required');
     });
 
-    it('returns error when model cannot be resolved', async () => {
-      // Mock configStore to return empty config (no model configured)
-      vi.doMock('../../main/config/config-store', () => ({
-        configStore: {
-          getAll: () => ({ model: '', provider: '' }),
-          get: () => undefined,
-        },
-      }));
-
+    it('returns structured error when execution fails', async () => {
       const extension = new SubagentExtension(() => null);
       const result = await extension.beforeSessionRun();
       const execute = result.customTools![0].execute as unknown as ToolExecuteFn;
 
+      // With the real configStore and no valid auth configured in the test
+      // environment, session creation/execution is expected to fail. The tool
+      // must surface that failure as a structured error result, not throw.
       const execResult = (await execute('test-call', { task: 'test task' })) as {
         content: { type: string; text: string }[];
       };
 
-      // Should either error about model resolution or proceed with default model
-      expect(execResult.content[0].text).toBeTruthy();
+      expect(execResult.content).toBeDefined();
+      expect(execResult.content[0].type).toBe('text');
+      expect(execResult.content[0].text.length).toBeGreaterThan(0);
     });
 
     it('tool has correct parameter schema', async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,6 +48,8 @@ export default defineConfig({
                 'ws',
                 'glob',
                 'dotenv',
+                '@slack/bolt',
+                '@slack/web-api',
               ],
               output: {
                 // Ensure consistent interop for CJS/ESM


### PR DESCRIPTION
## Summary
- Implements Subagent Phase 1: parent agent can spawn a focused child session via the `spawn_subagent` tool
- Child inherits MCP tools and config but NOT parent conversation history
- Depth limit: child cannot spawn grandchildren (tool omission enforces this)
- Extension-based registration following ConfigExtension pattern
- Lazy MCPManager getter avoids circular dependency at construction time
- Promise.race timeout (configurable 10-300s, default 120s)
- Also fixes vite build by externalizing @slack/bolt and @slack/web-api

## Tool Schema
```
spawn_subagent({
  task: string,           // Required: self-contained task description
  result_format?: string, // Optional: desired output format
  allowed_tools?: string[], // Optional: restrict child tools
  timeout_seconds?: number  // Optional: 10-300, default 120
})
```

## Test plan
- [x] Unit tests pass (7/7): registration, parameter validation, error handling
- [x] TypeScript compiles cleanly (--skipLibCheck)
- [x] Headless E2E: `spawn_subagent` visible in agent's tool list
- [ ] Manual: trigger spawn_subagent with a real task, verify child runs and returns result
- [ ] Verify timeout behavior with a long-running child task