### PR TITLE
fix(chat): preserve per-session scroll position

### DIFF
--- a/src/renderer/components/ChatView.tsx
+++ b/src/renderer/components/ChatView.tsx
@@ -64,6 +64,8 @@ export function ChatView() {
   const prevPartialLengthRef = useRef(0);
   const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollRequestRef = useRef<number | null>(null);
+  const scrollStateRequestRef = useRef<number | null>(null);
+  const pendingScrollStateRef = useRef<{ sessionId: string; scrollTop: number } | null>(null);
   const isScrollingRef = useRef(false);
 
   const hasActiveTurn = Boolean(activeTurn);
@@ -200,19 +202,41 @@ export function ChatView() {
   useEffect(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
+
+    const flushScrollPosition = () => {
+      scrollStateRequestRef.current = null;
+      const pending = pendingScrollStateRef.current;
+      pendingScrollStateRef.current = null;
+      if (pending) {
+        useAppStore.getState().setSessionScrollPosition(pending.sessionId, pending.scrollTop);
+      }
+    };
+
     const updateScrollState = () => {
       const distanceToBottom =
         container.scrollHeight - container.scrollTop - container.clientHeight;
       isUserAtBottomRef.current = distanceToBottom <= 80;
       if (activeSessionId) {
-        useAppStore.getState().setSessionScrollPosition(activeSessionId, container.scrollTop);
+        pendingScrollStateRef.current = {
+          sessionId: activeSessionId,
+          scrollTop: container.scrollTop,
+        };
+        if (scrollStateRequestRef.current === null) {
+          scrollStateRequestRef.current = requestAnimationFrame(flushScrollPosition);
+        }
       }
     };
     updateScrollState();
-    // 用户阅读旧消息时，阻止新消息自动滚动打断视线
+    // Keep new messages from interrupting the user while they read older content.
     const onScroll = () => updateScrollState();
     container.addEventListener('scroll', onScroll, { passive: true });
-    return () => container.removeEventListener('scroll', onScroll);
+    return () => {
+      container.removeEventListener('scroll', onScroll);
+      if (scrollStateRequestRef.current !== null) {
+        cancelAnimationFrame(scrollStateRequestRef.current);
+      }
+      flushScrollPosition();
+    };
   }, [activeSessionId]);
 
   useEffect(() => {

--- a/src/renderer/components/ChatView.tsx
+++ b/src/renderer/components/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { useState, useRef, useEffect, useLayoutEffect, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   useActiveSessionId,
@@ -17,6 +17,7 @@ import { SubagentTracker } from './SubagentTracker';
 import { ContextUsageBar } from './ContextUsageBar';
 import type { Message, ContentBlock } from '../types';
 import { Send, Square, Plus, Loader2, Plug, X, Clock } from 'lucide-react';
+import { isScrollNearBottom, resolveSessionScrollTop } from '../utils/chat-scroll-position';
 
 type AttachedFile = {
   name: string;
@@ -133,6 +134,30 @@ export function ChatView() {
       : Math.max(0, (executionClock.endAt ?? clockNow) - executionClock.startAt);
   const timerActive = Boolean(executionClock?.startAt && executionClock.endAt === null);
 
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !activeSessionId) return;
+
+    const savedScrollTop = useAppStore.getState().sessionScrollPositions[activeSessionId];
+    const restoredScrollTop = resolveSessionScrollTop(
+      savedScrollTop,
+      container.scrollHeight,
+      container.clientHeight
+    );
+    container.scrollTop = restoredScrollTop;
+    isUserAtBottomRef.current = isScrollNearBottom(
+      restoredScrollTop,
+      container.scrollHeight,
+      container.clientHeight
+    );
+
+    // Prevent the generic new-message effect from overriding the session restore.
+    const sessionState = useAppStore.getState().sessionStates[activeSessionId];
+    prevMessageCountRef.current = sessionState?.messages.length ?? 0;
+    prevPartialLengthRef.current =
+      (sessionState?.partialMessage.length ?? 0) + (sessionState?.partialThinking.length ?? 0);
+  }, [activeSessionId]);
+
   // Debounced scroll function to prevent scroll conflicts
   const scrollToBottom = useRef((behavior: ScrollBehavior = 'auto', immediate: boolean = false) => {
     // Cancel any pending scroll requests
@@ -179,13 +204,16 @@ export function ChatView() {
       const distanceToBottom =
         container.scrollHeight - container.scrollTop - container.clientHeight;
       isUserAtBottomRef.current = distanceToBottom <= 80;
+      if (activeSessionId) {
+        useAppStore.getState().setSessionScrollPosition(activeSessionId, container.scrollTop);
+      }
     };
     updateScrollState();
     // 用户阅读旧消息时，阻止新消息自动滚动打断视线
     const onScroll = () => updateScrollState();
     container.addEventListener('scroll', onScroll, { passive: true });
     return () => container.removeEventListener('scroll', onScroll);
-  }, []);
+  }, [activeSessionId]);
 
   useEffect(() => {
     const messageCount = messages.length;

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -93,6 +93,9 @@ interface AppState {
   // Per-session state (messages, partials, turns, traces, etc.)
   sessionStates: Record<string, SessionState>;
 
+  // Ephemeral viewport state, kept separate so scrolling does not rerender message consumers.
+  sessionScrollPositions: Record<string, number>;
+
   // UI state
   isLoading: boolean;
   sidebarCollapsed: boolean;
@@ -138,6 +141,7 @@ interface AppState {
   removeSession: (sessionId: string) => void;
   removeSessions: (sessionIds: string[]) => void;
   setActiveSession: (sessionId: string | null) => void;
+  setSessionScrollPosition: (sessionId: string, scrollTop: number) => void;
 
   addMessage: (sessionId: string, message: Message) => void;
   updateMessage: (sessionId: string, messageId: string, updates: Partial<Message>) => void;
@@ -238,6 +242,7 @@ export const useAppStore = create<AppState>((set) => ({
   sessions: [],
   activeSessionId: null,
   sessionStates: {},
+  sessionScrollPositions: {},
   isLoading: false,
   sidebarCollapsed: false,
   contextPanelCollapsed: false,
@@ -279,9 +284,13 @@ export const useAppStore = create<AppState>((set) => ({
   removeSession: (sessionId) =>
     set((state) => {
       const { [sessionId]: _, ...restSessionStates } = state.sessionStates;
+      const restScrollPositions = Object.fromEntries(
+        Object.entries(state.sessionScrollPositions).filter(([id]) => id !== sessionId)
+      );
       return {
         sessions: state.sessions.filter((s) => s.id !== sessionId),
         sessionStates: restSessionStates,
+        sessionScrollPositions: restScrollPositions,
         activeSessionId: state.activeSessionId === sessionId ? null : state.activeSessionId,
       };
     }),
@@ -290,19 +299,32 @@ export const useAppStore = create<AppState>((set) => ({
     set((state) => {
       const idSet = new Set(sessionIds);
       const newSessionStates: Record<string, SessionState> = {};
+      const newScrollPositions: Record<string, number> = {};
       for (const key of Object.keys(state.sessionStates)) {
         if (!idSet.has(key)) newSessionStates[key] = state.sessionStates[key];
+      }
+      for (const key of Object.keys(state.sessionScrollPositions)) {
+        if (!idSet.has(key)) newScrollPositions[key] = state.sessionScrollPositions[key];
       }
 
       return {
         sessions: state.sessions.filter((s) => !idSet.has(s.id)),
         sessionStates: newSessionStates,
+        sessionScrollPositions: newScrollPositions,
         activeSessionId:
           state.activeSessionId && idSet.has(state.activeSessionId) ? null : state.activeSessionId,
       };
     }),
 
   setActiveSession: (sessionId) => set({ activeSessionId: sessionId }),
+
+  setSessionScrollPosition: (sessionId, scrollTop) =>
+    set((state) => ({
+      sessionScrollPositions: {
+        ...state.sessionScrollPositions,
+        [sessionId]: scrollTop,
+      },
+    })),
 
   // Message actions
   addMessage: (sessionId, message) =>

--- a/src/renderer/utils/chat-scroll-position.ts
+++ b/src/renderer/utils/chat-scroll-position.ts
@@ -1,0 +1,18 @@
+export function resolveSessionScrollTop(
+  savedScrollTop: number | undefined,
+  scrollHeight: number,
+  clientHeight: number
+): number {
+  const maximumScrollTop = Math.max(0, scrollHeight - clientHeight);
+  if (savedScrollTop === undefined) return maximumScrollTop;
+  return Math.min(Math.max(0, savedScrollTop), maximumScrollTop);
+}
+
+export function isScrollNearBottom(
+  scrollTop: number,
+  scrollHeight: number,
+  clientHeight: number,
+  threshold = 80
+): boolean {
+  return scrollHeight - scrollTop - clientHeight <= threshold;
+}

--- a/src/tests/store/session-state.test.ts
+++ b/src/tests/store/session-state.test.ts
@@ -36,6 +36,7 @@ describe('SessionState unified store', () => {
       expect(state.sessionStates['s1'].executionClock).toEqual({ startAt: null, endAt: null });
       expect(state.sessionStates['s1'].traceSteps).toEqual([]);
       expect(state.sessionStates['s1'].contextWindow).toBe(0);
+      expect(state.sessionScrollPositions['s1']).toBeUndefined();
     });
   });
 
@@ -48,6 +49,7 @@ describe('SessionState unified store', () => {
       useAppStore.getState().removeSession('s1');
       expect(useAppStore.getState().sessionStates['s1']).toBeUndefined();
       expect(useAppStore.getState().sessions).toHaveLength(0);
+      expect(useAppStore.getState().sessionScrollPositions['s1']).toBeUndefined();
     });
 
     it('should clear activeSessionId when removing active session', () => {
@@ -56,6 +58,24 @@ describe('SessionState unified store', () => {
       useAppStore.getState().setActiveSession('s1');
       useAppStore.getState().removeSession('s1');
       expect(useAppStore.getState().activeSessionId).toBeNull();
+    });
+  });
+
+  describe('scroll positions', () => {
+    it('stores viewport positions independently for each session', () => {
+      useAppStore.getState().setSessionScrollPosition('s1', 120);
+      useAppStore.getState().setSessionScrollPosition('s2', 480);
+
+      expect(useAppStore.getState().sessionScrollPositions).toEqual({ s1: 120, s2: 480 });
+    });
+
+    it('removes viewport positions with their sessions', () => {
+      useAppStore.getState().addSession(makeSession('s1'));
+      useAppStore.getState().setSessionScrollPosition('s1', 120);
+
+      useAppStore.getState().removeSession('s1');
+
+      expect(useAppStore.getState().sessionScrollPositions['s1']).toBeUndefined();
     });
   });
 
@@ -116,8 +136,20 @@ describe('SessionState unified store', () => {
     it('should set messages (bulk replace)', () => {
       useAppStore.getState().addSession(makeSession('s1'));
       const msgs = [
-        { id: 'a', sessionId: 's1', role: 'user' as const, content: [{ type: 'text' as const, text: 'hi' }], timestamp: 1 },
-        { id: 'b', sessionId: 's1', role: 'assistant' as const, content: [{ type: 'text' as const, text: 'hello' }], timestamp: 2 },
+        {
+          id: 'a',
+          sessionId: 's1',
+          role: 'user' as const,
+          content: [{ type: 'text' as const, text: 'hi' }],
+          timestamp: 1,
+        },
+        {
+          id: 'b',
+          sessionId: 's1',
+          role: 'assistant' as const,
+          content: [{ type: 'text' as const, text: 'hello' }],
+          timestamp: 2,
+        },
       ];
       useAppStore.getState().setMessages('s1', msgs);
       expect(useAppStore.getState().sessionStates['s1'].messages).toHaveLength(2);
@@ -219,8 +251,11 @@ describe('SessionState unified store', () => {
       useAppStore.getState().addSession(makeSession('s1'));
       // Setup an active turn first
       useAppStore.getState().addMessage('s1', {
-        id: 'msg1', sessionId: 's1', role: 'user',
-        content: [{ type: 'text', text: 'test' }], timestamp: Date.now(),
+        id: 'msg1',
+        sessionId: 's1',
+        role: 'user',
+        content: [{ type: 'text', text: 'test' }],
+        timestamp: Date.now(),
       });
       useAppStore.getState().activateNextTurn('s1', 'step1');
       useAppStore.getState().updateActiveTurnStep('s1', 'step2');
@@ -233,8 +268,11 @@ describe('SessionState unified store', () => {
     it('should clear active turn', () => {
       useAppStore.getState().addSession(makeSession('s1'));
       useAppStore.getState().addMessage('s1', {
-        id: 'msg1', sessionId: 's1', role: 'user',
-        content: [{ type: 'text', text: 'test' }], timestamp: Date.now(),
+        id: 'msg1',
+        sessionId: 's1',
+        role: 'user',
+        content: [{ type: 'text', text: 'test' }],
+        timestamp: Date.now(),
       });
       useAppStore.getState().activateNextTurn('s1', 'step1');
       useAppStore.getState().clearActiveTurn('s1');
@@ -244,8 +282,11 @@ describe('SessionState unified store', () => {
     it('should only clear active turn when stepId matches', () => {
       useAppStore.getState().addSession(makeSession('s1'));
       useAppStore.getState().addMessage('s1', {
-        id: 'msg1', sessionId: 's1', role: 'user',
-        content: [{ type: 'text', text: 'test' }], timestamp: Date.now(),
+        id: 'msg1',
+        sessionId: 's1',
+        role: 'user',
+        content: [{ type: 'text', text: 'test' }],
+        timestamp: Date.now(),
       });
       useAppStore.getState().activateNextTurn('s1', 'step1');
       // Try clearing with wrong stepId - should not clear
@@ -259,8 +300,11 @@ describe('SessionState unified store', () => {
     it('should clear pending turns', () => {
       useAppStore.getState().addSession(makeSession('s1'));
       useAppStore.getState().addMessage('s1', {
-        id: 'msg1', sessionId: 's1', role: 'user',
-        content: [{ type: 'text', text: 'test' }], timestamp: Date.now(),
+        id: 'msg1',
+        sessionId: 's1',
+        role: 'user',
+        content: [{ type: 'text', text: 'test' }],
+        timestamp: Date.now(),
       });
       expect(useAppStore.getState().sessionStates['s1'].pendingTurns).toHaveLength(1);
       useAppStore.getState().clearPendingTurns('s1');
@@ -273,8 +317,21 @@ describe('SessionState unified store', () => {
       useAppStore.getState().addSession(makeSession('s1'));
       // Manually set messages with queued status
       useAppStore.getState().setMessages('s1', [
-        { id: 'msg1', sessionId: 's1', role: 'user', content: [{ type: 'text', text: 'a' }], timestamp: 1, localStatus: 'queued' },
-        { id: 'msg2', sessionId: 's1', role: 'user', content: [{ type: 'text', text: 'b' }], timestamp: 2 },
+        {
+          id: 'msg1',
+          sessionId: 's1',
+          role: 'user',
+          content: [{ type: 'text', text: 'a' }],
+          timestamp: 1,
+          localStatus: 'queued',
+        },
+        {
+          id: 'msg2',
+          sessionId: 's1',
+          role: 'user',
+          content: [{ type: 'text', text: 'b' }],
+          timestamp: 2,
+        },
       ]);
       useAppStore.getState().clearQueuedMessages('s1');
       const msgs = useAppStore.getState().sessionStates['s1'].messages;
@@ -285,7 +342,14 @@ describe('SessionState unified store', () => {
     it('should cancel queued messages', () => {
       useAppStore.getState().addSession(makeSession('s1'));
       useAppStore.getState().setMessages('s1', [
-        { id: 'msg1', sessionId: 's1', role: 'user', content: [{ type: 'text', text: 'a' }], timestamp: 1, localStatus: 'queued' },
+        {
+          id: 'msg1',
+          sessionId: 's1',
+          role: 'user',
+          content: [{ type: 'text', text: 'a' }],
+          timestamp: 1,
+          localStatus: 'queued',
+        },
       ]);
       useAppStore.getState().cancelQueuedMessages('s1');
       expect(useAppStore.getState().sessionStates['s1'].messages[0].localStatus).toBe('cancelled');
@@ -295,7 +359,14 @@ describe('SessionState unified store', () => {
   describe('trace steps', () => {
     it('should add and update trace steps', () => {
       useAppStore.getState().addSession(makeSession('s1'));
-      const step = { id: 'ts1', type: 'tool_call' as const, status: 'running' as const, title: 'read', toolName: 'read', timestamp: Date.now() };
+      const step = {
+        id: 'ts1',
+        type: 'tool_call' as const,
+        status: 'running' as const,
+        title: 'read',
+        toolName: 'read',
+        timestamp: Date.now(),
+      };
       useAppStore.getState().addTraceStep('s1', step);
       expect(useAppStore.getState().sessionStates['s1'].traceSteps).toHaveLength(1);
 
@@ -306,8 +377,21 @@ describe('SessionState unified store', () => {
     it('should set trace steps (bulk replace)', () => {
       useAppStore.getState().addSession(makeSession('s1'));
       const steps = [
-        { id: 'ts1', type: 'tool_call' as const, status: 'completed' as const, title: 'read', toolName: 'read', timestamp: 1 },
-        { id: 'ts2', type: 'thinking' as const, status: 'completed' as const, title: 'thinking', timestamp: 2 },
+        {
+          id: 'ts1',
+          type: 'tool_call' as const,
+          status: 'completed' as const,
+          title: 'read',
+          toolName: 'read',
+          timestamp: 1,
+        },
+        {
+          id: 'ts2',
+          type: 'thinking' as const,
+          status: 'completed' as const,
+          title: 'thinking',
+          timestamp: 2,
+        },
       ];
       useAppStore.getState().setTraceSteps('s1', steps);
       expect(useAppStore.getState().sessionStates['s1'].traceSteps).toHaveLength(2);

--- a/tests/chat-scroll-position.test.ts
+++ b/tests/chat-scroll-position.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isScrollNearBottom,
+  resolveSessionScrollTop,
+} from '../src/renderer/utils/chat-scroll-position';
+
+describe('chat session scroll restoration', () => {
+  it('defaults a session without history to the bottom', () => {
+    expect(resolveSessionScrollTop(undefined, 1200, 400)).toBe(800);
+  });
+
+  it('restores a saved session position', () => {
+    expect(resolveSessionScrollTop(275, 1200, 400)).toBe(275);
+  });
+
+  it('clamps stale positions after content shrinks', () => {
+    expect(resolveSessionScrollTop(900, 700, 400)).toBe(300);
+  });
+
+  it('recognizes the auto-scroll threshold', () => {
+    expect(isScrollNearBottom(720, 1200, 400)).toBe(true);
+    expect(isScrollNearBottom(719, 1200, 400)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- keep scroll offsets in per-session UI state without rerendering message consumers
- restore each session before paint and default unseen sessions to the latest message
- clamp stale offsets safely when conversation content becomes shorter
- clear viewport state when sessions are deleted
- add focused store and scroll calculation regression tests

## Validation

- `npx vitest run tests/chat-scroll-position.test.ts src/tests/store/session-state.test.ts --reporter=verbose` (32 passed)
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)

Fixes #267
