### PR TITLE
fix(chat): support RTL message direction

### DIFF
--- a/src/renderer/components/MessageMarkdown.tsx
+++ b/src/renderer/components/MessageMarkdown.tsx
@@ -4,6 +4,7 @@ import remarkMath from 'remark-math';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeKatex from 'rehype-katex';
+import { AUTO_TEXT_DIRECTION_PROPS } from '../utils/text-direction';
 
 // Hoisted to module scope to avoid re-creating arrays on every render
 const REMARK_PLUGINS = [remarkMath, [remarkGfm, { singleTilde: false }]] as const;
@@ -42,7 +43,10 @@ export const MessageMarkdown = memo(function MessageMarkdown({
   components,
 }: MessageMarkdownProps) {
   return (
-    <div className="prose-chat max-w-none text-text-primary">
+    <div
+      {...AUTO_TEXT_DIRECTION_PROPS}
+      className="prose-chat max-w-none text-text-primary text-start"
+    >
       <ReactMarkdown
         remarkPlugins={
           REMARK_PLUGINS as unknown as Parameters<typeof ReactMarkdown>[0]['remarkPlugins']

--- a/src/renderer/components/message/ContentBlockView.tsx
+++ b/src/renderer/components/message/ContentBlockView.tsx
@@ -14,6 +14,7 @@ import {
   resolveLocalFilePathFromHref,
 } from '../../utils/markdown-local-link';
 import { normalizeLatexDelimiters } from '../../utils/latex-delimiters';
+import { AUTO_TEXT_DIRECTION_PROPS } from '../../utils/text-direction';
 import type { ToolUseContent, ToolResultContent, FileAttachmentContent } from '../../types';
 import { FileText } from 'lucide-react';
 import { CodeBlock } from './CodeBlock';
@@ -200,10 +201,18 @@ export const ContentBlockView = memo(function ContentBlockView({
         return <CodeBlock language={match[1]}>{String(children).replace(/\n$/, '')}</CodeBlock>;
       },
       p({ children }: { children?: React.ReactNode }) {
-        return <p className="text-left">{renderChildrenWithFileLinks(children, 'p')}</p>;
+        return (
+          <p {...AUTO_TEXT_DIRECTION_PROPS} className="text-start">
+            {renderChildrenWithFileLinks(children, 'p')}
+          </p>
+        );
       },
       li({ children }: { children?: React.ReactNode }) {
-        return <li className="text-left">{renderChildrenWithFileLinks(children, 'li')}</li>;
+        return (
+          <li {...AUTO_TEXT_DIRECTION_PROPS} className="text-start">
+            {renderChildrenWithFileLinks(children, 'li')}
+          </li>
+        );
       },
       table({ children }: { children?: React.ReactNode }) {
         return (
@@ -266,7 +275,10 @@ export const ContentBlockView = memo(function ContentBlockView({
       // Simple text display for user messages, Markdown for assistant
       if (isUser) {
         return (
-          <p className="text-text-primary whitespace-pre-wrap break-words text-left">
+          <p
+            {...AUTO_TEXT_DIRECTION_PROPS}
+            className="text-text-primary whitespace-pre-wrap break-words text-start"
+          >
             {text}
             {isStreaming && <span className="inline-block w-2 h-4 bg-accent ml-1 animate-pulse" />}
           </p>
@@ -277,14 +289,20 @@ export const ContentBlockView = memo(function ContentBlockView({
         <PanelErrorBoundary
           name="MessageMarkdown"
           fallback={
-            <div className="prose-chat max-w-none text-text-primary whitespace-pre-wrap break-words">
+            <div
+              {...AUTO_TEXT_DIRECTION_PROPS}
+              className="prose-chat max-w-none text-text-primary whitespace-pre-wrap break-words text-start"
+            >
               {normalizedText}
             </div>
           }
         >
           <Suspense
             fallback={
-              <div className="prose-chat max-w-none text-text-primary whitespace-pre-wrap break-words">
+              <div
+                {...AUTO_TEXT_DIRECTION_PROPS}
+                className="prose-chat max-w-none text-text-primary whitespace-pre-wrap break-words text-start"
+              >
                 {normalizedText}
               </div>
             }

--- a/src/renderer/utils/text-direction.ts
+++ b/src/renderer/utils/text-direction.ts
@@ -1,0 +1,6 @@
+// Let the browser choose the direction from the first strong character in each
+// text block. `plaintext` keeps embedded LTR/RTL runs isolated from surrounding UI.
+export const AUTO_TEXT_DIRECTION_PROPS = {
+  dir: 'auto',
+  style: { unicodeBidi: 'plaintext' },
+} as const;

--- a/src/tests/text-direction.test.ts
+++ b/src/tests/text-direction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { AUTO_TEXT_DIRECTION_PROPS } from '../src/renderer/utils/text-direction';
+import { AUTO_TEXT_DIRECTION_PROPS } from '../renderer/utils/text-direction';
 
 describe('automatic chat text direction', () => {
   it('delegates direction detection to the browser for every text block', () => {

--- a/tests/text-direction.test.ts
+++ b/tests/text-direction.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { AUTO_TEXT_DIRECTION_PROPS } from '../src/renderer/utils/text-direction';
+
+describe('automatic chat text direction', () => {
+  it('delegates direction detection to the browser for every text block', () => {
+    expect(AUTO_TEXT_DIRECTION_PROPS.dir).toBe('auto');
+  });
+
+  it('isolates mixed-direction text from the surrounding interface', () => {
+    expect(AUTO_TEXT_DIRECTION_PROPS.style.unicodeBidi).toBe('plaintext');
+  });
+});


### PR DESCRIPTION
## Summary

- apply browser-native `dir="auto"` detection to user and assistant text blocks
- use logical start alignment instead of forcing all chat paragraphs left
- isolate mixed RTL/LTR runs with `unicode-bidi: plaintext`
- cover the shared direction contract with regression tests

## Validation

- `npx vitest run tests/text-direction.test.ts --reporter=verbose`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)

Fixes #265
