### PR TITLE
fix(gemini): preserve SDK module boundary in Electron

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -17,6 +17,8 @@ files:
   - node_modules/@img/**/*
   - node_modules/better-sqlite3/**/*
   - node_modules/@anthropic-ai/sdk/**/*
+  # Externalized from the Electron main bundle; keep the runtime package in installers.
+  - node_modules/@google/genai/**/*
   - node_modules/@larksuiteoapi/**/*
   - node_modules/openai/**/*
   - node_modules/@modelcontextprotocol/**/*

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -178,6 +178,31 @@ function sanitizeDiagnosticBaseUrl(value: string | undefined): string | null {
   }
 }
 
+async function verifyGeminiRuntimeForSmokeTest(): Promise<void> {
+  const { completeSimple, getModel } = await import('@mariozechner/pi-ai');
+  const model = getModel('google', 'gemini-2.5-flash');
+  if (!model) {
+    throw new Error('Gemini smoke-test model is missing from the pi-ai registry');
+  }
+
+  // Abort before dispatch so this loads the packaged Gemini provider and SDK
+  // without sending a network request or requiring a real API key.
+  const controller = new AbortController();
+  controller.abort();
+  const result = await completeSimple(
+    model,
+    {
+      systemPrompt: 'smoke',
+      messages: [{ role: 'user', content: 'smoke', timestamp: Date.now() }],
+    },
+    { apiKey: 'smoke-test-key', signal: controller.signal }
+  );
+
+  if (result.stopReason !== 'aborted') {
+    throw new Error(`Gemini provider smoke test returned ${result.stopReason}`);
+  }
+}
+
 async function resolveScheduledTaskTitle(
   prompt: string,
   _cwd?: string,
@@ -850,6 +875,13 @@ app
         log('[SmokeTest] better-sqlite3: OK');
       } catch (e) {
         log('[SmokeTest] FAIL: better-sqlite3 failed to load:', e);
+        process.exit(1);
+      }
+      try {
+        await verifyGeminiRuntimeForSmokeTest();
+        log('[SmokeTest] Gemini provider runtime: OK');
+      } catch (e) {
+        log('[SmokeTest] FAIL: Gemini provider runtime failed to load:', e);
         process.exit(1);
       }
       log('[SmokeTest] PASSED');

--- a/tests/vite-config-google-genai.test.ts
+++ b/tests/vite-config-google-genai.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const viteConfig = readFileSync(path.resolve(process.cwd(), 'vite.config.ts'), 'utf8');
+const builderConfig = readFileSync(path.resolve(process.cwd(), 'electron-builder.yml'), 'utf8');
+
+describe('Gemini Electron runtime packaging', () => {
+  it('keeps @google/genai external to the main-process bundle', () => {
+    expect(viteConfig).toContain(
+      "const googleGenAiExternals = ['@google/genai', /^@google\\/genai\\//]"
+    );
+    expect(viteConfig).toContain('...googleGenAiExternals');
+  });
+
+  it('ships the externalized SDK in packaged applications', () => {
+    expect(builderConfig).toContain('- node_modules/@google/genai/**/*');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,9 @@ import { builtinModules } from 'module';
 
 // Node built-in modules must be external for Electron main process
 const nodeBuiltins = builtinModules.flatMap((m) => [m, `node:${m}`]);
+// Keep the SDK's module boundary: bundling it makes Rollup's CJS namespace
+// helper crash on inherited enumerable exports from the external `ws` package.
+const googleGenAiExternals = ['@google/genai', /^@google\/genai\//];
 const ignoredWatchPaths = [
   '**/release/**',
   '**/dist/**',
@@ -30,6 +33,7 @@ export default defineConfig({
             rollupOptions: {
               external: [
                 ...nodeBuiltins,
+                ...googleGenAiExternals,
                 'better-sqlite3',
                 'bufferutil',
                 'utf-8-validate',


### PR DESCRIPTION
## Summary

- Keep `@google/genai` external to the Electron main-process bundle so Node loads the SDK through its native CJS module boundary.
- Explicitly include the externalized SDK in packaged applications.
- Extend the packaged-app smoke test to load the real Gemini provider path without issuing a network request.

## Root cause

The release bundle inlined `@google/genai` while leaving `ws` external. Rollup's generated CommonJS namespace helper enumerated an inherited export from `ws`, then tried to read `.get` from a missing own-property descriptor. This produced `Cannot read properties of undefined (reading 'get')` before any Gemini request was sent, which is why API keys, credits, networks, and model switching could not resolve the failure.

## Validation

- `npx vitest run tests/vite-config-google-genai.test.ts src/tests/config/api-diagnostics.test.ts tests/claude-sdk-one-shot.test.ts tests/pi-model-resolution.test.ts` (47 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; 8 existing warnings)
- `npx vite build`
- Windows unpacked build contains `@google/genai` and its runtime dependencies
- Packaged `Open Cowork.exe --smoke-test` passes, including `Gemini provider runtime: OK`

Fixes #299