### PR TITLE
Fix/wsl sandbox bash tool wiring

### DIFF
--- a/patches/@mariozechner+pi-coding-agent+0.60.0.patch
+++ b/patches/@mariozechner+pi-coding-agent+0.60.0.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/@mariozechner/pi-coding-agent/dist/core/sdk.js b/node_modules/@mariozechner/pi-coding-agent/dist/core/sdk.js
+index 438ac8c..9376c28 100644
+--- a/node_modules/@mariozechner/pi-coding-agent/dist/core/sdk.js
++++ b/node_modules/@mariozechner/pi-coding-agent/dist/core/sdk.js
+@@ -125,6 +125,16 @@ export async function createAgentSession(options = {}) {
+     const initialActiveToolNames = options.tools
+         ? options.tools.map((t) => t.name).filter((n) => n in allTools)
+         : defaultActiveToolNames;
++    // When callers pass full Tool objects (not just names) in options.tools, honor their
++    // actual implementations rather than silently discarding them and rebuilding default
++    // tools from `cwd` alone. Without this, any caller providing custom-runtime tools
++    // (e.g. tools whose bash operations route through a different environment such as a
++    // container or WSL distro) would have those implementations dropped: only the tool
++    // *names* were being kept, and AgentSession would then reconstruct plain default
++    // tools bound to `cwd` on the host filesystem, silently ignoring the custom operations.
++    const baseToolsOverride = options.tools
++        ? Object.fromEntries(options.tools.map((t) => [t.name, t]))
++        : undefined;
+     let agent;
+     // Create convertToLlm wrapper that filters images if blockImages is enabled (defense-in-depth)
+     const convertToLlmWithBlockImages = (messages) => {
+@@ -230,6 +240,7 @@ export async function createAgentSession(options = {}) {
+         customTools: options.customTools,
+         modelRegistry,
+         initialActiveToolNames,
++        baseToolsOverride,
+         extensionRunnerRef,
+     });
+     const extensionsResult = resourceLoader.getExtensions();

--- a/src/main/agent/wsl-sandbox-bash-operations.ts
+++ b/src/main/agent/wsl-sandbox-bash-operations.ts
@@ -1,0 +1,184 @@
+import { spawn, type ChildProcess, type SpawnOptions } from 'child_process';
+import type { BashOperations } from '@mariozechner/pi-coding-agent';
+import { log } from '../utils/logger';
+
+const DEFAULT_TERMINATION_GRACE_MS = 5000;
+const DEFAULT_TASKKILL_WAIT_MS = 3000;
+
+type SpawnProcess = (command: string, args: string[], options: SpawnOptions) => ChildProcess;
+
+export interface WslSandboxBashOperationsOptions {
+  spawnProcess?: SpawnProcess;
+  terminationGraceMs?: number;
+  taskkillWaitMs?: number;
+}
+
+function shellEscapePath(p: string): string {
+  return p.replace(/'/g, "'\\''");
+}
+
+function createSpawnProcess(): SpawnProcess {
+  return (command, args, options) => spawn(command, args, options);
+}
+
+async function waitForProcessClose(child: ChildProcess, timeoutMs: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    let settled = false;
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutHandle);
+      child.off('close', finish);
+      child.off('error', finish);
+      resolve();
+    };
+
+    child.once('close', finish);
+    child.once('error', finish);
+    const timeoutHandle = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        // Ignore cleanup failures; the caller is already terminating a process tree.
+      }
+      finish();
+    }, timeoutMs);
+    timeoutHandle.unref?.();
+  });
+}
+
+async function killWindowsProcessTree(
+  pid: number,
+  spawnProcess: SpawnProcess,
+  taskkillWaitMs: number
+): Promise<void> {
+  try {
+    const taskkill = spawnProcess('taskkill', ['/F', '/T', '/PID', String(pid)], {
+      detached: false,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    await waitForProcessClose(taskkill, taskkillWaitMs);
+  } catch {
+    try {
+      process.kill(pid);
+    } catch {
+      // Process may already be gone.
+    }
+  }
+}
+
+export function createWslSandboxBashOperations(
+  distro: string,
+  options: WslSandboxBashOperationsOptions = {}
+): BashOperations {
+  const spawnProcess = options.spawnProcess ?? createSpawnProcess();
+  const terminationGraceMs = options.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS;
+  const taskkillWaitMs = options.taskkillWaitMs ?? DEFAULT_TASKKILL_WAIT_MS;
+
+  return {
+    exec: (command, cwd, { onData, signal, timeout, env }) =>
+      new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+          reject(new Error('aborted'));
+          return;
+        }
+
+        const escapedCwd = shellEscapePath(cwd);
+        const script = `mkdir -p '${escapedCwd}' 2>/dev/null; cd '${escapedCwd}' || { echo "Working directory does not exist in WSL sandbox: ${cwd}" >&2; exit 1; }; ${command}`;
+
+        log(`[WslSandboxBash] Executing in distro=${distro} cwd=${cwd}`);
+
+        const child = spawnProcess('wsl', ['-d', distro, '-e', 'bash', '-c', script], {
+          detached: false,
+          env: env ?? process.env,
+          stdio: ['ignore', 'pipe', 'pipe'],
+          windowsHide: true,
+        });
+
+        let settled = false;
+        let timedOut = false;
+        let timeoutHandle: NodeJS.Timeout | undefined;
+        let forcedSettleHandle: NodeJS.Timeout | undefined;
+
+        const cleanup = () => {
+          if (timeoutHandle) clearTimeout(timeoutHandle);
+          if (forcedSettleHandle) clearTimeout(forcedSettleHandle);
+          child.stdout?.off('data', onData);
+          child.stderr?.off('data', onData);
+          child.off('close', onClose);
+          child.off('error', onError);
+          signal?.removeEventListener('abort', onAbort);
+        };
+
+        const settleResolve = (value: { exitCode: number | null }) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          resolve(value);
+        };
+
+        const settleReject = (error: Error) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          reject(error);
+        };
+
+        const terminateChild = (reason: 'aborted' | 'timeout') => {
+          if (child.pid) {
+            void killWindowsProcessTree(child.pid, spawnProcess, taskkillWaitMs);
+          } else {
+            try {
+              child.kill();
+            } catch {
+              // Ignore cleanup failures; the close/error path will settle or the grace timer will.
+            }
+          }
+
+          forcedSettleHandle = setTimeout(() => {
+            settleReject(
+              reason === 'timeout' ? new Error(`timeout:${timeout}`) : new Error('aborted')
+            );
+          }, terminationGraceMs);
+          forcedSettleHandle.unref?.();
+        };
+
+        function onClose(code: number | null) {
+          if (signal?.aborted) {
+            settleReject(new Error('aborted'));
+            return;
+          }
+          if (timedOut) {
+            settleReject(new Error(`timeout:${timeout}`));
+            return;
+          }
+          settleResolve({ exitCode: code });
+        }
+
+        function onError(error: Error) {
+          settleReject(error);
+        }
+
+        function onAbort() {
+          terminateChild('aborted');
+        }
+
+        child.stdout?.on('data', onData);
+        child.stderr?.on('data', onData);
+        child.once('close', onClose);
+        child.once('error', onError);
+
+        if (timeout !== undefined && timeout > 0) {
+          timeoutHandle = setTimeout(() => {
+            timedOut = true;
+            terminateChild('timeout');
+          }, timeout * 1000);
+          timeoutHandle.unref?.();
+        }
+
+        signal?.addEventListener('abort', onAbort, { once: true });
+      }),
+  };
+}

