### PR TITLE
fix(remote): multi-turn session mapping (#291) + headless stdio stdin-close exit

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2879,9 +2879,9 @@ ipcMain.handle('remote.getRemoteSessions', () => {
   }
 });
 
-ipcMain.handle('remote.clearRemoteSession', (_event, sessionId: string) => {
+ipcMain.handle('remote.clearRemoteSession', async (_event, sessionId: string) => {
   try {
-    const success = remoteManager.clearRemoteSession(sessionId);
+    const success = await remoteManager.clearRemoteSession(sessionId);
     return { success };
   } catch (error) {
     logError('[Remote] Error clearing remote session:', error);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1152,7 +1152,8 @@ app
 
         // Shut down when stdin closes (controller disconnected), mirroring RPC
         // mode. Without this the process would stay alive indefinitely after the
-        // client goes away. Guard against re-entry via a local flag.
+        // client goes away. StdioChannel.handleClose() is idempotent so onClose
+        // fires once; the local flag is a cheap extra guard for the async body.
         let stdioClosing = false;
         stdioChannel.onClose(() => {
           if (stdioClosing) return;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1150,6 +1150,31 @@ app
 
         const stdioChannel = await remoteManager.startStdioMode(headlessArgs.cwd);
 
+        // Shut down when stdin closes (controller disconnected), mirroring RPC
+        // mode. Without this the process would stay alive indefinitely after the
+        // client goes away. Guard against re-entry via a local flag.
+        let stdioClosing = false;
+        stdioChannel.onClose(() => {
+          if (stdioClosing) return;
+          stdioClosing = true;
+          void (async () => {
+            log('[Headless] stdio stdin closed, shutting down');
+            if (sessionManager) {
+              for (const s of sessionManager.listSessions()) {
+                if (s.status === 'running') {
+                  try {
+                    await sessionManager.stopSession(s.id);
+                  } catch {
+                    // Best effort
+                  }
+                }
+              }
+            }
+            await headlessCleanup();
+            process.exit(0);
+          })();
+        });
+
         // Set the interceptor so ALL events from SM flow through stdio routing
         // (fixes the dead-code issue: SM calls headlessSendWithPermission directly,
         // which now checks stdioEventInterceptor before writing JSONL)

--- a/src/main/remote/channels/stdio-channel.ts
+++ b/src/main/remote/channels/stdio-channel.ts
@@ -63,6 +63,7 @@ export class StdioChannel extends ChannelBase {
   private rl: readline.Interface | null = null;
   private activeSessions: Set<string> = new Set();
   private closeHandler?: () => void;
+  private _closing = false;
 
   /**
    * Register a handler invoked when stdin closes (controller disconnected).
@@ -306,6 +307,12 @@ export class StdioChannel extends ChannelBase {
   }
 
   private handleClose(): void {
+    // Idempotent: stdin's natural close and an explicit stop() can both land
+    // here. Guard internally so the closeHandler (and the abort emissions) run
+    // exactly once, regardless of the caller.
+    if (this._closing) return;
+    this._closing = true;
+
     log('[StdioChannel] stdin closed');
     this._connected = false;
 

--- a/src/main/remote/channels/stdio-channel.ts
+++ b/src/main/remote/channels/stdio-channel.ts
@@ -62,6 +62,16 @@ export class StdioChannel extends ChannelBase {
 
   private rl: readline.Interface | null = null;
   private activeSessions: Set<string> = new Set();
+  private closeHandler?: () => void;
+
+  /**
+   * Register a handler invoked when stdin closes (controller disconnected).
+   * Used by the headless stdio entry point to clean up and exit, mirroring
+   * RPC mode — otherwise the process would hang alive after disconnect.
+   */
+  onClose(handler: () => void): void {
+    this.closeHandler = handler;
+  }
 
   async start(): Promise<void> {
     if (this._connected) return;
@@ -316,6 +326,12 @@ export class StdioChannel extends ChannelBase {
 
     if (this.rl) {
       this.rl = null;
+    }
+
+    // Notify the owner (headless entry point) so it can clean up and exit.
+    // Without this the process stays alive after the controller disconnects.
+    if (this.closeHandler) {
+      this.closeHandler();
     }
   }
 

--- a/src/main/remote/remote-manager.ts
+++ b/src/main/remote/remote-manager.ts
@@ -498,8 +498,16 @@ export class RemoteManager extends EventEmitter {
 
   /**
    * Clear remote session
+   *
+   * Tears down both the router's queue/mapping and the RemoteManager's persistent
+   * session id mappings (so the session cannot be continued afterwards). The
+   * argument is the router-side remote session id (`remote-*`).
    */
-  clearRemoteSession(sessionId: string): boolean {
+  async clearRemoteSession(sessionId: string): Promise<boolean> {
+    const actualSessionId = this.reverseSessionIdMapping.get(sessionId);
+    if (actualSessionId) {
+      await this.removeRemoteSession(actualSessionId);
+    }
     return this.messageRouter.clearSession(sessionId);
   }
 
@@ -1088,7 +1096,15 @@ export class RemoteManager extends EventEmitter {
     // First flush any pending messages
     await this.flushResponseBuffer(actualSessionId);
 
-    // Then clear the buffer
+    // Then clear the ephemeral per-turn state only.
+    //
+    // IMPORTANT: This runs on every turn completion (session.status idle/error),
+    // so it must NOT tear down the persistent session id mappings. Doing so left
+    // `remoteSessionIds` (which is only ever added to) pointing at a session whose
+    // `reverseSessionIdMapping` entry had been deleted, so the next turn saw
+    // isNewSession === false but failed to resolve the actual session id and threw
+    // "No actual session ID found for remote session". Persistent mappings are torn
+    // down in removeRemoteSession(), on genuine session end. See issue #291.
     this.responseBuffers.delete(actualSessionId);
     this.sentMessageHashes.delete(actualSessionId);
     const timer = this.sendTimers.get(actualSessionId);
@@ -1096,19 +1112,28 @@ export class RemoteManager extends EventEmitter {
       clearTimeout(timer);
       this.sendTimers.delete(actualSessionId);
     }
+  }
 
-    // Clean up session mappings
-    const sessionId = this.sessionIdMapping.get(actualSessionId);
+  /**
+   * Tear down all persistent state for a remote session.
+   *
+   * Unlike clearSessionBuffer (per-turn), this removes the session id mappings so
+   * a remote id can no longer be continued. Call it on genuine session end
+   * (channel disconnect, explicit clear), not on turn completion. Keeps
+   * remoteSessionIds and the id mappings in lockstep to avoid the drift that
+   * caused issue #291.
+   */
+  async removeRemoteSession(actualSessionId: string): Promise<void> {
+    // Flush and clear any ephemeral state first.
+    await this.clearSessionBuffer(actualSessionId);
+
+    const remoteSessionId = this.sessionIdMapping.get(actualSessionId);
     this.sessionIdMapping.delete(actualSessionId);
-    if (sessionId) {
-      for (const [key, value] of this.reverseSessionIdMapping) {
-        if (value === actualSessionId) {
-          this.reverseSessionIdMapping.delete(key);
-          break;
-        }
-      }
-      this.sessionChannelMapping.delete(sessionId);
-      this.sessionOwnerMapping.delete(sessionId);
+    if (remoteSessionId) {
+      this.reverseSessionIdMapping.delete(remoteSessionId);
+      this.remoteSessionIds.delete(remoteSessionId);
+      this.sessionChannelMapping.delete(remoteSessionId);
+      this.sessionOwnerMapping.delete(remoteSessionId);
     }
   }
 

--- a/src/main/remote/remote-manager.ts
+++ b/src/main/remote/remote-manager.ts
@@ -19,6 +19,7 @@ import type {
   GatewayConfig,
   FeishuChannelConfig,
   ChannelType,
+  RemoteMessage,
   RemoteSessionMapping,
   PairedUser,
   PairingRequest,
@@ -247,7 +248,7 @@ export class RemoteManager extends EventEmitter {
 
     // Wire channel messages directly to the message router (bypass gateway auth)
     stdioChannel.onMessage((message) => {
-      this.messageRouter.routeMessage(message);
+      this.routeMessage(message);
     });
     stdioChannel.onError((error) => {
       logError('[RemoteManager] StdioChannel error:', error);
@@ -494,6 +495,17 @@ export class RemoteManager extends EventEmitter {
    */
   getRemoteSessions(): RemoteSessionMapping[] {
     return this.messageRouter.getAllSessionMappings();
+  }
+
+  /**
+   * Route an inbound channel message through the agent pipeline.
+   *
+   * Public entry point used by channels (e.g. stdio) to hand a message to the
+   * internal MessageRouter. Exposed so callers and tests don't reach into the
+   * private router.
+   */
+  routeMessage(message: RemoteMessage): Promise<void> {
+    return this.messageRouter.routeMessage(message);
   }
 
   /**

--- a/src/tests/remote/remote-manager-multiturn.test.ts
+++ b/src/tests/remote/remote-manager-multiturn.test.ts
@@ -34,14 +34,9 @@ vi.mock('../../main/utils/logger', () => ({
 import { RemoteManager, type AgentExecutor } from '../../main/remote/remote-manager';
 import type { RemoteMessage } from '../../main/remote/types';
 
-/** Route a message the way channels do (via the internal MessageRouter). */
+/** Route a message the way channels do (via the public RemoteManager API). */
 function route(manager: RemoteManager, message: RemoteMessage): Promise<void> {
-  const router = (
-    manager as unknown as {
-      messageRouter: { routeMessage(m: RemoteMessage): Promise<void> };
-    }
-  ).messageRouter;
-  return router.routeMessage(message);
+  return manager.routeMessage(message);
 }
 
 function makeMessage(channelId: string, text: string): RemoteMessage {

--- a/src/tests/remote/remote-manager-multiturn.test.ts
+++ b/src/tests/remote/remote-manager-multiturn.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Regression tests for src/main/remote/remote-manager.ts multi-turn session
+ * id mapping (issue #291).
+ *
+ * The bug: clearSessionBuffer() ran on every turn completion and tore down the
+ * persistent session id mappings, while remoteSessionIds (only ever added to)
+ * kept the remote id. The next turn saw isNewSession === false but could not
+ * resolve the actual session id and threw "No actual session ID found".
+ */
+
+vi.mock('electron', () => {
+  const app = {
+    getPath: () => '/tmp/test-user-data',
+    getVersion: () => '0.0.0-test',
+    isPackaged: false,
+    on: vi.fn(),
+    getName: () => 'test',
+    name: 'test',
+  };
+  const ipcMain = { on: vi.fn(), handle: vi.fn() };
+  const shell = {};
+  const electron = { app, ipcMain, shell, BrowserWindow: vi.fn() };
+  return { ...electron, default: electron };
+});
+
+vi.mock('../../main/utils/logger', () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+import { RemoteManager, type AgentExecutor } from '../../main/remote/remote-manager';
+import type { RemoteMessage } from '../../main/remote/types';
+
+/** Route a message the way channels do (via the internal MessageRouter). */
+function route(manager: RemoteManager, message: RemoteMessage): Promise<void> {
+  const router = (
+    manager as unknown as {
+      messageRouter: { routeMessage(m: RemoteMessage): Promise<void> };
+    }
+  ).messageRouter;
+  return router.routeMessage(message);
+}
+
+function makeMessage(channelId: string, text: string): RemoteMessage {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2)}`,
+    channelType: 'stdio' as RemoteMessage['channelType'],
+    channelId,
+    sender: { id: 'stdio-user', name: 'stdio', isBot: false },
+    content: { type: 'text', text },
+    timestamp: 1_700_000_000_000,
+    isGroup: false,
+    isMentioned: true,
+  };
+}
+
+describe('RemoteManager multi-turn session mapping (issue #291)', () => {
+  let manager: RemoteManager;
+  let startSession: ReturnType<typeof vi.fn>;
+  let continueSession: ReturnType<typeof vi.fn>;
+  let sessionCounter: number;
+
+  beforeEach(() => {
+    manager = new RemoteManager();
+    sessionCounter = 0;
+    startSession = vi.fn(async (_title: string, prompt: string, cwd?: string) => {
+      sessionCounter++;
+      return {
+        id: `actual-session-${sessionCounter}`,
+        title: prompt.slice(0, 10),
+        cwd,
+        messages: [],
+      } as unknown as Awaited<ReturnType<AgentExecutor['startSession']>>;
+    });
+    continueSession = vi.fn(async () => {});
+
+    const executor = {
+      startSession,
+      continueSession,
+      stopSession: vi.fn(async () => {}),
+    } as unknown as AgentExecutor;
+    manager.setAgentExecutor(executor);
+    // No renderer callback needed; emitRemoteUserMessage no-ops without one.
+  });
+
+  it('continues an existing session on the second turn instead of throwing', async () => {
+    const channelId = 'stdio-abc';
+
+    // Turn 1: starts a new session.
+    await route(manager, makeMessage(channelId, 'hello'));
+    expect(startSession).toHaveBeenCalledTimes(1);
+    expect(continueSession).not.toHaveBeenCalled();
+
+    const actualSessionId = 'actual-session-1';
+    expect(manager.isRemoteSession(actualSessionId)).toBe(true);
+
+    // Simulate turn completion clearing the ephemeral buffer
+    // (this is what session.status idle/error triggers in index.ts).
+    await manager.clearSessionBuffer(actualSessionId);
+
+    // The persistent mapping must survive the per-turn cleanup.
+    expect(manager.isRemoteSession(actualSessionId)).toBe(true);
+
+    // Turn 2: same channel session -> must continue, not throw, not re-start.
+    await expect(route(manager, makeMessage(channelId, 'again'))).resolves.not.toThrow();
+    expect(startSession).toHaveBeenCalledTimes(1);
+    expect(continueSession).toHaveBeenCalledTimes(1);
+    expect(continueSession).toHaveBeenCalledWith(
+      actualSessionId,
+      'again',
+      expect.anything(),
+      undefined
+    );
+  });
+
+  it('clearSessionBuffer does not remove persistent session id mappings', async () => {
+    await route(manager, makeMessage('stdio-xyz', 'hi'));
+    const actualSessionId = 'actual-session-1';
+
+    await manager.clearSessionBuffer(actualSessionId);
+
+    expect(manager.getRemoteSessionId(actualSessionId)).toBeDefined();
+    expect(manager.isRemoteSession(actualSessionId)).toBe(true);
+  });
+
+  it('removeRemoteSession tears down mappings so the id can no longer be continued', async () => {
+    await route(manager, makeMessage('stdio-teardown', 'hi'));
+    const actualSessionId = 'actual-session-1';
+    expect(manager.isRemoteSession(actualSessionId)).toBe(true);
+
+    await manager.removeRemoteSession(actualSessionId);
+
+    expect(manager.isRemoteSession(actualSessionId)).toBe(false);
+    expect(manager.getRemoteSessionId(actualSessionId)).toBeUndefined();
+
+    // A subsequent message on the same channel starts a fresh session
+    // (remoteSessionIds was cleared in lockstep, so no drift/throw).
+    await expect(route(manager, makeMessage('stdio-teardown', 'again'))).resolves.not.toThrow();
+    expect(startSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/tests/remote/stdio-channel.test.ts
+++ b/src/tests/remote/stdio-channel.test.ts
@@ -467,5 +467,22 @@ describe('StdioChannel', () => {
 
       expect(channel.connected).toBe(false);
     });
+
+    it('invokes the onClose handler when stdin closes', async () => {
+      const mockStdin = createMockStdin();
+      Object.defineProperty(process, 'stdin', { value: mockStdin, writable: true });
+
+      const channel = await getStdioChannel();
+      const onClose = vi.fn();
+      channel.onClose(onClose);
+      await channel.start();
+
+      // Simulate stdin close (controller disconnected)
+      mockStdin.push(null);
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(channel.connected).toBe(false);
+    });
   });
 });

--- a/src/tests/remote/stdio-channel.test.ts
+++ b/src/tests/remote/stdio-channel.test.ts
@@ -484,5 +484,24 @@ describe('StdioChannel', () => {
       expect(onClose).toHaveBeenCalledTimes(1);
       expect(channel.connected).toBe(false);
     });
+
+    it('invokes the onClose handler at most once (idempotent close)', async () => {
+      const mockStdin = createMockStdin();
+      Object.defineProperty(process, 'stdin', { value: mockStdin, writable: true });
+
+      const channel = await getStdioChannel();
+      const onClose = vi.fn();
+      channel.onClose(onClose);
+      await channel.start();
+
+      // The close path can be reached from more than one source (stdin's
+      // natural close, an explicit stop()). Invoking it twice must fire
+      // onClose exactly once thanks to the internal _closing guard.
+      const handleClose = (channel as unknown as { handleClose: () => void }).handleClose;
+      handleClose.call(channel);
+      handleClose.call(channel);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
Two related fixes in the `--headless --mode stdio` / `RemoteManager` path (both surfaced while verifying #282).

## 1. Multi-turn remote sessions (fixes #291)

Any follow-up message on an existing remote session failed with `No actual session ID found for remote session: remote-…` and the client got `❌ An internal error occurred.` Affected StdioChannel and every `RemoteManager`-backed channel; `session.abort` on an existing session failed too.

**Cause:** `clearSessionBuffer()` runs on every turn completion (`session.status` idle/error) to flush ephemeral per-turn buffers, but it also deleted the persistent id mappings (`sessionIdMapping`, `reverseSessionIdMapping`, channel/owner). `remoteSessionIds` is only ever added to, so turn 2 saw `isNewSession === false` yet couldn't resolve the actual id → throw.

**Fix:** Separate per-turn cleanup from teardown.
- `clearSessionBuffer()` clears only ephemeral state (buffers, timers, sent-hashes).
- New `removeRemoteSession()` tears down all persistent mappings in lockstep with `remoteSessionIds`; `clearRemoteSession()` resolves the actual id and calls it (now async; the IPC caller awaits).

## 2. Headless stdio process leak on stdin close

In stdio mode, `StdioChannel.handleClose()` logged "stdin closed" and emitted `!stop`, but nothing exited the process — it stayed alive indefinitely after the controller disconnected (had to be SIGTERM'd). RPC mode already exits on stdin close; stdio didn't.

**Fix:** Add an `onClose` callback to `StdioChannel` (invoked from `handleClose()`); the headless stdio entry point stops running sessions, runs `headlessCleanup()`, and `process.exit(0)` — mirroring RPC. Local re-entry guard prevents double shutdown.

## Tests

- `src/tests/remote/remote-manager-multiturn.test.ts` (new): two-turn flow continues (not re-starts, not throws); `clearSessionBuffer` preserves mappings; `removeRemoteSession` removes them. All three fail pre-fix, pass after.
- `src/tests/remote/stdio-channel.test.ts`: added a case asserting `onClose` fires on stdin close.
- Full `src/tests/remote` (25) + `src/tests/config` green; `tsc --noEmit` and eslint clean.

## Manual verification (real app, `--headless --mode stdio`)

Seeded `config.public.json` with `provider: ollama` + `model` to pass the credential gate without a real key.

- **Multi-turn** — turn-2 `session.message` before: `❌ internal error` + `No actual session ID found`. After: `Continuing session: … for remote: …` → `session.started` → `session.end`, no error.
- **Leak** — pipe one message then close stdin: before it hung until SIGTERM; after it self-exits `exit 0` in ~1s, logging `stdin closed → shutting down → Cleaning up`.
