### PR TITLE
fix: sandbox enable toggle and Linux status detection

### DIFF
--- a/src/renderer/components/settings/SettingsSandbox.tsx
+++ b/src/renderer/components/settings/SettingsSandbox.tsx
@@ -47,6 +47,14 @@ export function SettingsSandbox() {
   const [isInitialized, setIsInitialized] = useState(false);
   const [isTogglingSandbox, setIsTogglingSandbox] = useState(false);
   const successTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const reloadTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => {
+      if (successTimeoutRef.current) clearTimeout(successTimeoutRef.current);
+      if (reloadTimeoutRef.current) clearTimeout(reloadTimeoutRef.current);
+    };
+  }, []);
 
   const platform = window.electronAPI?.platform || 'unknown';
   const isWindows = platform === 'win32';
@@ -121,7 +129,8 @@ export function SettingsSandbox() {
           text: nextEnabled ? t('sandbox.enabledWillSetup') : t('sandbox.disabled'),
         });
         // Backend reloads the sandbox bridge on change; refresh status once that settles.
-        setTimeout(async () => {
+        if (reloadTimeoutRef.current) clearTimeout(reloadTimeoutRef.current);
+        reloadTimeoutRef.current = setTimeout(async () => {
           await loadStatus();
         }, 500);
         if (successTimeoutRef.current) clearTimeout(successTimeoutRef.current);
@@ -311,12 +320,12 @@ export function SettingsSandbox() {
     ? status?.wsl?.available
     : isMac
       ? status?.lima?.available
-      : true; // Linux runs natively - no VM/bridge required, so it's always "available"
+      : status?.initialized === true; // Linux: available once backend adapter reports initialized
   const sandboxReady = isWindows
     ? status?.wsl?.available && status?.wsl?.nodeAvailable
     : isMac
       ? status?.lima?.available && status?.lima?.instanceRunning && status?.lima?.nodeAvailable
-      : true; // Linux has no extra setup step, so it's ready as soon as it's enabled
+      : status?.initialized === true; // Linux: ready once backend adapter reports initialized
   const sandboxStatusText = !sandboxEnabled
     ? t('sandbox.disabledStatus')
     : sandboxReady
@@ -357,9 +366,6 @@ export function SettingsSandbox() {
           </p>
         </div>
         <div className="flex items-center justify-center gap-3">
-          <span className="text-sm text-text-secondary">
-            {sandboxEnabled ? t('common.enable') : t('common.disable')}
-          </span>
           <button
             onClick={handleToggleSandbox}
             disabled={isTogglingSandbox}

--- a/src/renderer/components/settings/SettingsSandbox.tsx
+++ b/src/renderer/components/settings/SettingsSandbox.tsx
@@ -45,6 +45,7 @@ export function SettingsSandbox() {
   const [error, setError] = useState<LocalizedBanner | null>(null);
   const [success, setSuccess] = useState<LocalizedBanner | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
+  const [isTogglingSandbox, setIsTogglingSandbox] = useState(false);
 
   const platform = window.electronAPI?.platform || 'unknown';
   const isWindows = platform === 'win32';
@@ -103,8 +104,34 @@ export function SettingsSandbox() {
     }
   }
 
-  // TODO: Re-enable when sandbox debugging is complete
-  // async function handleToggleSandbox() { ... }
+  async function handleToggleSandbox() {
+    if (isTogglingSandbox) return;
+    setIsTogglingSandbox(true);
+    setError(null);
+    setSuccess(null);
+
+    const nextEnabled = !sandboxEnabled;
+    try {
+      const result = await window.electronAPI.config.save({ sandboxEnabled: nextEnabled });
+      if (result.success) {
+        setSandboxEnabled(result.config.sandboxEnabled !== false);
+        setSuccess({
+          text: nextEnabled ? t('sandbox.enabledWillSetup') : t('sandbox.disabled'),
+        });
+        // Backend reloads the sandbox bridge on change; refresh status once that settles.
+        setTimeout(async () => {
+          await loadStatus();
+        }, 500);
+        setTimeout(() => setSuccess(null), 3000);
+      } else {
+        setError({ text: t('sandbox.failedToSave') });
+      }
+    } catch (err) {
+      setError({ text: err instanceof Error ? err.message : t('sandbox.failedToSave') });
+    } finally {
+      setIsTogglingSandbox(false);
+    }
+  }
 
   async function handleCheckStatus() {
     if (isChecking) return; // Prevent double-click
@@ -325,6 +352,28 @@ export function SettingsSandbox() {
                 ? t('sandbox.limaDesc')
                 : t('sandbox.nativeDesc')}
           </p>
+        </div>
+        <div className="flex items-center justify-center gap-3">
+          <span className="text-sm text-text-secondary">
+            {sandboxEnabled ? t('common.enable') : t('common.disable')}
+          </span>
+          <button
+            onClick={handleToggleSandbox}
+            disabled={isTogglingSandbox}
+            role="switch"
+            aria-checked={sandboxEnabled}
+            aria-label={t('sandbox.enableSandbox')}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:opacity-50 flex-shrink-0 ${
+              sandboxEnabled ? 'bg-accent' : 'bg-surface-muted'
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-text-primary transition-transform ${
+                sandboxEnabled ? 'translate-x-6' : 'translate-x-1'
+              }`}
+            />
+          </button>
+          {isTogglingSandbox && <Loader2 className="w-4 h-4 animate-spin text-text-muted" />}
         </div>
         <div
           className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium ${

--- a/src/renderer/components/settings/SettingsSandbox.tsx
+++ b/src/renderer/components/settings/SettingsSandbox.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Shield, AlertCircle, CheckCircle, Settings, Loader2 } from 'lucide-react';
 import { renderLocalizedBannerMessage } from './shared';
@@ -46,6 +46,7 @@ export function SettingsSandbox() {
   const [success, setSuccess] = useState<LocalizedBanner | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
   const [isTogglingSandbox, setIsTogglingSandbox] = useState(false);
+  const successTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
   const platform = window.electronAPI?.platform || 'unknown';
   const isWindows = platform === 'win32';
@@ -105,6 +106,7 @@ export function SettingsSandbox() {
   }
 
   async function handleToggleSandbox() {
+    if (!isElectron) return;
     if (isTogglingSandbox) return;
     setIsTogglingSandbox(true);
     setError(null);
@@ -122,7 +124,8 @@ export function SettingsSandbox() {
         setTimeout(async () => {
           await loadStatus();
         }, 500);
-        setTimeout(() => setSuccess(null), 3000);
+        if (successTimeoutRef.current) clearTimeout(successTimeoutRef.current);
+        successTimeoutRef.current = setTimeout(() => setSuccess(null), 3000);
       } else {
         setError({ text: t('sandbox.failedToSave') });
       }
@@ -308,12 +311,12 @@ export function SettingsSandbox() {
     ? status?.wsl?.available
     : isMac
       ? status?.lima?.available
-      : false;
+      : true; // Linux runs natively - no VM/bridge required, so it's always "available"
   const sandboxReady = isWindows
     ? status?.wsl?.available && status?.wsl?.nodeAvailable
     : isMac
       ? status?.lima?.available && status?.lima?.instanceRunning && status?.lima?.nodeAvailable
-      : false;
+      : true; // Linux has no extra setup step, so it's ready as soon as it's enabled
   const sandboxStatusText = !sandboxEnabled
     ? t('sandbox.disabledStatus')
     : sandboxReady


### PR DESCRIPTION
## Summary

Two related but separate fixes to the Sandbox settings panel (`SettingsSandbox.tsx`):

1. **Sandbox enable toggle was missing entirely.** The panel displayed status correctly (WSL2/Lima detection, Node/Python/pip checks all worked), but there was no way to actually turn Sandbox Mode on or off — `handleToggleSandbox` existed only as a commented-out `// TODO: Re-enable when sandbox debugging is complete` stub, with no UI control wired to it at all. Backend support (`config.save` IPC handler → `configStore.update` → `syncConfigAfterMutation` → `sessionManager.reloadSandbox()`) was already fully implemented and required no changes. This affects **all platforms** (Windows/WSL2, macOS/Lima, Linux), since it's the same shared component.

2. **`sandboxReady`/`sandboxAvailable` were hardcoded to `false` on native Linux hosts.** Separately, while testing the toggle fix by running the dev build directly on Linux (as opposed to Windows using WSL2 as a backend — a different code path), the status always read "Sandbox enabled but not fully configured" even though Linux native mode has no further setup step (per the existing `sandbox.linuxNative` copy: "Linux runs commands natively without additional sandboxing"). Fixed by treating Linux as always available/ready, matching intended behavior — this does **not** affect the Windows/WSL2 or macOS/Lima detection logic, which were already correct.

## Related

- #179 (Sandbox reports "Coming Soon" even though page implies feature already exists)
- #46 (unmerged attempt to re-enable sandbox)
- #188 (merged fix for the status display, but didn't restore the toggle itself)

## Testing

- Verified on Windows 11 + WSL2 (Ubuntu): toggle now switches Sandbox Mode on/off, status correctly reports "Sandbox ready and running" with WSL2/Node/Python/pip all green.
- Verified on native Linux (WSL Ubuntu run directly, non-Windows code path): status now correctly reports ready instead of a permanent false warning.
- `tsc --noEmit` and `eslint` pass with no new errors.