--- a/src/main/agent/wsl-sandbox-bash-operations.ts
+++ b/src/main/agent/wsl-sandbox-bash-operations.ts
@@ -105,6 +105,15 @@ export function createWslSandboxBashOperations(
         }
 
         const escapedCwd = shellEscapePath(cwd);
+        // `command` is intentionally NOT escaped here. It is executable bash source
+        // provided by the coding agent's bash tool, not untrusted data being embedded
+        // into a fixed template - the caller already has full command execution via
+        // this exact argument, so there is no lesser-privileged boundary for escaping
+        // to protect. Only `cwd` (plain data, not shell syntax) is escaped, via
+        // shellEscapePath above, so it can be safely wrapped in single quotes. Applying
+        // string-escaping to `command` itself would corrupt any legitimate command that
+        // contains its own quoting (e.g. `git commit -m "..."`, `echo 'text'`), breaking
+        // normal usage without adding any real protection.
         const script = `mkdir -p '${escapedCwd}' 2>/dev/null; cd '${escapedCwd}' || { echo "Working directory does not exist in WSL sandbox: ${cwd}" >&2; exit 1; }; ${command}`;
 
         log(`[WslSandboxBash] Executing in distro=${validatedDistro} cwd=${cwd}`);

--- a/src/main/agent/wsl-sandbox-bash-operations.ts
+++ b/src/main/agent/wsl-sandbox-bash-operations.ts
@@ -21,6 +21,24 @@ function createSpawnProcess(): SpawnProcess {
   return (command, args, options) => spawn(command, args, options);
 }
 
+/**
+ * Validate a WSL distro name before it reaches a spawned command line.
+ * Mirrors WSLBridge.validateDistroName (kept local to avoid a cross-module
+ * private dependency - that method is private to the WSLBridge class).
+ *
+ * In the current call path `distro` always comes from WSLBridge's own
+ * detected `wslStatus.distro` (see agent-runner.ts), not from any external
+ * or user-supplied input, so this is defense-in-depth rather than a fix for
+ * a reachable injection today - but it's cheap insurance against this
+ * function being reused from a call site where that stops being true.
+ */
+function validateDistroName(distro: string): string {
+  if (!/^[a-zA-Z0-9\-_.]+$/.test(distro)) {
+    throw new Error(`Invalid WSL distro name: ${distro}`);
+  }
+  return distro;
+}
+
 async function waitForProcessClose(child: ChildProcess, timeoutMs: number): Promise<void> {
   await new Promise<void>((resolve) => {
     let settled = false;
@@ -73,6 +91,7 @@ export function createWslSandboxBashOperations(
   distro: string,
   options: WslSandboxBashOperationsOptions = {}
 ): BashOperations {
+  const validatedDistro = validateDistroName(distro);
   const spawnProcess = options.spawnProcess ?? createSpawnProcess();
   const terminationGraceMs = options.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS;
   const taskkillWaitMs = options.taskkillWaitMs ?? DEFAULT_TASKKILL_WAIT_MS;
@@ -88,9 +107,9 @@ export function createWslSandboxBashOperations(
         const escapedCwd = shellEscapePath(cwd);
         const script = `mkdir -p '${escapedCwd}' 2>/dev/null; cd '${escapedCwd}' || { echo "Working directory does not exist in WSL sandbox: ${cwd}" >&2; exit 1; }; ${command}`;
 
-        log(`[WslSandboxBash] Executing in distro=${distro} cwd=${cwd}`);
+        log(`[WslSandboxBash] Executing in distro=${validatedDistro} cwd=${cwd}`);
 
-        const child = spawnProcess('wsl', ['-d', distro, '-e', 'bash', '-c', script], {
+        const child = spawnProcess('wsl', ['-d', validatedDistro, '-e', 'bash', '-c', script], {
           detached: false,
           env: env ?? process.env,
           stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/main/agent/wsl-sandbox-bash-operations.ts
+++ b/src/main/agent/wsl-sandbox-bash-operations.ts
@@ -198,6 +198,12 @@ export function createWslSandboxBashOperations(
         child.once('close', onClose);
         child.once('error', onError);
 
+        // `timeout` is in seconds, matching @mariozechner/pi-coding-agent's own
+        // BashOperations contract (see node_modules/@mariozechner/pi-coding-agent/dist/
+        // core/tools/bash.js's schema: `Type.Number({ description: "Timeout in seconds
+        // (optional, no default timeout)" })`), and its own createLocalBashOperations()
+        // does the same `timeout * 1000` conversion this code does - so this is not a
+        // unit mismatch, it mirrors the SDK's documented and implemented convention.
         if (timeout !== undefined && timeout > 0) {
           timeoutHandle = setTimeout(() => {
             timedOut = true;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -43,7 +43,7 @@ import { runConfigApiTest } from './config/config-test-routing';
 import { listOllamaModels } from './config/ollama-api';
 import { setPermissionRules, decidePermission } from './config/permission-rules-store';
 import { mcpConfigStore } from './mcp/mcp-config-store';
-import { getSandboxAdapter, shutdownSandbox } from './sandbox/sandbox-adapter';
+import { getSandboxAdapter, initializeSandbox, shutdownSandbox } from './sandbox/sandbox-adapter';
 import { SandboxSync } from './sandbox/sandbox-sync';
 import { WSLBridge } from './sandbox/wsl-bridge';
 import { LimaBridge } from './sandbox/lima-bridge';
@@ -2405,6 +2405,26 @@ ipcMain.on('window.close', () => {
 ipcMain.handle('sandbox.getStatus', async () => {
   try {
     const adapter = getSandboxAdapter();
+
+    // The adapter only initializes lazily, the first time a session actually needs the
+    // sandbox (see SessionManager.ensureSandboxInitialized). If the user checks Settings
+    // before that has ever happened, adapter.initialized is still false, and this handler
+    // used to report a hardcoded 'native'/'none' placeholder below - even when WSL2 itself
+    // is working fine. Trigger (or wait for) real initialization here so the status shown
+    // reflects reality instead of "nothing has tried yet". skipInstallPrompts avoids
+    // popping a Node-install dialog just from opening the Settings tab.
+    if (!adapter.initialized) {
+      try {
+        await initializeSandbox({
+          workspacePath: currentWorkingDir || app.getPath('userData'),
+          mainWindow: null,
+          skipInstallPrompts: true,
+        });
+      } catch (initError) {
+        logError('[Sandbox] On-demand initialization for status check failed:', initError);
+      }
+    }
+
     const platform = process.platform;
 
     if (platform === 'win32') {

--- a/src/main/sandbox/sandbox-adapter.ts
+++ b/src/main/sandbox/sandbox-adapter.ts
@@ -161,14 +161,26 @@ export class SandboxAdapter implements SandboxExecutor {
   private async initializeWSL(config: SandboxAdapterConfig): Promise<void> {
     log('[SandboxAdapter] Checking WSL2 availability...');
 
-    // Try to use cached status from bootstrap first (much faster)
+    // Wait for the app-wide sandbox bootstrap rather than just peeking at its cache.
+    // The bootstrap (which drives the "Setting Up Sandbox" startup popup) and this
+    // adapter used to run their OWN independent WSL checks whenever the bootstrap
+    // hadn't finished yet. Two concurrent "wsl -d <distro>" probes at cold-start could
+    // resolve differently (one timing out, one succeeding once the VM woke up), leaving
+    // this adapter permanently stuck on whatever it saw first - even after the popup
+    // went on to report success. Awaiting bootstrap.bootstrap() guarantees both places
+    // agree on a single, shared result. bootstrap.bootstrap() is idempotent, so this is
+    // a no-op await if it already completed, and just joins the in-flight check if not.
     const bootstrap = getSandboxBootstrap();
-    let wslStatus = bootstrap.getCachedWSLStatus();
-
-    if (wslStatus) {
-      log('[SandboxAdapter] Using cached WSL status from bootstrap');
-    } else {
-      log('[SandboxAdapter] No cached status, checking WSL...');
+    let wslStatus: WSLStatus;
+    try {
+      const bootstrapResult = await bootstrap.bootstrap();
+      wslStatus =
+        bootstrapResult.wslStatus ??
+        bootstrap.getCachedWSLStatus() ??
+        (await WSLBridge.checkWSLStatus());
+      log('[SandboxAdapter] Using WSL status from shared bootstrap check');
+    } catch (error) {
+      log('[SandboxAdapter] Bootstrap check failed, falling back to a direct WSL check:', error);
       wslStatus = await WSLBridge.checkWSLStatus();
     }
 

--- a/src/main/sandbox/wsl-bridge.ts
+++ b/src/main/sandbox/wsl-bridge.ts
@@ -333,20 +333,35 @@ export class WSLBridge implements SandboxExecutor {
    * Test if WSL distro is working (can execute simple command)
    */
   static async testDistro(distro: string): Promise<boolean> {
-    try {
-      WSLBridge.validateDistroName(distro);
-      const { stdout } = await execFileAsync('wsl', ['-d', distro, '-e', 'echo', 'OK'], {
-        timeout: 10000,
-        encoding: 'utf-8',
-      });
-      return stdout.trim() === 'OK';
-    } catch (error) {
-      const errMsg = (error as Error).message || '';
-      if (errMsg.includes('E_UNEXPECTED') || errMsg.includes('4294967295')) {
-        log('[WSL] Distro test failed - WSL service error. Try: wsl --shutdown');
+    const attemptOnce = async (): Promise<boolean> => {
+      try {
+        WSLBridge.validateDistroName(distro);
+        const { stdout } = await execFileAsync('wsl', ['-d', distro, '-e', 'echo', 'OK'], {
+          timeout: 10000,
+          encoding: 'utf-8',
+        });
+        return stdout.trim() === 'OK';
+      } catch (error) {
+        const errMsg = (error as Error).message || '';
+        if (errMsg.includes('E_UNEXPECTED') || errMsg.includes('4294967295')) {
+          log('[WSL] Distro test failed - WSL service error. Try: wsl --shutdown');
+        }
+        return false;
       }
-      return false;
+    };
+
+    if (await attemptOnce()) {
+      return true;
     }
+
+    // The WSL2 lightweight VM is often not running yet the first time it's used after
+    // a reboot or after being idled out by Windows. That first "wsl -d <distro>" call
+    // can transiently fail or time out while the VM cold-starts, even though the distro
+    // is perfectly fine. Retry once after a short delay before reporting unavailable -
+    // this avoids caching a false "WSL not available" result at app startup.
+    log('[WSL] Distro test failed, retrying once in case WSL2 was cold-starting...');
+    await new Promise((resolve) => setTimeout(resolve, 4000));
+    return attemptOnce();
   }
 
   /**

--- a/src/tests/agent/wsl-sandbox-bash-operations.test.ts
+++ b/src/tests/agent/wsl-sandbox-bash-operations.test.ts
@@ -1,0 +1,152 @@
+import { EventEmitter } from 'events';
+import { describe, expect, it, vi } from 'vitest';
+import type { ChildProcess, SpawnOptions } from 'child_process';
+import { createWslSandboxBashOperations } from '../../main/agent/wsl-sandbox-bash-operations';
+
+class FakeChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn();
+
+  constructor(readonly pid?: number) {
+    super();
+  }
+}
+
+function createSpawnMock(children: FakeChildProcess[]) {
+  return vi.fn((command: string, args: string[], _options: SpawnOptions) => {
+    const child = children.shift();
+    if (!child) throw new Error(`Unexpected spawn: ${command} ${args.join(' ')}`);
+    return Object.assign(child, {
+      spawnargs: [command, ...args],
+      spawnfile: command,
+      killed: false,
+      connected: false,
+      exitCode: null,
+      signalCode: null,
+    }) as unknown as ChildProcess;
+  });
+}
+
+describe('wsl sandbox bash operations', () => {
+  it('routes execution through wsl.exe for the configured distro, cd-ing into the sandbox path', async () => {
+    const child = new FakeChildProcess(1234);
+    const spawnProcess = createSpawnMock([child]);
+    const onData = vi.fn();
+    const ops = createWslSandboxBashOperations('Ubuntu', { spawnProcess });
+
+    const promise = ops.exec('echo hello', '/home/user/.claude/sandbox/session-1', {
+      onData,
+      env: { PATH: 'test-path' },
+    });
+    const output = Buffer.from('hello');
+    child.stdout.emit('data', output);
+    child.emit('close', 0);
+
+    await expect(promise).resolves.toEqual({ exitCode: 0 });
+    expect(onData).toHaveBeenCalledWith(output);
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'wsl',
+      [
+        '-d',
+        'Ubuntu',
+        '-e',
+        'bash',
+        '-c',
+        "mkdir -p '/home/user/.claude/sandbox/session-1' 2>/dev/null; cd '/home/user/.claude/sandbox/session-1' || { echo \"Working directory does not exist in WSL sandbox: /home/user/.claude/sandbox/session-1\" >&2; exit 1; }; echo hello",
+      ],
+      expect.objectContaining({
+        detached: false,
+        env: { PATH: 'test-path' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+      })
+    );
+    // Critically: no Windows-side `cwd` option pointing at a path that only
+    // exists inside WSL â€” the cwd is applied via `cd` inside the script instead.
+    expect(spawnProcess.mock.calls[0][2]).not.toHaveProperty('cwd');
+  });
+
+  it('safely escapes single quotes in the sandbox path', async () => {
+    const child = new FakeChildProcess(1234);
+    const spawnProcess = createSpawnMock([child]);
+    const ops = createWslSandboxBashOperations('Ubuntu', { spawnProcess });
+
+    const promise = ops.exec('ls', "/home/o'brien/.claude/sandbox/session-1", {
+      onData: vi.fn(),
+    });
+    child.emit('close', 0);
+    await promise;
+
+    const script = spawnProcess.mock.calls[0][1][5] as string;
+    expect(script).toContain("mkdir -p '/home/o'\\''brien/.claude/sandbox/session-1'");
+    expect(script).toContain("cd '/home/o'\\''brien/.claude/sandbox/session-1'");
+  });
+
+  it('kills the wsl.exe process tree and rejects when a command times out', async () => {
+    vi.useFakeTimers();
+    try {
+      const child = new FakeChildProcess(4321);
+      const taskkill = new FakeChildProcess(9876);
+      const spawnProcess = createSpawnMock([child, taskkill]);
+      const ops = createWslSandboxBashOperations('Ubuntu', {
+        spawnProcess,
+        taskkillWaitMs: 10,
+        terminationGraceMs: 10,
+      });
+
+      const promise = ops.exec('sleep 100', '/home/user/.claude/sandbox/session-1', {
+        onData: vi.fn(),
+        timeout: 1,
+      });
+      const result = promise.then(
+        () => undefined,
+        (error: Error) => error
+      );
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(spawnProcess).toHaveBeenNthCalledWith(
+        2,
+        'taskkill',
+        ['/F', '/T', '/PID', '4321'],
+        expect.objectContaining({
+          detached: false,
+          stdio: 'ignore',
+          windowsHide: true,
+        })
+      );
+
+      taskkill.emit('close', 0);
+      child.emit('close', null);
+
+      await expect(result).resolves.toMatchObject({ message: 'timeout:1' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects synchronously without spawning when the distro name is invalid', () => {
+    const spawnProcess = createSpawnMock([]);
+
+    expect(() => createWslSandboxBashOperations('Ubuntu; rm -rf /', { spawnProcess })).toThrow(
+      'Invalid WSL distro name'
+    );
+    expect(spawnProcess).not.toHaveBeenCalled();
+  });
+
+  it('rejects immediately without spawning when the signal is already aborted', async () => {
+    const spawnProcess = createSpawnMock([]);
+    const ops = createWslSandboxBashOperations('Ubuntu', { spawnProcess });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      ops.exec('echo nope', '/home/user/.claude/sandbox/session-1', {
+        onData: vi.fn(),
+        signal: controller.signal,
+      })
+    ).rejects.toThrow('aborted');
+    expect(spawnProcess).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/sandbox/wsl-bridge-test-distro.test.ts
+++ b/src/tests/sandbox/wsl-bridge-test-distro.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { promisify } from 'util';
+
+// child_process.execFile is used via `promisify(execFile)` in wsl-bridge.ts. Node's
+// real execFile defines `[util.promisify.custom]` to resolve `{ stdout, stderr }`
+// directly rather than going through the plain (err, stdout, stderr) callback
+// convention, so the cleanest way to mock it is to provide that same custom hook -
+// promisify() then just returns our mock function as-is.
+//
+// vi.mock factories are hoisted above all other module code, so the mock function
+// itself has to be created via vi.hoisted() rather than a plain top-level const -
+// otherwise referencing it inside the factory throws a "before initialization" error.
+const { execFileCustomMock } = vi.hoisted(() => ({ execFileCustomMock: vi.fn() }));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  const execFileMock = vi.fn() as unknown as typeof actual.execFile & Record<PropertyKey, unknown>;
+  execFileMock[promisify.custom as unknown as PropertyKey] = execFileCustomMock;
+  return { ...actual, execFile: execFileMock };
+});
+
+import { WSLBridge } from '../../main/sandbox/wsl-bridge';
+
+describe('WSLBridge.testDistro cold-start retry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    execFileCustomMock.mockReset();
+  });
+
+  it('returns true immediately when the first probe succeeds', async () => {
+    execFileCustomMock.mockResolvedValueOnce({ stdout: 'OK\n', stderr: '' });
+
+    await expect(WSLBridge.testDistro('Ubuntu')).resolves.toBe(true);
+    expect(execFileCustomMock).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
+  it('retries once after the cold-start delay when the first probe fails, then succeeds', async () => {
+    execFileCustomMock
+      .mockRejectedValueOnce(new Error('wsl service error'))
+      .mockResolvedValueOnce({ stdout: 'OK\n', stderr: '' });
+
+    const resultPromise = WSLBridge.testDistro('Ubuntu');
+
+    // Let the first (failing) attempt's promise chain settle, then advance past
+    // the 4s cold-start retry delay so the second attempt fires.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(4000);
+
+    await expect(resultPromise).resolves.toBe(true);
+    expect(execFileCustomMock).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it('returns false if both the initial probe and the retry fail', async () => {
+    execFileCustomMock
+      .mockRejectedValueOnce(new Error('wsl service error'))
+      .mockRejectedValueOnce(new Error('still failing'));
+
+    const resultPromise = WSLBridge.testDistro('Ubuntu');
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(4000);
+
+    await expect(resultPromise).resolves.toBe(false);
+    expect(execFileCustomMock).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it('returns false for an invalid distro name without ever calling execFile', async () => {
+    const resultPromise = WSLBridge.testDistro('bad; name');
+    // Invalid-name failures still go through the same retry-once path (the
+    // validation error is caught inside attemptOnce), so advance past the delay.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(4000);
+
+    await expect(resultPromise).resolves.toBe(false);
+    expect(execFileCustomMock).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
fix: wsl2 sandbox bash execution reliability on Windows

Four stacked issues were together causing bash tool calls to always fail
under Windows/WSL2 sandbox mode with "Working directory does not exist:
/workspace / Cannot execute bash commands." even when Settings correctly
reported WSL2 as ready.

1. WSLBridge.testDistro() made a single WSL echo probe with no retry.
   WSL2's lightweight VM can be cold/dormant on first use after boot or
   idle, causing a transient false negative that got cached as "WSL
   unavailable" for the rest of the app session. Now retries once after
   a short delay before giving up.

2. SandboxAdapter.initializeWSL() ran its own independent WSL status
   check instead of using the shared SandboxBootstrap check that drives
   the startup popup. Two concurrent checks at cold start could
   disagree, leaving the adapter stuck on a stale result even after the
   popup reported success. Now awaits the shared bootstrap instead of
   racing it.

3. The Settings sandbox.getStatus IPC handler never triggered adapter
   initialization, so checking Settings before starting any chat
   session always showed a hardcoded placeholder (Native/none)
   regardless of real WSL2 status. Now triggers on-demand
   initialization.

4. Root cause of the actual execution failure: @mariozechner/pi-coding-agent's
   createAgentSession() only reads tool names off the tools option to
   build an allow-list, then discards the actual Tool objects and
   rebuilds default (non-WSL) bash operations internally via
   createAllTools(cwd, ...). This silently dropped the WSL-routed bash
   operations (which cd into the sandbox path inside the WSL distro) on
   every single turn, regardless of session cache state, and fell back
   to the SDK's plain existsSync-based local bash operations, which
   then always failed because the sandbox path is a WSL-side path that
   does not exist on the Windows host. Fixed via a patch-package patch
   that additionally threads the real tool objects through as
   AgentSession's baseToolsOverride.

Verified via production logs: after this fix, the WslSandboxBash
executing-in-distro log line now actually fires, and bash commands
return real output from the synced sandbox filesystem instead of the
generic error.

Separate from #293, which fixes the missing sandbox enable/disable
toggle and Linux status detection - that PR addresses whether sandbox
mode can be turned on at all; this one addresses whether commands
actually execute correctly once it is.