### PR TITLE
feat(schedule): add HTTP reactive polling for scheduled tasks

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -101,6 +101,10 @@ export interface ScheduledTaskRow {
   run_at: number;
   next_run_at: number | null;
   schedule_config: string | null;
+  watch_config?: string | null;
+  last_state?: string | null;
+  last_checked_at?: number | null;
+  consecutive_unchanged?: number;
   repeat_every: number | null;
   repeat_unit: string | null;
   enabled: number;
@@ -216,7 +220,7 @@ function getDatabasePath(): string {
 /**
  * Initialize the database schema
  */
-function initializeSchema(database: Database.Database): void {
+export function initializeSchema(database: Database.Database): void {
   try {
     // Enable WAL mode for better performance
     database.pragma('journal_mode = WAL');
@@ -330,6 +334,10 @@ function initializeSchema(database: Database.Database): void {
       run_at INTEGER NOT NULL,
       next_run_at INTEGER,
       schedule_config TEXT,
+      watch_config TEXT,
+      last_state TEXT,
+      last_checked_at INTEGER,
+      consecutive_unchanged INTEGER NOT NULL DEFAULT 0,
       repeat_every INTEGER,
       repeat_unit TEXT,
       enabled INTEGER NOT NULL DEFAULT 1,
@@ -341,6 +349,15 @@ function initializeSchema(database: Database.Database): void {
     )
   `);
     ensureColumn(database, 'scheduled_tasks', 'schedule_config', 'schedule_config TEXT');
+    ensureColumn(database, 'scheduled_tasks', 'watch_config', 'watch_config TEXT');
+    ensureColumn(database, 'scheduled_tasks', 'last_state', 'last_state TEXT');
+    ensureColumn(database, 'scheduled_tasks', 'last_checked_at', 'last_checked_at INTEGER');
+    ensureColumn(
+      database,
+      'scheduled_tasks',
+      'consecutive_unchanged',
+      'consecutive_unchanged INTEGER NOT NULL DEFAULT 0'
+    );
 
     database.exec(`
     CREATE INDEX IF NOT EXISTS idx_scheduled_tasks_next_run
@@ -491,9 +508,9 @@ export function initDatabase(): DatabaseInstance {
 
   const insertScheduledTask = rawDb.prepare(`
     INSERT OR REPLACE INTO scheduled_tasks (
-      id, title, prompt, cwd, run_at, next_run_at, schedule_config, repeat_every, repeat_unit, enabled, last_run_at, last_run_session_id, last_error, created_at, updated_at
+      id, title, prompt, cwd, run_at, next_run_at, schedule_config, watch_config, last_state, last_checked_at, consecutive_unchanged, repeat_every, repeat_unit, enabled, last_run_at, last_run_session_id, last_error, created_at, updated_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   const getScheduledTaskStmt = rawDb.prepare(`
@@ -659,6 +676,10 @@ export function initDatabase(): DatabaseInstance {
           task.run_at,
           task.next_run_at,
           task.schedule_config,
+          task.watch_config ?? null,
+          task.last_state ?? null,
+          task.last_checked_at ?? null,
+          task.consecutive_unchanged ?? 0,
           task.repeat_every,
           task.repeat_unit,
           task.enabled,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -68,6 +68,8 @@ import {
   type ScheduledTaskUpdateInput,
 } from './schedule/scheduled-task-manager';
 import { createScheduledTaskStore } from './schedule/scheduled-task-store';
+import { HttpConditionChecker } from './schedule/http-condition-checker';
+import type { HttpWatchConfig } from '../shared/schedule/watch-task';
 import {
   buildScheduledTaskFallbackTitle,
   buildScheduledTaskTitle,
@@ -133,6 +135,9 @@ let skillsManager: SkillsManager | null = null;
 let pluginRuntimeService: PluginRuntimeService | null = null;
 let memoryService: MemoryService | null = null;
 let scheduledTaskManager: ScheduledTaskManager | null = null;
+const httpConditionChecker = new HttpConditionChecker();
+const checkHttpCondition = (config: HttpWatchConfig): Promise<string> =>
+  httpConditionChecker.check(config);
 
 /**
  * Tool names that a spawned subagent may never invoke, regardless of what
@@ -996,6 +1001,7 @@ app
       const headlessScheduledTaskStore = createScheduledTaskStore(db);
       scheduledTaskManager = new ScheduledTaskManager({
         store: headlessScheduledTaskStore,
+        checkCondition: checkHttpCondition,
         executeTask: async (task) => {
           if (!sessionManager) {
             throw new Error('Session manager not initialized');
@@ -1409,6 +1415,7 @@ app
     const scheduledTaskStore = createScheduledTaskStore(db);
     scheduledTaskManager = new ScheduledTaskManager({
       store: scheduledTaskStore,
+      checkCondition: checkHttpCondition,
       executeTask: async (task) => {
         if (!sessionManager) {
           throw new Error('Session manager not initialized');

--- a/src/main/schedule/http-condition-checker.ts
+++ b/src/main/schedule/http-condition-checker.ts
@@ -1,0 +1,197 @@
+import { createHash } from 'node:crypto';
+import type { HttpWatchConfig } from '../../shared/schedule/watch-task';
+
+export const MAX_HTTP_RESPONSE_BYTES = 1_048_576;
+export const MAX_HTTP_REDIRECTS = 3;
+
+export const HTTP_CONDITION_CHECK_ERROR_CODES = {
+  timeout: 'timeout',
+  request_failed: 'request_failed',
+  request_url_invalid: 'request_url_invalid',
+  request_protocol_unsupported: 'request_protocol_unsupported',
+  redirect_limit_exceeded: 'redirect_limit_exceeded',
+  redirect_location_missing: 'redirect_location_missing',
+  redirect_location_invalid: 'redirect_location_invalid',
+  redirect_protocol_unsupported: 'redirect_protocol_unsupported',
+  response_body_too_large: 'response_body_too_large',
+  response_cleanup_failed: 'response_cleanup_failed',
+} as const;
+
+export type HttpConditionCheckErrorCode =
+  (typeof HTTP_CONDITION_CHECK_ERROR_CODES)[keyof typeof HTTP_CONDITION_CHECK_ERROR_CODES];
+
+const ERROR_MESSAGES: Record<HttpConditionCheckErrorCode, string> = {
+  timeout: 'HTTP condition check timed out.',
+  request_failed: 'HTTP condition check request failed.',
+  request_url_invalid: 'HTTP condition check URL is invalid.',
+  request_protocol_unsupported: 'HTTP condition check URL must use HTTP or HTTPS.',
+  redirect_limit_exceeded: 'HTTP condition check exceeded the redirect limit.',
+  redirect_location_missing: 'HTTP condition check redirect is missing Location.',
+  redirect_location_invalid: 'HTTP condition check redirect Location is invalid.',
+  redirect_protocol_unsupported: 'HTTP condition check redirect must use HTTP or HTTPS.',
+  response_body_too_large: 'HTTP condition check response body exceeds 1048576 bytes.',
+  response_cleanup_failed: 'HTTP condition check could not discard a response body.',
+};
+
+export class HttpConditionCheckError extends Error {
+  readonly name = 'HttpConditionCheckError';
+
+  constructor(
+    readonly code: HttpConditionCheckErrorCode,
+    options?: ErrorOptions
+  ) {
+    super(ERROR_MESSAGES[code], options);
+  }
+}
+
+export interface ConditionChecker {
+  check(config: HttpWatchConfig): Promise<string>;
+}
+
+export class HttpConditionChecker implements ConditionChecker {
+  async check(config: HttpWatchConfig): Promise<string> {
+    const controller = new AbortController();
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, config.checkConfig.timeoutMs);
+
+    try {
+      return await checkHttpCondition(config, controller.signal);
+    } catch (error) {
+      if (timedOut) {
+        throw new HttpConditionCheckError('timeout', { cause: error });
+      }
+      if (error instanceof HttpConditionCheckError) {
+        throw error;
+      }
+      throw new HttpConditionCheckError('request_failed', { cause: error });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+async function checkHttpCondition(config: HttpWatchConfig, signal: AbortSignal): Promise<string> {
+  let currentUrl = parseRequestUrl(config.checkConfig.url);
+  let redirectsFollowed = 0;
+
+  for (;;) {
+    const response = await fetch(currentUrl, {
+      method: config.checkConfig.method,
+      redirect: 'manual',
+      signal,
+    });
+
+    if (isRedirectStatus(response.status)) {
+      await discardResponseBody(response);
+      if (redirectsFollowed === MAX_HTTP_REDIRECTS) {
+        throw new HttpConditionCheckError('redirect_limit_exceeded');
+      }
+
+      const location = response.headers.get('location');
+      if (location === null) {
+        throw new HttpConditionCheckError('redirect_location_missing');
+      }
+
+      currentUrl = parseRedirectUrl(location, currentUrl);
+      redirectsFollowed += 1;
+      continue;
+    }
+
+    if (config.compareMode === 'status') {
+      await discardResponseBody(response);
+      return String(response.status);
+    }
+
+    return hashResponseBody(response);
+  }
+}
+
+function parseRequestUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new HttpConditionCheckError('request_url_invalid', { cause: error });
+    }
+    throw error;
+  }
+  if (!isHttpUrl(url)) {
+    throw new HttpConditionCheckError('request_protocol_unsupported');
+  }
+  return url;
+}
+
+function parseRedirectUrl(location: string, currentUrl: URL): URL {
+  let redirectUrl: URL;
+  try {
+    redirectUrl = new URL(location, currentUrl);
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new HttpConditionCheckError('redirect_location_invalid', { cause: error });
+    }
+    throw error;
+  }
+  if (!isHttpUrl(redirectUrl)) {
+    throw new HttpConditionCheckError('redirect_protocol_unsupported');
+  }
+  return redirectUrl;
+}
+
+function isHttpUrl(url: URL): boolean {
+  return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+function isRedirectStatus(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+async function discardResponseBody(response: Response): Promise<void> {
+  if (response.body === null) {
+    return;
+  }
+  try {
+    await response.body.cancel();
+  } catch (error) {
+    throw new HttpConditionCheckError('response_cleanup_failed', { cause: error });
+  }
+}
+
+async function hashResponseBody(response: Response): Promise<string> {
+  const hash = createHash('sha256');
+  const body = response.body;
+  if (body === null) {
+    return hash.digest('hex');
+  }
+
+  const reader = body.getReader();
+  let completed = false;
+  let bytesRead = 0;
+
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        completed = true;
+        return hash.digest('hex');
+      }
+
+      bytesRead += chunk.value.byteLength;
+      if (bytesRead > MAX_HTTP_RESPONSE_BYTES) {
+        throw new HttpConditionCheckError('response_body_too_large');
+      }
+      hash.update(chunk.value);
+    }
+  } finally {
+    try {
+      if (!completed) {
+        await reader.cancel();
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}

--- a/src/main/schedule/scheduled-task-manager.ts
+++ b/src/main/schedule/scheduled-task-manager.ts
@@ -15,6 +15,12 @@ import {
   buildScheduledTaskFallbackTitle,
   buildScheduledTaskTitle,
 } from '../../shared/schedule/task-title';
+import {
+  areHttpWatchConfigsEqual,
+  normalizeWatchConfig,
+  type HttpWatchConfig,
+  type HttpWatchConfigInput,
+} from '../../shared/schedule/watch-task';
 import { log, logError } from '../utils/logger';
 
 export type ScheduleRepeatUnit = 'minute' | 'hour' | 'day';
@@ -49,6 +55,11 @@ export interface ScheduledTask {
   lastRunAt: number | null;
   lastRunSessionId: string | null;
   lastError: string | null;
+  watchConfig: HttpWatchConfig | null;
+  watchConfigError: string | null;
+  lastState: string | null;
+  lastCheckedAt: number | null;
+  consecutiveUnchanged: number;
   createdAt: number;
   updatedAt: number;
 }
@@ -60,6 +71,7 @@ export interface ScheduledTaskCreateInput {
   runAt: number;
   nextRunAt?: number | null;
   scheduleConfig?: ScheduledTaskScheduleConfig | null;
+  watchConfig?: HttpWatchConfigInput | null;
   repeatEvery?: number | null;
   repeatUnit?: ScheduleRepeatUnit | null;
   enabled?: boolean;
@@ -72,6 +84,7 @@ export interface ScheduledTaskUpdateInput {
   runAt?: number;
   nextRunAt?: number | null;
   scheduleConfig?: ScheduledTaskScheduleConfig | null;
+  watchConfig?: HttpWatchConfigInput | null;
   repeatEvery?: number | null;
   repeatUnit?: ScheduleRepeatUnit | null;
   enabled?: boolean;
@@ -80,11 +93,19 @@ export interface ScheduledTaskUpdateInput {
   lastError?: string | null;
 }
 
+export type ScheduledTaskStoreCreateInput = ScheduledTaskCreateInput;
+
+export interface ScheduledTaskStoreUpdateInput extends ScheduledTaskUpdateInput {
+  lastState?: string | null;
+  lastCheckedAt?: number | null;
+  consecutiveUnchanged?: number;
+}
+
 export interface ScheduledTaskStore {
   list(): ScheduledTask[];
   get(id: string): ScheduledTask | null;
-  create(input: ScheduledTaskCreateInput): ScheduledTask;
-  update(id: string, updates: ScheduledTaskUpdateInput): ScheduledTask | null;
+  create(input: ScheduledTaskStoreCreateInput): ScheduledTask;
+  update(id: string, updates: ScheduledTaskStoreUpdateInput): ScheduledTask | null;
   delete(id: string): boolean;
 }
 
@@ -93,6 +114,7 @@ export interface ScheduledTaskRunResult {
 }
 
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const MIN_WATCH_TASK_INTERVAL_MS = 60_000;
 
 interface ScheduledTaskExecutionRecord {
   success: boolean;
@@ -102,6 +124,7 @@ interface ScheduledTaskExecutionRecord {
 
 interface ScheduledTaskManagerOptions {
   store: ScheduledTaskStore;
+  checkCondition?: (config: HttpWatchConfig) => Promise<string>;
   executeTask: (task: ScheduledTask) => Promise<ScheduledTaskRunResult>;
   onTaskError?: (taskId: string, error: string) => void;
   now?: () => number;
@@ -109,6 +132,7 @@ interface ScheduledTaskManagerOptions {
 
 export class ScheduledTaskManager {
   private readonly store: ScheduledTaskStore;
+  private readonly checkCondition?: (config: HttpWatchConfig) => Promise<string>;
   private readonly executeTask: (task: ScheduledTask) => Promise<ScheduledTaskRunResult>;
   private readonly onTaskError?: (taskId: string, error: string) => void;
   private readonly now: () => number;
@@ -118,6 +142,7 @@ export class ScheduledTaskManager {
 
   constructor(options: ScheduledTaskManagerOptions) {
     this.store = options.store;
+    this.checkCondition = options.checkCondition;
     this.executeTask = options.executeTask;
     this.onTaskError = options.onTaskError;
     this.now = options.now ?? (() => Date.now());
@@ -171,13 +196,23 @@ export class ScheduledTaskManager {
       normalizedScheduleConfig || normalizedRepeatEvery === null
         ? null
         : normalizeRepeatUnit(input.repeatUnit);
+    const normalizedWatchConfig = normalizeWatchConfigInput(input.watchConfig);
+    if (normalizedWatchConfig !== null && normalizedWatchConfig !== undefined) {
+      assertValidWatchTaskSchedule(
+        normalizedScheduleConfig,
+        normalizedRepeatEvery,
+        normalizedRepeatUnit
+      );
+    }
     const created = this.store.create({
-      ...input,
       title: normalizedTitle,
       prompt: normalizedPrompt,
+      cwd: input.cwd,
+      runAt: input.runAt,
       scheduleConfig: normalizedScheduleConfig,
       nextRunAt: input.nextRunAt ?? input.runAt,
       enabled: input.enabled ?? true,
+      watchConfig: normalizedWatchConfig,
       repeatEvery: normalizedRepeatEvery,
       repeatUnit: normalizedRepeatUnit,
     });
@@ -193,34 +228,82 @@ export class ScheduledTaskManager {
       updates.title === undefined
         ? current.title
         : buildScheduledTaskTitle(updates.title || nextPrompt);
-    const nextScheduleConfig =
+    const normalizedScheduleConfig =
       updates.scheduleConfig === undefined
         ? undefined
         : normalizeScheduleConfig(updates.scheduleConfig);
-    const usesScheduleConfig =
-      nextScheduleConfig !== undefined
-        ? nextScheduleConfig !== null
-        : current.scheduleConfig !== null;
-    const nextRepeatEvery = usesScheduleConfig
+    const nextScheduleConfig =
+      normalizedScheduleConfig === undefined ? current.scheduleConfig : normalizedScheduleConfig;
+    const usesScheduleConfig = nextScheduleConfig !== null;
+    const normalizedRepeatEvery = usesScheduleConfig
       ? null
       : updates.repeatEvery === undefined
         ? undefined
         : normalizeRepeatEvery(updates.repeatEvery);
-    let nextRepeatUnit = usesScheduleConfig
+    let normalizedRepeatUnit = usesScheduleConfig
       ? null
       : updates.repeatUnit === undefined
         ? undefined
         : normalizeRepeatUnit(updates.repeatUnit);
-    if (!usesScheduleConfig && nextRepeatEvery !== undefined && nextRepeatEvery === null) {
+    if (
+      !usesScheduleConfig &&
+      normalizedRepeatEvery !== undefined &&
+      normalizedRepeatEvery === null
+    ) {
+      normalizedRepeatUnit = null;
+    }
+    const nextRepeatEvery = usesScheduleConfig
+      ? null
+      : normalizedRepeatEvery === undefined
+        ? current.repeatEvery
+        : normalizedRepeatEvery;
+    let nextRepeatUnit = usesScheduleConfig
+      ? null
+      : normalizedRepeatUnit === undefined
+        ? current.repeatUnit
+        : normalizedRepeatUnit;
+    if (!usesScheduleConfig && nextRepeatEvery === null) {
       nextRepeatUnit = null;
     }
+    const normalizedWatchConfig = normalizeWatchConfigInput(updates.watchConfig);
+    const nextWatchConfig =
+      normalizedWatchConfig === undefined ? current.watchConfig : normalizedWatchConfig;
+    if (nextWatchConfig !== null) {
+      assertValidWatchTaskSchedule(nextScheduleConfig, nextRepeatEvery, nextRepeatUnit);
+    }
+    const resetWatchRuntimeState =
+      normalizedWatchConfig === null
+        ? current.watchConfig !== null || current.watchConfigError !== null
+        : normalizedWatchConfig !== undefined &&
+          (current.watchConfig === null ||
+            !areHttpWatchConfigsEqual(current.watchConfig, normalizedWatchConfig));
     const updated = this.store.update(id, {
-      ...updates,
-      prompt: nextPrompt,
       title: nextTitle,
-      scheduleConfig: nextScheduleConfig,
-      repeatEvery: nextRepeatEvery,
-      repeatUnit: nextRepeatUnit,
+      prompt: nextPrompt,
+      scheduleConfig: normalizedScheduleConfig,
+      repeatEvery: normalizedRepeatEvery,
+      repeatUnit: normalizedRepeatUnit,
+      ...(updates.cwd === undefined ? {} : { cwd: updates.cwd }),
+      ...(updates.runAt === undefined ? {} : { runAt: updates.runAt }),
+      ...(updates.nextRunAt === undefined ? {} : { nextRunAt: updates.nextRunAt }),
+      ...(normalizedWatchConfig === undefined ? {} : { watchConfig: normalizedWatchConfig }),
+      ...(updates.enabled === undefined ? {} : { enabled: updates.enabled }),
+      ...(updates.lastRunAt === undefined ? {} : { lastRunAt: updates.lastRunAt }),
+      ...(updates.lastRunSessionId === undefined
+        ? {}
+        : { lastRunSessionId: updates.lastRunSessionId }),
+      ...(resetWatchRuntimeState
+        ? { lastError: null }
+        : updates.lastError === undefined
+          ? {}
+          : { lastError: updates.lastError }),
+      ...(resetWatchRuntimeState
+        ? {
+            lastState: null,
+            lastCheckedAt: null,
+            consecutiveUnchanged: 0,
+          }
+        : {}),
     });
     if (!updated) return null;
     this.scheduleTask(updated);
@@ -257,7 +340,7 @@ export class ScheduledTaskManager {
     this.executingTasks.add(id);
     const taskToExecute = this.prepareExecution(task);
     try {
-      const execution = await this.executeAndRecord(taskToExecute);
+      const execution = await this.executeTaskPipeline(taskToExecute);
       if (!execution.success) {
         throw new Error(execution.error ?? 'Scheduled task execution failed');
       }
@@ -293,11 +376,20 @@ export class ScheduledTaskManager {
       return;
     }
     if (this.executingTasks.has(taskId)) {
+      if (task.watchConfig !== null || task.watchConfigError !== null) {
+        const nextRunAt = computeNextRunAt(task, this.now());
+        if (nextRunAt !== null) {
+          const updated = this.store.update(task.id, { nextRunAt, enabled: true });
+          if (updated) {
+            this.scheduleTask(updated);
+          }
+        }
+      }
       return;
     }
     this.executingTasks.add(taskId);
     const taskToExecute = this.prepareExecution(task);
-    this.executeAndRecord(taskToExecute)
+    this.executeTaskPipeline(taskToExecute)
       .catch((err) => {
         const errorMessage = err instanceof Error ? err.message : String(err);
         try {
@@ -359,6 +451,126 @@ export class ScheduledTaskManager {
     }
     const base = task.nextRunAt ?? task.runAt ?? now;
     return Math.max(base, now);
+  }
+
+  private async executeTaskPipeline(task: ScheduledTask): Promise<ScheduledTaskExecutionRecord> {
+    if (task.watchConfig !== null) {
+      return this.checkAndExecuteWatchTask(task, task.watchConfig, this.now());
+    }
+    if (task.watchConfigError !== null) {
+      return this.recordWatchTaskCheckFailure(task, this.now(), task.watchConfigError);
+    }
+    return this.executeAndRecord(task);
+  }
+
+  private async checkAndExecuteWatchTask(
+    task: ScheduledTask,
+    config: HttpWatchConfig,
+    checkedAt: number
+  ): Promise<ScheduledTaskExecutionRecord> {
+    if (this.checkCondition === undefined) {
+      return this.recordWatchTaskCheckFailure(
+        task,
+        checkedAt,
+        'WatchTask condition checker is unavailable.'
+      );
+    }
+
+    let currentState: string;
+    try {
+      currentState = await this.checkCondition(config);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return this.recordWatchTaskCheckFailure(task, checkedAt, errorMessage);
+    }
+
+    const stateUpdate = this.buildWatchTaskStateUpdate(task, currentState, checkedAt);
+    const updatedTask = this.persistWatchTaskState(task, stateUpdate.updates);
+    if (updatedTask === null) {
+      return { success: false, error: 'WatchTask state update could not be persisted.' };
+    }
+    if (!stateUpdate.shouldExecute) {
+      return { success: true };
+    }
+    return this.executeAndRecord(updatedTask);
+  }
+
+  private buildWatchTaskStateUpdate(
+    task: ScheduledTask,
+    currentState: string,
+    checkedAt: number
+  ): {
+    readonly shouldExecute: boolean;
+    readonly updates: ScheduledTaskStoreUpdateInput;
+  } {
+    if (task.lastState === null) {
+      return {
+        shouldExecute: false,
+        updates: {
+          lastState: currentState,
+          lastCheckedAt: checkedAt,
+          consecutiveUnchanged: 0,
+          lastError: null,
+        },
+      };
+    }
+    if (task.lastState === currentState) {
+      return {
+        shouldExecute: false,
+        updates: {
+          lastCheckedAt: checkedAt,
+          consecutiveUnchanged: task.consecutiveUnchanged + 1,
+          lastError: null,
+        },
+      };
+    }
+    return {
+      shouldExecute: true,
+      updates: {
+        lastState: currentState,
+        lastCheckedAt: checkedAt,
+        consecutiveUnchanged: 0,
+        lastError: null,
+      },
+    };
+  }
+
+  private recordWatchTaskCheckFailure(
+    task: ScheduledTask,
+    checkedAt: number,
+    error: string
+  ): ScheduledTaskExecutionRecord {
+    const updatedTask = this.persistWatchTaskState(task, {
+      lastCheckedAt: checkedAt,
+      lastError: error,
+    });
+    if (updatedTask === null) {
+      return { success: false, error: 'WatchTask state update could not be persisted.' };
+    }
+    this.reportWatchTaskError(task.id, error);
+    return { success: false, error };
+  }
+
+  private persistWatchTaskState(
+    task: ScheduledTask,
+    updates: ScheduledTaskStoreUpdateInput
+  ): ScheduledTask | null {
+    try {
+      const updatedTask = this.store.update(task.id, updates);
+      if (updatedTask !== null) {
+        return updatedTask;
+      }
+      this.reportWatchTaskError(task.id, 'WatchTask state update returned no task.');
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.reportWatchTaskError(task.id, `WatchTask state update failed: ${errorMessage}`);
+    }
+    return null;
+  }
+
+  private reportWatchTaskError(taskId: string, error: string): void {
+    this.onTaskError?.(taskId, error);
+    logError(`[ScheduledTask] WatchTask check failed for ${taskId}:`, error);
   }
 
   private async executeAndRecord(task: ScheduledTask): Promise<ScheduledTaskExecutionRecord> {
@@ -438,6 +650,32 @@ function normalizeScheduleConfig(
     return { kind: 'weekly', weekdays, times };
   }
   return null;
+}
+
+function normalizeWatchConfigInput(
+  value: HttpWatchConfigInput | null | undefined
+): HttpWatchConfig | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  return normalizeWatchConfig(value);
+}
+
+function assertValidWatchTaskSchedule(
+  scheduleConfig: ScheduledTaskScheduleConfig | null,
+  repeatEvery: number | null,
+  repeatUnit: ScheduleRepeatUnit | null
+): void {
+  if (scheduleConfig !== null) {
+    return;
+  }
+  const intervalMs = getIntervalMs(repeatEvery, repeatUnit);
+  if (intervalMs === null) {
+    throw new Error('WatchTasks require a repeating interval, daily, or weekly schedule.');
+  }
+  if (intervalMs < MIN_WATCH_TASK_INTERVAL_MS) {
+    throw new Error('WatchTask automatic intervals must be at least 60000 ms.');
+  }
 }
 
 function isRepeatingTask(task: ScheduledTask): boolean {

--- a/src/main/schedule/scheduled-task-store.ts
+++ b/src/main/schedule/scheduled-task-store.ts
@@ -1,20 +1,24 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { DatabaseInstance, ScheduledTaskRow } from '../db/database';
+import { normalizeWatchConfig, parsePersistedWatchConfig } from '../../shared/schedule/watch-task';
+import type { HttpWatchConfigInput } from '../../shared/schedule/watch-task';
 import type {
   ScheduledTask,
-  ScheduledTaskCreateInput,
   ScheduledTaskStore,
-  ScheduledTaskUpdateInput,
+  ScheduledTaskStoreCreateInput,
+  ScheduledTaskStoreUpdateInput,
 } from './scheduled-task-manager';
 
-export function createScheduledTaskStore(db: DatabaseInstance): ScheduledTaskStore {
+export type ScheduledTaskDatabase = Pick<DatabaseInstance, 'scheduledTasks'>;
+
+export function createScheduledTaskStore(db: ScheduledTaskDatabase): ScheduledTaskStore {
   return {
     list: () => db.scheduledTasks.getAll().map(mapRowToTask),
     get: (id: string) => {
       const row = db.scheduledTasks.get(id);
       return row ? mapRowToTask(row) : null;
     },
-    create: (input: ScheduledTaskCreateInput) => {
+    create: (input: ScheduledTaskStoreCreateInput) => {
       const now = Date.now();
       const row: ScheduledTaskRow = {
         id: uuidv4(),
@@ -24,6 +28,10 @@ export function createScheduledTaskStore(db: DatabaseInstance): ScheduledTaskSto
         run_at: input.runAt,
         next_run_at: input.nextRunAt ?? input.runAt,
         schedule_config: input.scheduleConfig ? JSON.stringify(input.scheduleConfig) : null,
+        watch_config: serializeWatchConfig(input.watchConfig),
+        last_state: null,
+        last_checked_at: null,
+        consecutive_unchanged: 0,
         repeat_every: input.repeatEvery ?? null,
         repeat_unit: input.repeatUnit ?? null,
         enabled: input.enabled === false ? 0 : 1,
@@ -36,7 +44,7 @@ export function createScheduledTaskStore(db: DatabaseInstance): ScheduledTaskSto
       db.scheduledTasks.create(row);
       return mapRowToTask(row);
     },
-    update: (id: string, updates: ScheduledTaskUpdateInput) => {
+    update: (id: string, updates: ScheduledTaskStoreUpdateInput) => {
       const mapped = mapTaskUpdatesToRow(updates);
       db.scheduledTasks.update(id, mapped);
       const row = db.scheduledTasks.get(id);
@@ -52,6 +60,8 @@ export function createScheduledTaskStore(db: DatabaseInstance): ScheduledTaskSto
 }
 
 function mapRowToTask(row: ScheduledTaskRow): ScheduledTask {
+  const watch = mapPersistedWatchConfig(row.watch_config);
+
   return {
     id: row.id,
     title: row.title,
@@ -66,12 +76,16 @@ function mapRowToTask(row: ScheduledTaskRow): ScheduledTask {
     lastRunAt: row.last_run_at,
     lastRunSessionId: row.last_run_session_id,
     lastError: row.last_error,
+    ...watch,
+    lastState: row.last_state ?? null,
+    lastCheckedAt: row.last_checked_at ?? null,
+    consecutiveUnchanged: row.consecutive_unchanged ?? 0,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
 }
 
-function mapTaskUpdatesToRow(updates: ScheduledTaskUpdateInput): Partial<ScheduledTaskRow> {
+function mapTaskUpdatesToRow(updates: ScheduledTaskStoreUpdateInput): Partial<ScheduledTaskRow> {
   const mapped: Partial<ScheduledTaskRow> = {};
   if (updates.title !== undefined) mapped.title = updates.title;
   if (updates.prompt !== undefined) mapped.prompt = updates.prompt;
@@ -81,13 +95,49 @@ function mapTaskUpdatesToRow(updates: ScheduledTaskUpdateInput): Partial<Schedul
   if (updates.scheduleConfig !== undefined) {
     mapped.schedule_config = updates.scheduleConfig ? JSON.stringify(updates.scheduleConfig) : null;
   }
+  if (updates.watchConfig !== undefined) {
+    mapped.watch_config = serializeWatchConfig(updates.watchConfig);
+  }
   if (updates.repeatEvery !== undefined) mapped.repeat_every = updates.repeatEvery;
   if (updates.repeatUnit !== undefined) mapped.repeat_unit = updates.repeatUnit;
   if (updates.enabled !== undefined) mapped.enabled = updates.enabled ? 1 : 0;
   if (updates.lastRunAt !== undefined) mapped.last_run_at = updates.lastRunAt;
   if (updates.lastRunSessionId !== undefined) mapped.last_run_session_id = updates.lastRunSessionId;
   if (updates.lastError !== undefined) mapped.last_error = updates.lastError;
+  if (updates.lastState !== undefined) mapped.last_state = updates.lastState;
+  if (updates.lastCheckedAt !== undefined) mapped.last_checked_at = updates.lastCheckedAt;
+  if (updates.consecutiveUnchanged !== undefined) {
+    mapped.consecutive_unchanged = updates.consecutiveUnchanged;
+  }
   return mapped;
+}
+
+function serializeWatchConfig(value: HttpWatchConfigInput | null | undefined): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return JSON.stringify(normalizeWatchConfig(value));
+}
+
+function mapPersistedWatchConfig(
+  value: string | null | undefined
+): Pick<ScheduledTask, 'watchConfig' | 'watchConfigError'> {
+  const parsed = parsePersistedWatchConfig(value ?? null);
+
+  switch (parsed.kind) {
+    case 'none':
+      return { watchConfig: null, watchConfigError: null };
+    case 'valid':
+      return { watchConfig: parsed.config, watchConfigError: null };
+    case 'invalid':
+      return { watchConfig: null, watchConfigError: parsed.error };
+    default:
+      return assertNever(parsed);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unexpected persisted watch configuration result: ${String(value)}`);
 }
 
 function parseScheduleConfig(value: string | null): ScheduledTask['scheduleConfig'] {

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -1,3 +1,5 @@
+import type { HttpWatchConfig, HttpWatchConfigInput } from '../../shared/schedule/watch-task';
+
 // Session types
 export interface Session {
   id: string;
@@ -140,12 +142,17 @@ export interface ScheduleTask {
   runAt: number;
   nextRunAt: number | null;
   scheduleConfig: ScheduleConfig | null;
+  watchConfig: HttpWatchConfig | null;
   repeatEvery: number | null;
   repeatUnit: ScheduleRepeatUnit | null;
   enabled: boolean;
   lastRunAt: number | null;
   lastRunSessionId: string | null;
   lastError: string | null;
+  lastState: string | null;
+  lastCheckedAt: number | null;
+  consecutiveUnchanged: number;
+  readonly watchConfigError: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -157,6 +164,7 @@ export interface ScheduleCreateInput {
   runAt: number;
   nextRunAt?: number | null;
   scheduleConfig?: ScheduleConfig | null;
+  watchConfig?: HttpWatchConfigInput | null;
   repeatEvery?: number | null;
   repeatUnit?: ScheduleRepeatUnit | null;
   enabled?: boolean;
@@ -169,6 +177,7 @@ export interface ScheduleUpdateInput {
   runAt?: number;
   nextRunAt?: number | null;
   scheduleConfig?: ScheduleConfig | null;
+  watchConfig?: HttpWatchConfigInput | null;
   repeatEvery?: number | null;
   repeatUnit?: ScheduleRepeatUnit | null;
   enabled?: boolean;

--- a/src/shared/schedule/watch-task-contract.typecheck.ts
+++ b/src/shared/schedule/watch-task-contract.typecheck.ts
@@ -1,0 +1,37 @@
+import type { ScheduleCreateInput, ScheduleTask, ScheduleUpdateInput } from '../../renderer/types';
+import type { HttpWatchConfig, HttpWatchConfigInput } from './watch-task';
+
+export type Assert<T extends true> = T;
+
+type IsEqual<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? (<Value>() => Value extends Right ? 1 : 2) extends <Value>() => Value extends Left ? 1 : 2
+      ? true
+      : false
+    : false;
+
+type RuntimeStateKey = 'lastState' | 'lastCheckedAt' | 'consecutiveUnchanged' | 'watchConfigError';
+type PublicScheduleInputKey = keyof ScheduleCreateInput | keyof ScheduleUpdateInput;
+
+export type ScheduleTaskHasNormalizedWatchConfig = Assert<
+  IsEqual<ScheduleTask['watchConfig'], HttpWatchConfig | null>
+>;
+export type ScheduleTaskHasLastState = Assert<IsEqual<ScheduleTask['lastState'], string | null>>;
+export type ScheduleTaskHasLastCheckedAt = Assert<
+  IsEqual<ScheduleTask['lastCheckedAt'], number | null>
+>;
+export type ScheduleTaskHasConsecutiveUnchanged = Assert<
+  IsEqual<ScheduleTask['consecutiveUnchanged'], number>
+>;
+export type ScheduleTaskHasWatchConfigError = Assert<
+  IsEqual<ScheduleTask['watchConfigError'], string | null>
+>;
+export type ScheduleCreateInputHasEditableWatchConfig = Assert<
+  IsEqual<ScheduleCreateInput['watchConfig'], HttpWatchConfigInput | null | undefined>
+>;
+export type ScheduleUpdateInputHasEditableWatchConfig = Assert<
+  IsEqual<ScheduleUpdateInput['watchConfig'], HttpWatchConfigInput | null | undefined>
+>;
+export type RuntimeStateKeysAreExcludedFromPublicInputs = Assert<
+  Extract<RuntimeStateKey, PublicScheduleInputKey> extends never ? true : false
+>;

--- a/src/shared/schedule/watch-task.ts
+++ b/src/shared/schedule/watch-task.ts
@@ -1,0 +1,173 @@
+const DEFAULT_HTTP_METHOD = 'GET';
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MIN_TIMEOUT_MS = 1_000;
+const MAX_TIMEOUT_MS = 30_000;
+
+export const WATCH_COMPARE_MODES = ['status', 'bodyHash'] as const;
+
+export type WatchCompareMode = (typeof WATCH_COMPARE_MODES)[number];
+
+type HttpWatchMethod = 'GET' | 'HEAD';
+
+export type HttpWatchConfigInput = {
+  readonly checkType: 'http';
+  readonly compareMode: WatchCompareMode;
+  readonly checkConfig: {
+    readonly url: string;
+    readonly method?: HttpWatchMethod;
+    readonly timeoutMs?: number;
+  };
+};
+
+export type HttpWatchConfig = {
+  readonly checkType: 'http';
+  readonly compareMode: WatchCompareMode;
+  readonly checkConfig: {
+    readonly url: string;
+    readonly method: HttpWatchMethod;
+    readonly timeoutMs: number;
+  };
+};
+
+export type PersistedWatchConfigParseResult =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'valid'; readonly config: HttpWatchConfig }
+  | { readonly kind: 'invalid'; readonly error: string };
+
+export class WatchConfigValidationError extends Error {
+  readonly name = 'WatchConfigValidationError';
+}
+
+export function normalizeWatchConfig(input: unknown): HttpWatchConfig {
+  const config = requireObject(input);
+  const checkType = config.checkType;
+  if (checkType !== 'http') {
+    throw new WatchConfigValidationError('Watch configuration checkType must be http.');
+  }
+
+  const compareMode = config.compareMode;
+  if (compareMode !== 'status' && compareMode !== 'bodyHash') {
+    throw new WatchConfigValidationError(
+      'Watch configuration compareMode must be status or bodyHash.'
+    );
+  }
+
+  const checkConfig = requireObject(config.checkConfig);
+  const url = requireString(checkConfig.url, 'Watch configuration URL must be a string.');
+  const method = normalizeMethod(checkConfig.method);
+  const timeoutMs = normalizeTimeout(checkConfig.timeoutMs);
+
+  if (method === 'HEAD' && compareMode === 'bodyHash') {
+    throw new WatchConfigValidationError(
+      'Watch configuration cannot compare a HEAD response body hash.'
+    );
+  }
+
+  return {
+    checkType,
+    compareMode,
+    checkConfig: {
+      url: normalizeUrl(url),
+      method,
+      timeoutMs,
+    },
+  };
+}
+
+export function parsePersistedWatchConfig(value: unknown): PersistedWatchConfigParseResult {
+  if (value === null) {
+    return { kind: 'none' };
+  }
+  if (typeof value !== 'string') {
+    return { kind: 'invalid', error: 'Persisted HTTP watch configuration must be a JSON string.' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return { kind: 'invalid', error: 'Invalid persisted HTTP watch configuration JSON.' };
+    }
+    throw error;
+  }
+
+  try {
+    return { kind: 'valid', config: normalizeWatchConfig(parsed) };
+  } catch (error) {
+    if (error instanceof WatchConfigValidationError) {
+      return { kind: 'invalid', error: error.message };
+    }
+    throw error;
+  }
+}
+
+export function areHttpWatchConfigsEqual(first: HttpWatchConfig, second: HttpWatchConfig): boolean {
+  return (
+    first.compareMode === second.compareMode &&
+    first.checkConfig.url === second.checkConfig.url &&
+    first.checkConfig.method === second.checkConfig.method &&
+    first.checkConfig.timeoutMs === second.checkConfig.timeoutMs
+  );
+}
+
+function requireObject(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new WatchConfigValidationError('Watch configuration must be an object.');
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireString(value: unknown, errorMessage: string): string {
+  if (typeof value !== 'string') {
+    throw new WatchConfigValidationError(errorMessage);
+  }
+  return value;
+}
+
+function normalizeMethod(value: unknown): HttpWatchMethod {
+  if (value === undefined) {
+    return DEFAULT_HTTP_METHOD;
+  }
+  if (value === 'GET' || value === 'HEAD') {
+    return value;
+  }
+  throw new WatchConfigValidationError('Watch configuration method must be GET or HEAD.');
+}
+
+function normalizeTimeout(value: unknown): number {
+  if (value === undefined) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+  if (
+    typeof value !== 'number' ||
+    !Number.isInteger(value) ||
+    value < MIN_TIMEOUT_MS ||
+    value > MAX_TIMEOUT_MS
+  ) {
+    throw new WatchConfigValidationError(
+      'Watch configuration timeoutMs must be an integer between 1000 and 30000.'
+    );
+  }
+  return value;
+}
+
+function normalizeUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new WatchConfigValidationError('Watch configuration URL must be a valid URL.');
+    }
+    throw error;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new WatchConfigValidationError('Watch configuration URL must use HTTP or HTTPS.');
+  }
+  return url.toString();
+}

--- a/tests/http-condition-checker.test.ts
+++ b/tests/http-condition-checker.test.ts
@@ -1,0 +1,261 @@
+import { createHash } from 'node:crypto';
+import { once } from 'node:events';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import {
+  HttpConditionChecker,
+  type HttpConditionCheckErrorCode,
+} from '../src/main/schedule/http-condition-checker';
+import type { HttpWatchConfig, WatchCompareMode } from '../src/shared/schedule/watch-task';
+
+const checker = new HttpConditionChecker();
+const MAX_RESPONSE_BYTES = 1_048_576;
+
+type RequestHandler = (request: IncomingMessage, response: ServerResponse) => void;
+
+function checkConfig(url: string, compareMode: WatchCompareMode): HttpWatchConfig {
+  return {
+    checkType: 'http',
+    compareMode,
+    checkConfig: { url, method: 'GET', timeoutMs: 1_000 },
+  };
+}
+
+async function withServer<T>(
+  handler: RequestHandler,
+  runWithServer: (baseUrl: string) => Promise<T>
+): Promise<T> {
+  const server = createServer(handler);
+  server.listen(0);
+  await once(server, 'listening');
+
+  try {
+    return await runWithServer(serverUrl(server));
+  } finally {
+    await closeServer(server);
+  }
+}
+
+function serverUrl(server: Server): string {
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('Expected ephemeral HTTP server to expose a TCP port.');
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function expectCheckError(
+  operation: Promise<string>,
+  code: HttpConditionCheckErrorCode
+): Promise<void> {
+  await expect(operation).rejects.toMatchObject({
+    name: 'HttpConditionCheckError',
+    code,
+  });
+}
+
+describe('HttpConditionChecker', () => {
+  it('returns a SHA-256 hash of raw GET response bytes', async () => {
+    await withServer(
+      (_request, response) => response.end('hello'),
+      async (baseUrl) => {
+        await expect(checker.check(checkConfig(baseUrl, 'bodyHash'))).resolves.toBe(
+          '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+        );
+      }
+    );
+  });
+
+  it('returns the same hash for unchanged consecutive response bytes', async () => {
+    await withServer(
+      (_request, response) => response.end('hello'),
+      async (baseUrl) => {
+        const firstHash = await checker.check(checkConfig(baseUrl, 'bodyHash'));
+        const secondHash = await checker.check(checkConfig(baseUrl, 'bodyHash'));
+        expect(secondHash).toBe(firstHash);
+      }
+    );
+  });
+
+  it('returns a HEAD response status without hashing its body', async () => {
+    let observedMethod = '';
+    await withServer(
+      (request, response) => {
+        observedMethod = request.method ?? '';
+        response.writeHead(204);
+        response.end();
+      },
+      async (baseUrl) => {
+        const headConfig: HttpWatchConfig = {
+          ...checkConfig(baseUrl, 'status'),
+          checkConfig: { url: baseUrl, method: 'HEAD', timeoutMs: 1_000 },
+        };
+        await expect(checker.check(headConfig)).resolves.toBe('204');
+      }
+    );
+    expect(observedMethod).toBe('HEAD');
+  });
+
+  it('returns a 500 status as an observation', async () => {
+    await withServer(
+      (_request, response) => {
+        response.writeHead(500);
+        response.end('server failure');
+      },
+      async (baseUrl) => expect(checker.check(checkConfig(baseUrl, 'status'))).resolves.toBe('500')
+    );
+  });
+
+  it('follows a relative redirect', async () => {
+    await withServer(
+      (request, response) => {
+        if (request.url === '/nested/start') {
+          response.writeHead(302, { location: '../final' });
+          response.end();
+          return;
+        }
+        response.writeHead(201);
+        response.end();
+      },
+      async (baseUrl) =>
+        expect(checker.check(checkConfig(`${baseUrl}/nested/start`, 'status'))).resolves.toBe('201')
+    );
+  });
+
+  it('follows exactly three redirects', async () => {
+    const redirects = new Map([
+      ['/one', '/two'],
+      ['/two', '/three'],
+      ['/three', '/final'],
+    ]);
+    await withServer(
+      (request, response) => {
+        const location = redirects.get(request.url ?? '');
+        if (location !== undefined) {
+          response.writeHead(302, { location });
+          response.end();
+          return;
+        }
+        response.writeHead(204);
+        response.end();
+      },
+      async (baseUrl) =>
+        expect(checker.check(checkConfig(`${baseUrl}/one`, 'status'))).resolves.toBe('204')
+    );
+  });
+
+  it('rejects a fourth redirect', async () => {
+    const redirects = new Map([
+      ['/one', '/two'],
+      ['/two', '/three'],
+      ['/three', '/four'],
+      ['/four', '/five'],
+    ]);
+    await withServer(
+      (request, response) => {
+        response.writeHead(302, { location: redirects.get(request.url ?? '') });
+        response.end();
+      },
+      async (baseUrl) =>
+        expectCheckError(
+          checker.check(checkConfig(`${baseUrl}/one`, 'status')),
+          'redirect_limit_exceeded'
+        )
+    );
+  });
+
+  it('rejects a redirect to a non-HTTP protocol', async () => {
+    await withServer(
+      (_request, response) => {
+        response.writeHead(302, { location: 'file:///tmp/condition' });
+        response.end();
+      },
+      async (baseUrl) =>
+        expectCheckError(
+          checker.check(checkConfig(baseUrl, 'status')),
+          'redirect_protocol_unsupported'
+        )
+    );
+  });
+
+  it('rejects an invalid redirect location', async () => {
+    await withServer(
+      (_request, response) => {
+        response.writeHead(302, { location: 'http://[::1' });
+        response.end();
+      },
+      async (baseUrl) =>
+        expectCheckError(checker.check(checkConfig(baseUrl, 'status')), 'redirect_location_invalid')
+    );
+  });
+
+  it('rejects a redirect with no Location header', async () => {
+    await withServer(
+      (_request, response) => {
+        response.writeHead(302);
+        response.end();
+      },
+      async (baseUrl) =>
+        expectCheckError(checker.check(checkConfig(baseUrl, 'status')), 'redirect_location_missing')
+    );
+  });
+
+  it('uses one bounded timeout for the complete check', async () => {
+    await withServer(
+      (_request, response) => response.write('partial response body'),
+      async (baseUrl) =>
+        expectCheckError(checker.check(checkConfig(baseUrl, 'bodyHash')), 'timeout')
+    );
+  });
+
+  it('accepts a response body of exactly one MiB', async () => {
+    const body = Buffer.alloc(MAX_RESPONSE_BYTES, 0x61);
+    const expectedHash = createHash('sha256').update(body).digest('hex');
+    await withServer(
+      (_request, response) => response.end(body),
+      async (baseUrl) =>
+        expect(checker.check(checkConfig(baseUrl, 'bodyHash'))).resolves.toBe(expectedHash)
+    );
+  });
+
+  it('rejects a response body larger than one MiB', async () => {
+    await withServer(
+      (_request, response) => response.end(Buffer.alloc(MAX_RESPONSE_BYTES + 1)),
+      async (baseUrl) =>
+        expectCheckError(checker.check(checkConfig(baseUrl, 'bodyHash')), 'response_body_too_large')
+    );
+  });
+
+  it('allows private and localhost URLs across a redirect', async () => {
+    let port = '';
+    await withServer(
+      (request, response) => {
+        if (request.url === '/private') {
+          response.writeHead(302, { location: `http://localhost:${port}/localhost` });
+          response.end();
+          return;
+        }
+        response.end('allowed');
+      },
+      async (baseUrl) => {
+        port = new URL(baseUrl).port;
+        await expect(checker.check(checkConfig(`${baseUrl}/private`, 'status'))).resolves.toBe(
+          '200'
+        );
+      }
+    );
+  });
+});

--- a/tests/reactive-polling-integration.test.ts
+++ b/tests/reactive-polling-integration.test.ts
@@ -1,0 +1,186 @@
+import { createHash } from 'node:crypto';
+import { once } from 'node:events';
+import { createServer, type Server } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import { HttpConditionChecker } from '../src/main/schedule/http-condition-checker';
+import {
+  ScheduledTaskManager,
+  type ScheduledTask,
+  type ScheduledTaskStore,
+} from '../src/main/schedule/scheduled-task-manager';
+import { normalizeWatchConfig } from '../src/shared/schedule/watch-task';
+
+type LoopbackServer = {
+  readonly url: string;
+  setBody(body: string): void;
+  getRequestCount(): number;
+};
+
+function createWatchTask(url: string, now: number): ScheduledTask {
+  return {
+    id: 'integration-watch-task',
+    title: 'Watch loopback state',
+    prompt: 'React to a changed loopback response.',
+    cwd: '/tmp/reactive-polling',
+    runAt: now + 60_000,
+    nextRunAt: now + 60_000,
+    scheduleConfig: null,
+    repeatEvery: 1,
+    repeatUnit: 'minute',
+    enabled: true,
+    lastRunAt: null,
+    lastRunSessionId: null,
+    lastError: null,
+    watchConfig: normalizeWatchConfig({
+      checkType: 'http',
+      compareMode: 'bodyHash',
+      checkConfig: { url, method: 'GET', timeoutMs: 1_000 },
+    }),
+    watchConfigError: null,
+    lastState: null,
+    lastCheckedAt: null,
+    consecutiveUnchanged: 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function createStore(task: ScheduledTask): ScheduledTaskStore {
+  let currentTask = task;
+
+  return {
+    list: () => [currentTask],
+    get: (id) => (id === currentTask.id ? currentTask : null),
+    create: () => {
+      throw new Error('The integration Store does not create tasks.');
+    },
+    update: (id, updates) => {
+      if (id !== currentTask.id) {
+        return null;
+      }
+      currentTask = { ...currentTask, ...updates, updatedAt: Date.now() };
+      return currentTask;
+    },
+    delete: () => false,
+  };
+}
+
+function hash(body: string): string {
+  return createHash('sha256').update(body).digest('hex');
+}
+
+async function withLoopbackServer<T>(
+  runWithServer: (server: LoopbackServer) => Promise<T>
+): Promise<T> {
+  let responseBody = 'A';
+  let requestCount = 0;
+  const server = createServer((_request, response) => {
+    requestCount += 1;
+    response.end(responseBody);
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('Expected an ephemeral loopback TCP port.');
+  }
+
+  try {
+    return await runWithServer({
+      url: `http://127.0.0.1:${address.port}/state`,
+      setBody: (body) => {
+        responseBody = body;
+      },
+      getRequestCount: () => requestCount,
+    });
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+describe('reactive polling integration', () => {
+  it('runs A, unchanged A, changed B, failed C, and unchanged C through the real loopback checker', async () => {
+    await withLoopbackServer(async (loopback) => {
+      // Given
+      const now = Date.now();
+      const task = createWatchTask(loopback.url, now);
+      const store = createStore(task);
+      const checker = new HttpConditionChecker();
+      let agentCalls = 0;
+      const manager = new ScheduledTaskManager({
+        store,
+        checkCondition: (config) => checker.check(config),
+        executeTask: async () => {
+          agentCalls += 1;
+          if (agentCalls === 2) {
+            throw new Error('Agent failed C');
+          }
+          return { sessionId: 'agent-B' };
+        },
+        now: () => now,
+      });
+
+      // When
+      await manager.runNow(task.id);
+
+      // Then
+      expect(store.get(task.id)).toMatchObject({
+        lastState: hash('A'),
+        consecutiveUnchanged: 0,
+        lastError: null,
+      });
+      expect(agentCalls).toBe(0);
+
+      await manager.runNow(task.id);
+      expect(store.get(task.id)).toMatchObject({
+        lastState: hash('A'),
+        consecutiveUnchanged: 1,
+        lastError: null,
+      });
+      expect(agentCalls).toBe(0);
+
+      loopback.setBody('B');
+      await manager.runNow(task.id);
+      expect(store.get(task.id)).toMatchObject({
+        lastState: hash('B'),
+        consecutiveUnchanged: 0,
+        lastRunSessionId: 'agent-B',
+        lastError: null,
+      });
+      expect(agentCalls).toBe(1);
+
+      loopback.setBody('C');
+      await expect(manager.runNow(task.id)).rejects.toThrow('Agent failed C');
+      expect(store.get(task.id)).toMatchObject({
+        lastState: hash('C'),
+        consecutiveUnchanged: 0,
+        lastRunSessionId: null,
+        lastError: 'Agent failed C',
+      });
+      expect(agentCalls).toBe(2);
+
+      await manager.runNow(task.id);
+      expect(store.get(task.id)).toMatchObject({
+        lastState: hash('C'),
+        consecutiveUnchanged: 1,
+        lastError: null,
+        nextRunAt: now + 60_000,
+      });
+      expect(agentCalls).toBe(2);
+      expect(loopback.getRequestCount()).toBe(5);
+    });
+  });
+});

--- a/tests/schedule-ipc-contract.test.ts
+++ b/tests/schedule-ipc-contract.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const rootPath = process.cwd();
+const rendererTypes = readFileSync(path.join(rootPath, 'src/renderer/types/index.ts'), 'utf8');
+const preloadSource = readFileSync(path.join(rootPath, 'src/preload/index.ts'), 'utf8');
+const mainSource = readFileSync(path.join(rootPath, 'src/main/index.ts'), 'utf8');
+const componentPath = path.join(rootPath, 'src/renderer/components');
+const componentSource = readdirSync(componentPath, { recursive: true })
+  .filter((entry) => entry.endsWith('.ts') || entry.endsWith('.tsx'))
+  .map((entry) => readFileSync(path.join(componentPath, entry), 'utf8'))
+  .join('\n');
+
+describe('schedule IPC WatchTask contract', () => {
+  it('uses the shared WatchTask types for editable inputs and normalized task outputs', () => {
+    expect(rendererTypes).toContain(
+      "import type { HttpWatchConfig, HttpWatchConfigInput } from '../../shared/schedule/watch-task';"
+    );
+    expect(rendererTypes).toContain('watchConfig: HttpWatchConfig | null;');
+    expect(rendererTypes).toContain('lastState: string | null;');
+    expect(rendererTypes).toContain('lastCheckedAt: number | null;');
+    expect(rendererTypes).toContain('consecutiveUnchanged: number;');
+    expect(rendererTypes).toContain('readonly watchConfigError: string | null;');
+    expect(rendererTypes.match(/watchConfig\?: HttpWatchConfigInput \| null;/g)).toHaveLength(2);
+  });
+
+  it('keeps the established schedule IPC bridge channels and method signatures', () => {
+    const scheduleChannels = Array.from(
+      preloadSource.matchAll(/ipcRenderer\.invoke\('(schedule\.[^']+)'/g),
+      (match) => match[1] ?? ''
+    );
+
+    expect(scheduleChannels).toEqual([
+      'schedule.list',
+      'schedule.create',
+      'schedule.update',
+      'schedule.delete',
+      'schedule.toggle',
+      'schedule.runNow',
+    ]);
+    expect(preloadSource).toContain(
+      'create: (payload: ScheduleCreateInput): Promise<ScheduleTask>'
+    );
+    expect(preloadSource).toContain(
+      'update: (id: string, updates: ScheduleUpdateInput): Promise<ScheduleTask | null>'
+    );
+  });
+
+  it('keeps WatchTask fields out of renderer components', () => {
+    expect(componentSource).not.toMatch(
+      /\b(watchConfig|lastState|lastCheckedAt|consecutiveUnchanged|watchConfigError)\b/
+    );
+  });
+
+  it('wires the HTTP condition checker into headless and GUI managers', () => {
+    expect(mainSource).toContain(
+      "import { HttpConditionChecker } from './schedule/http-condition-checker';"
+    );
+    expect(mainSource).toContain('const checkHttpCondition =');
+    expect(mainSource.match(/checkCondition: checkHttpCondition/g)).toHaveLength(2);
+  });
+});

--- a/tests/scheduled-task-database.test.ts
+++ b/tests/scheduled-task-database.test.ts
@@ -1,0 +1,275 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ScheduledTaskRow } from '../src/main/db/database';
+
+interface SchemaColumn {
+  readonly name: string;
+  readonly type: string;
+  readonly notnull: number;
+  readonly dflt_value: string | null;
+}
+
+interface WatchStateRow {
+  readonly watch_config: string | null;
+  readonly last_state: string | null;
+  readonly last_checked_at: number | null;
+  readonly consecutive_unchanged: number;
+}
+
+let testRoot = '';
+let databaseModule: typeof import('../src/main/db/database') | null = null;
+
+function mockElectron(userDataPath: string): void {
+  vi.doMock('electron', () => ({
+    app: {
+      getPath: () => userDataPath,
+    },
+  }));
+}
+
+function mockLogger(): void {
+  vi.doMock('../src/main/utils/logger', () => ({
+    log: vi.fn(),
+    logWarn: vi.fn(),
+    logError: vi.fn(),
+  }));
+}
+
+async function loadDatabaseModule(
+  userDataPath: string
+): Promise<typeof import('../src/main/db/database')> {
+  vi.resetModules();
+  mockElectron(userDataPath);
+  mockLogger();
+  databaseModule = await import('../src/main/db/database');
+  return databaseModule;
+}
+
+function databasePath(userDataPath: string): string {
+  return path.join(userDataPath, 'data', 'cowork.db');
+}
+
+function createLegacyScheduledTaskDatabase(userDataPath: string): void {
+  const dbDirectory = path.join(userDataPath, 'data');
+  fs.mkdirSync(dbDirectory, { recursive: true });
+
+  const legacyDatabase = new Database(databasePath(userDataPath));
+  legacyDatabase.exec(`
+    CREATE TABLE scheduled_tasks (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      prompt TEXT NOT NULL,
+      cwd TEXT NOT NULL,
+      run_at INTEGER NOT NULL,
+      next_run_at INTEGER,
+      schedule_config TEXT,
+      repeat_every INTEGER,
+      repeat_unit TEXT,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      last_run_at INTEGER,
+      last_run_session_id TEXT,
+      last_error TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  legacyDatabase
+    .prepare(
+      `
+    INSERT INTO scheduled_tasks (
+      id, title, prompt, cwd, run_at, next_run_at, schedule_config, repeat_every, repeat_unit,
+      enabled, last_run_at, last_run_session_id, last_error, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `
+    )
+    .run(
+      'legacy-task',
+      'Legacy task',
+      'Legacy prompt',
+      '/legacy/cwd',
+      100,
+      200,
+      '{"kind":"legacy"}',
+      5,
+      'minutes',
+      1,
+      50,
+      'legacy-session',
+      'legacy-error',
+      10,
+      20
+    );
+  legacyDatabase.close();
+}
+
+function getWatchColumns(database: Database.Database): SchemaColumn[] {
+  return database
+    .prepare<[], SchemaColumn>('PRAGMA table_info(scheduled_tasks)')
+    .all()
+    .filter((column) =>
+      ['watch_config', 'last_state', 'last_checked_at', 'consecutive_unchanged'].includes(
+        column.name
+      )
+    )
+    .map((column) => ({
+      name: column.name,
+      type: column.type,
+      notnull: column.notnull,
+      dflt_value: column.dflt_value,
+    }));
+}
+
+function createScheduledTask(): ScheduledTaskRow {
+  return {
+    id: 'watch-task',
+    title: 'Watch task',
+    prompt: 'Observe the endpoint',
+    cwd: '/watch/cwd',
+    run_at: 1_000,
+    next_run_at: 2_000,
+    schedule_config: '{"kind":"interval"}',
+    repeat_every: 60,
+    repeat_unit: 'seconds',
+    enabled: 1,
+    last_run_at: 900,
+    last_run_session_id: 'watch-session',
+    last_error: null,
+    created_at: 100,
+    updated_at: 200,
+    watch_config: '{"checkType":"http"}',
+    last_state: 'state-one',
+    last_checked_at: 1_500,
+    consecutive_unchanged: 4,
+  };
+}
+
+describe('scheduled task database watch columns', () => {
+  beforeEach(() => {
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'open-cowork-scheduled-task-db-test-'));
+  });
+
+  afterEach(() => {
+    databaseModule?.closeDatabase();
+    databaseModule = null;
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.doUnmock('electron');
+    vi.doUnmock('../src/main/utils/logger');
+
+    if (testRoot && fs.existsSync(testRoot)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('creates watch columns with the approved definitions for a fresh database', async () => {
+    const userDataPath = path.join(testRoot, 'userData');
+    const database = await loadDatabaseModule(userDataPath);
+
+    const instance = database.initDatabase();
+
+    expect(getWatchColumns(instance.raw)).toEqual([
+      { name: 'watch_config', type: 'TEXT', notnull: 0, dflt_value: null },
+      { name: 'last_state', type: 'TEXT', notnull: 0, dflt_value: null },
+      { name: 'last_checked_at', type: 'INTEGER', notnull: 0, dflt_value: null },
+      { name: 'consecutive_unchanged', type: 'INTEGER', notnull: 1, dflt_value: '0' },
+    ]);
+  });
+
+  it('migrates an old row with exact defaults while preserving legacy fields', async () => {
+    const userDataPath = path.join(testRoot, 'userData');
+    createLegacyScheduledTaskDatabase(userDataPath);
+    const database = await loadDatabaseModule(userDataPath);
+
+    const instance = database.initDatabase();
+    const migrated = instance.scheduledTasks.get('legacy-task');
+    const watchState = instance.raw
+      .prepare<[string], WatchStateRow>(
+        `
+      SELECT watch_config, last_state, last_checked_at, consecutive_unchanged
+      FROM scheduled_tasks
+      WHERE id = ?
+    `
+      )
+      .get('legacy-task');
+
+    expect(migrated).toMatchObject({
+      id: 'legacy-task',
+      title: 'Legacy task',
+      prompt: 'Legacy prompt',
+      cwd: '/legacy/cwd',
+      run_at: 100,
+      next_run_at: 200,
+      schedule_config: '{"kind":"legacy"}',
+      repeat_every: 5,
+      repeat_unit: 'minutes',
+      enabled: 1,
+      last_run_at: 50,
+      last_run_session_id: 'legacy-session',
+      last_error: 'legacy-error',
+      created_at: 10,
+      updated_at: 20,
+    });
+    expect(watchState).toEqual({
+      watch_config: null,
+      last_state: null,
+      last_checked_at: null,
+      consecutive_unchanged: 0,
+    });
+  });
+
+  it('round-trips every watch field through create, update, get, list, and delete', async () => {
+    const userDataPath = path.join(testRoot, 'userData');
+    const database = await loadDatabaseModule(userDataPath);
+    const instance = database.initDatabase();
+    const task = createScheduledTask();
+
+    instance.scheduledTasks.create(task);
+
+    expect(instance.scheduledTasks.get(task.id)).toMatchObject(task);
+    expect(instance.scheduledTasks.getAll()).toEqual([expect.objectContaining(task)]);
+
+    instance.scheduledTasks.update(task.id, {
+      watch_config: '{"checkType":"http","compareMode":"status"}',
+      last_state: 'state-two',
+      last_checked_at: 2_500,
+      consecutive_unchanged: 0,
+    });
+
+    expect(instance.scheduledTasks.get(task.id)).toMatchObject({
+      watch_config: '{"checkType":"http","compareMode":"status"}',
+      last_state: 'state-two',
+      last_checked_at: 2_500,
+      consecutive_unchanged: 0,
+    });
+
+    instance.scheduledTasks.delete(task.id);
+
+    expect(instance.scheduledTasks.get(task.id)).toBeUndefined();
+    expect(instance.scheduledTasks.getAll()).toEqual([]);
+  });
+
+  it('initializes a migrated database again after closing the singleton', async () => {
+    const userDataPath = path.join(testRoot, 'userData');
+    createLegacyScheduledTaskDatabase(userDataPath);
+    const database = await loadDatabaseModule(userDataPath);
+
+    const first = database.initDatabase();
+    first.close();
+    const second = database.initDatabase();
+
+    expect(getWatchColumns(second.raw)).toEqual([
+      { name: 'watch_config', type: 'TEXT', notnull: 0, dflt_value: null },
+      { name: 'last_state', type: 'TEXT', notnull: 0, dflt_value: null },
+      { name: 'last_checked_at', type: 'INTEGER', notnull: 0, dflt_value: null },
+      { name: 'consecutive_unchanged', type: 'INTEGER', notnull: 1, dflt_value: '0' },
+    ]);
+    expect(second.scheduledTasks.get('legacy-task')).toMatchObject({
+      id: 'legacy-task',
+      title: 'Legacy task',
+      prompt: 'Legacy prompt',
+    });
+  });
+});

--- a/tests/scheduled-task-edge-cases.test.ts
+++ b/tests/scheduled-task-edge-cases.test.ts
@@ -21,6 +21,11 @@ function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     lastRunAt: null,
     lastRunSessionId: null,
     lastError: null,
+    watchConfig: null,
+    watchConfigError: null,
+    lastState: null,
+    lastCheckedAt: null,
+    consecutiveUnchanged: 0,
     createdAt: now,
     updatedAt: now,
     ...overrides,
@@ -131,7 +136,11 @@ describe('ScheduledTaskManager – edge cases', () => {
     };
 
     const executeTask = vi.fn().mockResolvedValue({ sessionId: 'session-null' });
-    const manager = new ScheduledTaskManager({ store: innerStore, executeTask, now: () => Date.now() });
+    const manager = new ScheduledTaskManager({
+      store: innerStore,
+      executeTask,
+      now: () => Date.now(),
+    });
     manager.start();
 
     // Should not throw even though store.update returns null
@@ -173,6 +182,7 @@ describe('ScheduledTaskManager – edge cases', () => {
     expect(final?.nextRunAt).toBeGreaterThan(now);
 
     // Access internal timers map to verify exactly one timer exists
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const timers = (manager as any).timers as Map<string, NodeJS.Timeout>;
     expect(timers.size).toBe(1);
     expect(timers.has('rapid-toggle')).toBe(true);

--- a/tests/scheduled-task-manager.test.ts
+++ b/tests/scheduled-task-manager.test.ts
@@ -1,11 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ScheduledTaskManager,
+  type ScheduledTaskCreateInput,
+  type ScheduledTaskRunResult,
   type ScheduledTaskScheduleConfig,
   type ScheduledTask,
   type ScheduledTaskStore,
 } from '../src/main/schedule/scheduled-task-manager';
 import { buildScheduledTaskTitle } from '../src/shared/schedule/task-title';
+import {
+  normalizeWatchConfig,
+  type HttpWatchConfig,
+  type HttpWatchConfigInput,
+} from '../src/shared/schedule/watch-task';
 
 function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
   const now = Date.now();
@@ -23,6 +30,11 @@ function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     lastRunAt: null,
     lastRunSessionId: null,
     lastError: null,
+    watchConfig: null,
+    watchConfigError: null,
+    lastState: null,
+    lastCheckedAt: null,
+    consecutiveUnchanged: 0,
     createdAt: now,
     updatedAt: now,
     ...overrides,
@@ -47,6 +59,39 @@ function createWeeklySchedule(weekdays: number[], times: string[]): ScheduledTas
   return { kind: 'weekly', weekdays, times };
 }
 
+function createHttpWatchConfig(
+  checkConfig: HttpWatchConfigInput['checkConfig'] = { url: 'https://example.com/status' },
+  compareMode: HttpWatchConfigInput['compareMode'] = 'status'
+): HttpWatchConfigInput {
+  return { checkType: 'http', compareMode, checkConfig };
+}
+
+function createWatchTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return createTask({
+    repeatEvery: 1,
+    repeatUnit: 'minute',
+    watchConfig: normalizeWatchConfig(createHttpWatchConfig()),
+    lastState: 'prior-state',
+    lastCheckedAt: 1_700_000_000_000,
+    consecutiveUnchanged: 3,
+    lastError: 'prior check failed',
+    ...overrides,
+  });
+}
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolvePromise: (value: T) => void = () => {
+    throw new Error('Deferred promise resolver was not initialized.');
+  };
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+}
+
 function createStore(initialTasks: ScheduledTask[]): ScheduledTaskStore {
   const tasks = new Map<string, ScheduledTask>(initialTasks.map((task) => [task.id, task]));
 
@@ -61,6 +106,11 @@ function createStore(initialTasks: ScheduledTask[]): ScheduledTaskStore {
         lastRunAt: null,
         lastRunSessionId: null,
         lastError: null,
+        watchConfig: null,
+        watchConfigError: null,
+        lastState: null,
+        lastCheckedAt: null,
+        consecutiveUnchanged: 0,
         createdAt,
         updatedAt: createdAt,
       };
@@ -80,6 +130,35 @@ function createStore(initialTasks: ScheduledTask[]): ScheduledTaskStore {
     },
     delete: (id) => tasks.delete(id),
   };
+}
+
+type WatchTaskFixtureOptions = {
+  readonly task: ScheduledTask;
+  readonly checkCondition: (config: HttpWatchConfig) => Promise<string>;
+  readonly executeTask: (task: ScheduledTask) => Promise<ScheduledTaskRunResult>;
+  readonly onTaskError?: (taskId: string, error: string) => void;
+};
+
+function createWatchTaskFixture(options: WatchTaskFixtureOptions): {
+  readonly manager: ScheduledTaskManager;
+  readonly store: ScheduledTaskStore;
+  readonly onTaskError: (taskId: string, error: string) => void;
+} {
+  const store = createStore([options.task]);
+  const onTaskError = options.onTaskError ?? vi.fn();
+  const manager = new ScheduledTaskManager({
+    store,
+    checkCondition: options.checkCondition,
+    executeTask: options.executeTask,
+    onTaskError,
+    now: () => Date.now(),
+  });
+  return { manager, store, onTaskError };
+}
+
+async function runAutomaticWatchTask(manager: ScheduledTaskManager): Promise<void> {
+  manager.start();
+  await vi.advanceTimersByTimeAsync(0);
 }
 
 describe('ScheduledTaskManager', () => {
@@ -579,5 +658,798 @@ describe('ScheduledTaskManager', () => {
     const after = store.get('error-callback');
     expect(after?.lastError).toBe('execution failed');
     consoleSpy.mockRestore();
+  });
+
+  describe('WatchTask validation', () => {
+    function createValidationManager(initialTasks: ScheduledTask[] = []): {
+      manager: ScheduledTaskManager;
+      store: ScheduledTaskStore;
+    } {
+      const store = createStore(initialTasks);
+      const manager = new ScheduledTaskManager({
+        store,
+        executeTask: vi.fn().mockResolvedValue({ sessionId: 'watch-validation' }),
+        now: () => Date.now(),
+      });
+      return { manager, store };
+    }
+
+    it('accepts an interval WatchTask and writes its normalized configuration', () => {
+      const { manager, store } = createValidationManager();
+      const createSpy = vi.spyOn(store, 'create');
+      const watchConfig = createHttpWatchConfig({ url: 'HTTPS://EXAMPLE.COM:443/status' });
+
+      manager.create({
+        prompt: 'check interval',
+        cwd: '/tmp/project',
+        runAt: Date.now() + 60_000,
+        repeatEvery: 1,
+        repeatUnit: 'minute',
+        watchConfig,
+      });
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ watchConfig: normalizeWatchConfig(watchConfig) })
+      );
+    });
+
+    it('accepts a daily WatchTask and writes its normalized configuration', () => {
+      const { manager, store } = createValidationManager();
+      const createSpy = vi.spyOn(store, 'create');
+      const watchConfig = createHttpWatchConfig();
+
+      manager.create({
+        prompt: 'check daily',
+        cwd: '/tmp/project',
+        runAt: Date.now() + 60_000,
+        scheduleConfig: createDailySchedule(['09:00']),
+        watchConfig,
+      });
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ watchConfig: normalizeWatchConfig(watchConfig) })
+      );
+    });
+
+    it('accepts a weekly WatchTask and writes its normalized configuration', () => {
+      const { manager, store } = createValidationManager();
+      const createSpy = vi.spyOn(store, 'create');
+      const watchConfig = createHttpWatchConfig();
+
+      manager.create({
+        prompt: 'check weekly',
+        cwd: '/tmp/project',
+        runAt: Date.now() + 60_000,
+        scheduleConfig: createWeeklySchedule([1], ['09:00']),
+        watchConfig,
+      });
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ watchConfig: normalizeWatchConfig(watchConfig) })
+      );
+    });
+
+    it('rejects a one-time WatchTask before it reaches the Store', () => {
+      const { manager, store } = createValidationManager();
+      const createSpy = vi.spyOn(store, 'create');
+
+      expect(() =>
+        manager.create({
+          prompt: 'check once',
+          cwd: '/tmp/project',
+          runAt: Date.now() + 60_000,
+          watchConfig: createHttpWatchConfig(),
+        })
+      ).toThrow('WatchTasks require a repeating interval, daily, or weekly schedule.');
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects an automatic WatchTask interval shorter than one minute', () => {
+      const { manager, store } = createValidationManager();
+      const createSpy = vi.spyOn(store, 'create');
+
+      expect(() =>
+        manager.create({
+          prompt: 'check too soon',
+          cwd: '/tmp/project',
+          runAt: Date.now() + 60_000,
+          repeatEvery: 0.5,
+          repeatUnit: 'minute',
+          watchConfig: createHttpWatchConfig(),
+        })
+      ).toThrow('WatchTasks require a repeating interval, daily, or weekly schedule.');
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        condition: 'uses a non-HTTP protocol',
+        watchConfig: createHttpWatchConfig({ url: 'file:///tmp/status' }),
+        message: 'Watch configuration URL must use HTTP or HTTPS.',
+      },
+      {
+        condition: 'uses an out-of-range timeout',
+        watchConfig: createHttpWatchConfig({
+          url: 'https://example.com/status',
+          timeoutMs: 999,
+        }),
+        message: 'Watch configuration timeoutMs must be an integer between 1000 and 30000.',
+      },
+      {
+        condition: 'compares a HEAD response body hash',
+        watchConfig: createHttpWatchConfig(
+          { url: 'https://example.com/status', method: 'HEAD' },
+          'bodyHash'
+        ),
+        message: 'Watch configuration cannot compare a HEAD response body hash.',
+      },
+    ])('rejects a WatchTask that $condition', ({ watchConfig, message }) => {
+      const { manager, store } = createValidationManager();
+      const createSpy = vi.spyOn(store, 'create');
+
+      expect(() =>
+        manager.create({
+          prompt: 'check invalid config',
+          cwd: '/tmp/project',
+          runAt: Date.now() + 60_000,
+          repeatEvery: 1,
+          repeatUnit: 'minute',
+          watchConfig,
+        })
+      ).toThrow(message);
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it('merges the current one-time schedule before accepting a WatchTask update', () => {
+      const { manager, store } = createValidationManager([createTask({ id: 'one-time' })]);
+      const updateSpy = vi.spyOn(store, 'update');
+
+      expect(() => manager.update('one-time', { watchConfig: createHttpWatchConfig() })).toThrow(
+        'WatchTasks require a repeating interval, daily, or weekly schedule.'
+      );
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it('preserves WatchTask runtime state for an equivalent normalized configuration', () => {
+      const currentWatchConfig = normalizeWatchConfig(createHttpWatchConfig());
+      const { manager } = createValidationManager([
+        createWatchTask({ id: 'equivalent', watchConfig: currentWatchConfig }),
+      ]);
+      const equivalentConfig = createHttpWatchConfig({
+        url: 'HTTPS://EXAMPLE.COM:443/status',
+      });
+
+      const updated = manager.update('equivalent', { watchConfig: equivalentConfig });
+
+      expect(updated).toMatchObject({
+        watchConfig: currentWatchConfig,
+        lastState: 'prior-state',
+        lastCheckedAt: 1_700_000_000_000,
+        consecutiveUnchanged: 3,
+        lastError: 'prior check failed',
+      });
+    });
+
+    it.each([
+      {
+        field: 'URL',
+        watchConfig: createHttpWatchConfig({ url: 'https://example.com/changed' }),
+      },
+      {
+        field: 'method',
+        watchConfig: createHttpWatchConfig({ url: 'https://example.com/status', method: 'HEAD' }),
+      },
+      {
+        field: 'compare mode',
+        watchConfig: createHttpWatchConfig({ url: 'https://example.com/status' }, 'bodyHash'),
+      },
+      {
+        field: 'timeout',
+        watchConfig: createHttpWatchConfig({
+          url: 'https://example.com/status',
+          timeoutMs: 12_000,
+        }),
+      },
+    ])('resets WatchTask runtime state when the $field changes', ({ watchConfig }) => {
+      const { manager } = createValidationManager([createWatchTask({ id: 'reset-config' })]);
+
+      const updated = manager.update('reset-config', { watchConfig });
+
+      expect(updated).toMatchObject({
+        lastState: null,
+        lastCheckedAt: null,
+        consecutiveUnchanged: 0,
+        lastError: null,
+      });
+    });
+
+    it('resets WatchTask runtime state when watch configuration is removed', () => {
+      const { manager } = createValidationManager([createWatchTask({ id: 'remove-watch' })]);
+
+      const updated = manager.update('remove-watch', { watchConfig: null });
+
+      expect(updated).toMatchObject({
+        watchConfig: null,
+        lastState: null,
+        lastCheckedAt: null,
+        consecutiveUnchanged: 0,
+        lastError: null,
+      });
+    });
+
+    it('does not forward public runtime state supplied during WatchTask creation', () => {
+      const { manager, store } = createValidationManager();
+      const createSpy = vi.spyOn(store, 'create');
+      const publicCreatePayload: ScheduledTaskCreateInput & {
+        lastState: string;
+        lastCheckedAt: number;
+        consecutiveUnchanged: number;
+      } = {
+        prompt: 'check state input',
+        cwd: '/tmp/project',
+        runAt: Date.now() + 60_000,
+        repeatEvery: 1,
+        repeatUnit: 'minute',
+        watchConfig: createHttpWatchConfig(),
+        lastState: 'injected-state',
+        lastCheckedAt: 123,
+        consecutiveUnchanged: 99,
+      };
+
+      manager.create(publicCreatePayload);
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          lastState: 'injected-state',
+          lastCheckedAt: 123,
+          consecutiveUnchanged: 99,
+        })
+      );
+    });
+
+    it('does not mutate WatchTask runtime state from a public update payload', () => {
+      const { manager } = createValidationManager([createWatchTask({ id: 'state-update' })]);
+      const publicUpdatePayload = {
+        lastState: 'injected-state',
+        lastCheckedAt: 123,
+        consecutiveUnchanged: 99,
+      };
+
+      const updated = manager.update('state-update', publicUpdatePayload);
+
+      expect(updated).toMatchObject({
+        lastState: 'prior-state',
+        lastCheckedAt: 1_700_000_000_000,
+        consecutiveUnchanged: 3,
+      });
+    });
+  });
+
+  describe('WatchTask check-persist-act pipeline', () => {
+    it('persists the first baseline before an automatic WatchTask decides not to invoke Agent', async () => {
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-baseline',
+        nextRunAt: now,
+        lastState: null,
+        lastCheckedAt: null,
+        consecutiveUnchanged: 0,
+        lastError: 'previous failure',
+        lastRunAt: 123,
+        lastRunSessionId: 'prior-session',
+      });
+      const checkCondition = vi.fn().mockResolvedValue('A');
+      const executeTask = vi.fn().mockResolvedValue({ sessionId: 'unexpected' });
+      const { manager, store } = createWatchTaskFixture({ task, checkCondition, executeTask });
+      const updateSpy = vi.spyOn(store, 'update');
+      checkCondition.mockImplementation(async () => {
+        expect(updateSpy).toHaveBeenCalledWith(
+          task.id,
+          expect.objectContaining({ nextRunAt: now + 60_000, enabled: true })
+        );
+        return 'A';
+      });
+
+      await runAutomaticWatchTask(manager);
+
+      expect(store.get(task.id)).toMatchObject({
+        nextRunAt: now + 60_000,
+        lastState: 'A',
+        lastCheckedAt: now,
+        consecutiveUnchanged: 0,
+        lastError: null,
+        lastRunAt: 123,
+        lastRunSessionId: 'prior-session',
+      });
+      expect(checkCondition).toHaveBeenCalledWith(task.watchConfig);
+      expect(executeTask).not.toHaveBeenCalled();
+    });
+
+    it('increments an unchanged state and clears its prior check error without invoking Agent', async () => {
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-unchanged',
+        nextRunAt: now,
+        lastState: 'A',
+        consecutiveUnchanged: 2,
+        lastError: 'previous check failure',
+        lastRunAt: 456,
+      });
+      const checkCondition = vi.fn().mockResolvedValue('A');
+      const executeTask = vi.fn().mockResolvedValue({ sessionId: 'unexpected' });
+      const { manager, store } = createWatchTaskFixture({ task, checkCondition, executeTask });
+
+      await runAutomaticWatchTask(manager);
+
+      expect(store.get(task.id)).toMatchObject({
+        lastState: 'A',
+        lastCheckedAt: now,
+        consecutiveUnchanged: 3,
+        lastError: null,
+        lastRunAt: 456,
+      });
+      expect(executeTask).not.toHaveBeenCalled();
+    });
+
+    it('persists a changed state before invoking Agent', async () => {
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-changed',
+        nextRunAt: now,
+        lastState: 'A',
+        consecutiveUnchanged: 4,
+        lastError: 'previous check failure',
+      });
+      const checkCondition = vi.fn().mockResolvedValue('B');
+      const executeTask = vi.fn().mockImplementation(async () => {
+        expect(store.get(task.id)).toMatchObject({
+          lastState: 'B',
+          lastCheckedAt: now,
+          consecutiveUnchanged: 0,
+          lastError: null,
+        });
+        return { sessionId: 'watch-session' };
+      });
+      const { manager, store } = createWatchTaskFixture({ task, checkCondition, executeTask });
+
+      await runAutomaticWatchTask(manager);
+
+      expect(executeTask).toHaveBeenCalledTimes(1);
+      expect(store.get(task.id)).toMatchObject({
+        lastState: 'B',
+        lastCheckedAt: now,
+        consecutiveUnchanged: 0,
+        lastError: null,
+        lastRunAt: now,
+        lastRunSessionId: 'watch-session',
+      });
+    });
+
+    it('keeps an advanced baseline after Agent fails and does not retry it when unchanged', async () => {
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-agent-failure',
+        nextRunAt: now,
+        lastState: 'A',
+      });
+      const checkCondition = vi.fn().mockResolvedValue('B');
+      const executeTask = vi.fn().mockRejectedValue(new Error('Agent failed'));
+      const { manager, store } = createWatchTaskFixture({ task, checkCondition, executeTask });
+
+      await runAutomaticWatchTask(manager);
+
+      expect(store.get(task.id)).toMatchObject({
+        lastState: 'B',
+        lastCheckedAt: now,
+        consecutiveUnchanged: 0,
+        lastError: 'Agent failed',
+        lastRunAt: now,
+        lastRunSessionId: null,
+      });
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(executeTask).toHaveBeenCalledTimes(1);
+      expect(store.get(task.id)).toMatchObject({
+        lastState: 'B',
+        consecutiveUnchanged: 1,
+        lastError: null,
+      });
+    });
+
+    it('records and reports checker failures without invoking Agent', async () => {
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-checker-failure',
+        nextRunAt: now,
+        lastState: 'A',
+        consecutiveUnchanged: 2,
+      });
+      const checkCondition = vi.fn().mockRejectedValue(new Error('checker failed'));
+      const executeTask = vi.fn().mockResolvedValue({ sessionId: 'unexpected' });
+      const onTaskError = vi.fn();
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { manager, store } = createWatchTaskFixture({
+        task,
+        checkCondition,
+        executeTask,
+        onTaskError,
+      });
+
+      await runAutomaticWatchTask(manager);
+
+      expect(store.get(task.id)).toMatchObject({
+        lastState: 'A',
+        lastCheckedAt: now,
+        consecutiveUnchanged: 2,
+        lastError: 'checker failed',
+      });
+      expect(executeTask).not.toHaveBeenCalled();
+      expect(onTaskError).toHaveBeenCalledWith(task.id, 'checker failed');
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('reports a WatchTask state persistence failure and skips Agent', async () => {
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-state-persist-throws',
+        nextRunAt: now,
+        lastState: null,
+      });
+      const checkCondition = vi.fn().mockResolvedValue('A');
+      const executeTask = vi.fn().mockResolvedValue({ sessionId: 'unexpected' });
+      const onTaskError = vi.fn();
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { manager, store } = createWatchTaskFixture({
+        task,
+        checkCondition,
+        executeTask,
+        onTaskError,
+      });
+      const originalUpdate = store.update.bind(store);
+      store.update = (id, updates) => {
+        if (updates.lastCheckedAt !== undefined) {
+          throw new Error('state persistence failed');
+        }
+        return originalUpdate(id, updates);
+      };
+
+      await runAutomaticWatchTask(manager);
+
+      expect(executeTask).not.toHaveBeenCalled();
+      expect(onTaskError).toHaveBeenCalledWith(
+        task.id,
+        expect.stringContaining('state persistence failed')
+      );
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('reports a missing WatchTask state update and skips Agent', async () => {
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-state-persist-null',
+        nextRunAt: now,
+        lastState: null,
+      });
+      const checkCondition = vi.fn().mockResolvedValue('A');
+      const executeTask = vi.fn().mockResolvedValue({ sessionId: 'unexpected' });
+      const onTaskError = vi.fn();
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { manager, store } = createWatchTaskFixture({
+        task,
+        checkCondition,
+        executeTask,
+        onTaskError,
+      });
+      const originalUpdate = store.update.bind(store);
+      store.update = (id, updates) =>
+        updates.lastCheckedAt !== undefined ? null : originalUpdate(id, updates);
+
+      await runAutomaticWatchTask(manager);
+
+      expect(executeTask).not.toHaveBeenCalled();
+      expect(onTaskError).toHaveBeenCalledWith(
+        task.id,
+        expect.stringContaining('state update returned no task')
+      );
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('treats malformed persisted WatchTasks as check failures for automatic and runNow paths', async () => {
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-malformed',
+        nextRunAt: now,
+        watchConfig: null,
+        watchConfigError: 'Invalid persisted HTTP watch configuration JSON.',
+        lastState: 'A',
+        consecutiveUnchanged: 2,
+      });
+      const checkCondition = vi.fn().mockResolvedValue('unexpected');
+      const executeTask = vi.fn().mockResolvedValue({ sessionId: 'unexpected' });
+      const onTaskError = vi.fn();
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { manager, store } = createWatchTaskFixture({
+        task,
+        checkCondition,
+        executeTask,
+        onTaskError,
+      });
+
+      await runAutomaticWatchTask(manager);
+      await expect(manager.runNow(task.id)).rejects.toThrow(
+        'Invalid persisted HTTP watch configuration JSON.'
+      );
+
+      expect(store.get(task.id)).toMatchObject({
+        lastState: 'A',
+        lastCheckedAt: now,
+        consecutiveUnchanged: 2,
+        lastError: 'Invalid persisted HTTP watch configuration JSON.',
+      });
+      expect(checkCondition).not.toHaveBeenCalled();
+      expect(executeTask).not.toHaveBeenCalled();
+      expect(onTaskError).toHaveBeenCalledTimes(2);
+      consoleSpy.mockRestore();
+    });
+
+    it('rejects runNow after recording a checker failure without invoking Agent', async () => {
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-run-now-checker-failure',
+        nextRunAt: now + 60_000,
+        lastState: 'A',
+        consecutiveUnchanged: 2,
+      });
+      const checkCondition = vi.fn().mockRejectedValue(new Error('runNow checker failed'));
+      const executeTask = vi.fn().mockResolvedValue({ sessionId: 'unexpected' });
+      const onTaskError = vi.fn();
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { manager, store } = createWatchTaskFixture({
+        task,
+        checkCondition,
+        executeTask,
+        onTaskError,
+      });
+
+      await expect(manager.runNow(task.id)).rejects.toThrow('runNow checker failed');
+
+      expect(store.get(task.id)).toMatchObject({
+        lastState: 'A',
+        lastCheckedAt: now,
+        consecutiveUnchanged: 2,
+        lastError: 'runNow checker failed',
+        lastRunAt: null,
+        lastRunSessionId: null,
+      });
+      expect(executeTask).not.toHaveBeenCalled();
+      expect(onTaskError).toHaveBeenCalledWith(task.id, 'runNow checker failed');
+      consoleSpy.mockRestore();
+    });
+
+    it('rejects runNow after Agent fails while retaining the advanced WatchTask baseline', async () => {
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-run-now-agent-failure',
+        nextRunAt: now + 60_000,
+        lastState: 'A',
+      });
+      const checkCondition = vi.fn().mockResolvedValue('B');
+      const executeTask = vi.fn().mockRejectedValue(new Error('runNow Agent failed'));
+      const { manager, store } = createWatchTaskFixture({ task, checkCondition, executeTask });
+
+      await expect(manager.runNow(task.id)).rejects.toThrow('runNow Agent failed');
+
+      expect(store.get(task.id)).toMatchObject({
+        lastState: 'B',
+        lastCheckedAt: now,
+        consecutiveUnchanged: 0,
+        lastError: 'runNow Agent failed',
+        lastRunAt: now,
+        lastRunSessionId: null,
+      });
+    });
+
+    it('reschedules a WatchTask after its timer overlaps an unresolved checker', async () => {
+      // Given
+      const now = Date.now();
+      const task = createWatchTask({ id: 'watch-long-checker', nextRunAt: now, lastState: null });
+      const checker = createDeferred<string>();
+      const checkCondition = vi.fn().mockReturnValue(checker.promise);
+      const executeTask = vi.fn().mockResolvedValue({ sessionId: 'unexpected' });
+      const { manager, store } = createWatchTaskFixture({ task, checkCondition, executeTask });
+
+      // When
+      await runAutomaticWatchTask(manager);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      // Then
+      expect(checkCondition).toHaveBeenCalledTimes(1);
+      expect(executeTask).not.toHaveBeenCalled();
+      expect(store.get(task.id)?.nextRunAt).toBe(now + 120_000);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(checkCondition).toHaveBeenCalledTimes(1);
+      expect(store.get(task.id)?.nextRunAt).toBe(now + 180_000);
+
+      checker.resolve('A');
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(checkCondition).toHaveBeenCalledTimes(2);
+      manager.stop();
+    });
+
+    it('reschedules a WatchTask after its timer overlaps an unresolved Agent', async () => {
+      // Given
+      const now = Date.now();
+      const task = createWatchTask({ id: 'watch-long-agent', nextRunAt: now, lastState: 'A' });
+      const agent = createDeferred<ScheduledTaskRunResult>();
+      const checkCondition = vi.fn().mockResolvedValue('B');
+      const executeTask = vi.fn().mockReturnValue(agent.promise);
+      const { manager, store } = createWatchTaskFixture({ task, checkCondition, executeTask });
+
+      // When
+      await runAutomaticWatchTask(manager);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      // Then
+      expect(checkCondition).toHaveBeenCalledTimes(1);
+      expect(executeTask).toHaveBeenCalledTimes(1);
+      expect(store.get(task.id)?.nextRunAt).toBe(now + 120_000);
+
+      agent.resolve({ sessionId: 'watch-agent' });
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(checkCondition).toHaveBeenCalledTimes(2);
+      expect(executeTask).toHaveBeenCalledTimes(1);
+      manager.stop();
+    });
+
+    it('keeps a future WatchTask timer after runNow overlaps it', async () => {
+      // Given
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-run-now-overlap',
+        nextRunAt: now + 60_000,
+        lastState: null,
+      });
+      const checker = createDeferred<string>();
+      const checkCondition = vi.fn().mockReturnValue(checker.promise);
+      const executeTask = vi.fn().mockResolvedValue({ sessionId: 'unexpected' });
+      const { manager, store } = createWatchTaskFixture({ task, checkCondition, executeTask });
+      manager.start();
+
+      // When
+      const runNow = manager.runNow(task.id);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      // Then
+      expect(checkCondition).toHaveBeenCalledTimes(1);
+      expect(executeTask).not.toHaveBeenCalled();
+      expect(store.get(task.id)?.nextRunAt).toBe(now + 120_000);
+
+      checker.resolve('A');
+      await runNow;
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(checkCondition).toHaveBeenCalledTimes(2);
+      manager.stop();
+    });
+
+    it('leaves a stale WatchTask trigger at its persisted future slot', async () => {
+      // Given
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-stale-trigger',
+        nextRunAt: now - 60_000,
+        lastState: 'A',
+      });
+      const checkCondition = vi.fn().mockResolvedValue('A');
+      const executeTask = vi.fn().mockResolvedValue({ sessionId: 'unexpected' });
+      const { manager, store } = createWatchTaskFixture({ task, checkCondition, executeTask });
+      const timerSpy = vi.spyOn(globalThis, 'setTimeout');
+      manager.start();
+      const staleTrigger = timerSpy.mock.calls[0]?.[0];
+      if (typeof staleTrigger !== 'function') {
+        throw new Error('Expected an initial timer callback.');
+      }
+
+      // When
+      await manager.runNow(task.id);
+      staleTrigger();
+
+      // Then
+      expect(checkCondition).toHaveBeenCalledTimes(1);
+      expect(executeTask).not.toHaveBeenCalled();
+      expect(store.get(task.id)?.nextRunAt).toBe(now + 60_000);
+      timerSpy.mockRestore();
+      manager.stop();
+    });
+
+    it('restores an overdue WatchTask from its persisted future slot after restart', async () => {
+      // Given
+      const now = Date.now();
+      const task = createWatchTask({
+        id: 'watch-restart-overdue',
+        nextRunAt: now - 60_000,
+        lastState: null,
+      });
+      const checker = createDeferred<string>();
+      const firstCheckCondition = vi.fn().mockReturnValue(checker.promise);
+      const executeTask = vi.fn().mockResolvedValue({ sessionId: 'unexpected' });
+      const { manager, store } = createWatchTaskFixture({
+        task,
+        checkCondition: firstCheckCondition,
+        executeTask,
+      });
+      manager.start();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+      manager.stop();
+      checker.resolve('A');
+      await Promise.resolve();
+      const restartedCheckCondition = vi.fn().mockResolvedValue('A');
+      const restartedManager = new ScheduledTaskManager({
+        store,
+        checkCondition: restartedCheckCondition,
+        executeTask,
+        now: () => Date.now(),
+      });
+
+      // When
+      restartedManager.start();
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      // Then
+      expect(firstCheckCondition).toHaveBeenCalledTimes(1);
+      expect(restartedCheckCondition).toHaveBeenCalledTimes(1);
+      expect(executeTask).not.toHaveBeenCalled();
+      restartedManager.stop();
+    });
+
+    it('keeps ordinary one-time, interval, daily, and weekly tasks out of the checker', async () => {
+      // Given
+      const now = Date.now();
+      const tasks = [
+        createTask({ id: 'ordinary-once', nextRunAt: now + 60_000 }),
+        createTask({
+          id: 'ordinary-interval',
+          nextRunAt: now + 60_000,
+          repeatEvery: 1,
+          repeatUnit: 'minute',
+        }),
+        createTask({
+          id: 'ordinary-daily',
+          nextRunAt: now + 60_000,
+          scheduleConfig: createDailySchedule(['09:00']),
+        }),
+        createTask({
+          id: 'ordinary-weekly',
+          nextRunAt: now + 60_000,
+          scheduleConfig: createWeeklySchedule([1], ['09:00']),
+        }),
+      ];
+      const store = createStore(tasks);
+      const checkCondition = vi.fn().mockResolvedValue('unexpected');
+      const executeTask = vi.fn().mockResolvedValue({ sessionId: 'ordinary-session' });
+      const manager = new ScheduledTaskManager({
+        store,
+        checkCondition,
+        executeTask,
+        now: () => Date.now(),
+      });
+
+      // When
+      for (const task of tasks) {
+        await manager.runNow(task.id);
+      }
+
+      // Then
+      expect(checkCondition).not.toHaveBeenCalled();
+      expect(executeTask).toHaveBeenCalledTimes(4);
+    });
   });
 });

--- a/tests/scheduled-task-store.test.ts
+++ b/tests/scheduled-task-store.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+import type { ScheduledTaskRow } from '../src/main/db/database';
+import {
+  createScheduledTaskStore,
+  type ScheduledTaskDatabase,
+} from '../src/main/schedule/scheduled-task-store';
+import type {
+  ScheduledTaskCreateInput,
+  ScheduledTaskUpdateInput,
+} from '../src/main/schedule/scheduled-task-manager';
+
+type RuntimeStateKey = 'lastState' | 'lastCheckedAt' | 'consecutiveUnchanged';
+
+function createRow(overrides: Partial<ScheduledTaskRow> = {}): ScheduledTaskRow {
+  return {
+    id: 'task-1',
+    title: 'Watch endpoint',
+    prompt: 'Observe endpoint state',
+    cwd: '/tmp/project',
+    run_at: 1_000,
+    next_run_at: 2_000,
+    schedule_config: null,
+    watch_config: null,
+    last_state: null,
+    last_checked_at: null,
+    consecutive_unchanged: 0,
+    repeat_every: 5,
+    repeat_unit: 'minute',
+    enabled: 1,
+    last_run_at: null,
+    last_run_session_id: null,
+    last_error: null,
+    created_at: 100,
+    updated_at: 200,
+    ...overrides,
+  };
+}
+
+function createFakeDatabase(initialRows: readonly ScheduledTaskRow[] = []): {
+  readonly database: ScheduledTaskDatabase;
+  readonly rows: Map<string, ScheduledTaskRow>;
+} {
+  const rows = new Map(initialRows.map((row) => [row.id, row]));
+
+  return {
+    database: {
+      scheduledTasks: {
+        create: (task) => {
+          rows.set(task.id, task);
+        },
+        update: (id, updates) => {
+          const existing = rows.get(id);
+          if (!existing) return;
+          rows.set(id, { ...existing, ...updates, updated_at: existing.updated_at + 1 });
+        },
+        get: (id) => rows.get(id),
+        getAll: () => Array.from(rows.values()),
+        delete: (id) => {
+          rows.delete(id);
+        },
+      },
+    },
+    rows,
+  };
+}
+
+describe('createScheduledTaskStore', () => {
+  it('stores normalized watch config and default runtime state when creating a task', () => {
+    const { database, rows } = createFakeDatabase();
+    const store = createScheduledTaskStore(database);
+
+    const created = store.create({
+      title: 'Watch endpoint',
+      prompt: 'Observe endpoint state',
+      cwd: '/tmp/project',
+      runAt: 1_000,
+      watchConfig: {
+        checkType: 'http',
+        compareMode: 'status',
+        checkConfig: { url: 'HTTP://EXAMPLE.COM:80/health' },
+      },
+    });
+
+    expect(rows.get(created.id)).toMatchObject({
+      watch_config:
+        '{"checkType":"http","compareMode":"status","checkConfig":{"url":"http://example.com/health","method":"GET","timeoutMs":10000}}',
+      last_state: null,
+      last_checked_at: null,
+      consecutive_unchanged: 0,
+    });
+    expect(created).toMatchObject({
+      watchConfig: {
+        checkType: 'http',
+        compareMode: 'status',
+        checkConfig: {
+          url: 'http://example.com/health',
+          method: 'GET',
+          timeoutMs: 10_000,
+        },
+      },
+      watchConfigError: null,
+      lastState: null,
+      lastCheckedAt: null,
+      consecutiveUnchanged: 0,
+    });
+  });
+
+  it('returns valid watch config through get and list after an ordinary update', () => {
+    const { database } = createFakeDatabase([
+      createRow({
+        watch_config:
+          '{"checkType":"http","compareMode":"bodyHash","checkConfig":{"url":"https://example.com/feed","method":"GET","timeoutMs":5000}}',
+        last_state: 'before',
+        last_checked_at: 1_500,
+        consecutive_unchanged: 2,
+      }),
+    ]);
+    const store = createScheduledTaskStore(database);
+
+    store.update('task-1', { title: 'Updated watch endpoint' });
+
+    expect(store.get('task-1')).toMatchObject({
+      title: 'Updated watch endpoint',
+      watchConfig: {
+        checkType: 'http',
+        compareMode: 'bodyHash',
+        checkConfig: {
+          url: 'https://example.com/feed',
+          method: 'GET',
+          timeoutMs: 5_000,
+        },
+      },
+      watchConfigError: null,
+      lastState: 'before',
+      lastCheckedAt: 1_500,
+      consecutiveUnchanged: 2,
+    });
+    expect(store.list()).toEqual([expect.objectContaining({ id: 'task-1' })]);
+  });
+
+  it('maps a legacy null watch config to no config and default runtime state', () => {
+    const { database } = createFakeDatabase([createRow()]);
+    const store = createScheduledTaskStore(database);
+
+    expect(store.get('task-1')).toMatchObject({
+      watchConfig: null,
+      watchConfigError: null,
+      lastState: null,
+      lastCheckedAt: null,
+      consecutiveUnchanged: 0,
+      scheduleConfig: null,
+    });
+  });
+
+  it('removes a configured watch when explicitly updated to null', () => {
+    const { database, rows } = createFakeDatabase([
+      createRow({
+        watch_config:
+          '{"checkType":"http","compareMode":"status","checkConfig":{"url":"https://example.com/health","method":"GET","timeoutMs":10000}}',
+      }),
+    ]);
+    const store = createScheduledTaskStore(database);
+
+    store.update('task-1', { watchConfig: null });
+
+    expect(rows.get('task-1')?.watch_config).toBeNull();
+    expect(store.get('task-1')).toMatchObject({ watchConfig: null, watchConfigError: null });
+  });
+
+  it('persists runtime state through the Store-only update path', () => {
+    const { database, rows } = createFakeDatabase([createRow()]);
+    const store = createScheduledTaskStore(database);
+
+    store.update('task-1', {
+      lastState: 'state-after-check',
+      lastCheckedAt: 4_000,
+      consecutiveUnchanged: 3,
+    });
+
+    expect(rows.get('task-1')).toMatchObject({
+      last_state: 'state-after-check',
+      last_checked_at: 4_000,
+      consecutive_unchanged: 3,
+    });
+  });
+
+  it('preserves malformed persisted JSON as an error without throwing or logging raw data from list', () => {
+    const rawConfig = '{secret:do-not-log';
+    const { database } = createFakeDatabase([createRow({ watch_config: rawConfig })]);
+    const store = createScheduledTaskStore(database);
+    const errorSpy = vi.spyOn(console, 'error');
+
+    const listed = store.list();
+
+    expect(listed).toEqual([
+      expect.objectContaining({
+        watchConfig: null,
+        watchConfigError: 'Invalid persisted HTTP watch configuration JSON.',
+      }),
+    ]);
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining(rawConfig));
+  });
+
+  it('maps valid JSON with an invalid watch shape to its deterministic error', () => {
+    const { database } = createFakeDatabase([createRow({ watch_config: '{"checkType":"http"}' })]);
+    const store = createScheduledTaskStore(database);
+
+    expect(store.get('task-1')).toMatchObject({
+      watchConfig: null,
+      watchConfigError: 'Watch configuration compareMode must be status or bodyHash.',
+    });
+  });
+
+  it('keeps runtime state outside public manager create and update inputs', () => {
+    expectTypeOf<Extract<keyof ScheduledTaskCreateInput, RuntimeStateKey>>().toEqualTypeOf<never>();
+    expectTypeOf<Extract<keyof ScheduledTaskUpdateInput, RuntimeStateKey>>().toEqualTypeOf<never>();
+  });
+});

--- a/tests/watch-task-types.test.ts
+++ b/tests/watch-task-types.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import {
+  areHttpWatchConfigsEqual,
+  normalizeWatchConfig,
+  parsePersistedWatchConfig,
+} from '../src/shared/schedule/watch-task';
+
+describe('HTTP watch task contract', () => {
+  it('normalizes HTTP watch configuration defaults and canonical URL', () => {
+    const normalized = normalizeWatchConfig({
+      checkType: 'http',
+      compareMode: 'status',
+      checkConfig: {
+        url: 'HTTP://Example.COM:80/updates/../status',
+      },
+    });
+
+    expect(normalized).toEqual({
+      checkType: 'http',
+      compareMode: 'status',
+      checkConfig: {
+        url: 'http://example.com/status',
+        method: 'GET',
+        timeoutMs: 10_000,
+      },
+    });
+  });
+
+  it('compares semantically equivalent normalized HTTP watch configurations', () => {
+    const implicitDefaults = normalizeWatchConfig({
+      checkType: 'http',
+      compareMode: 'status',
+      checkConfig: { url: 'http://example.com' },
+    });
+    const explicitDefaults = normalizeWatchConfig({
+      checkType: 'http',
+      compareMode: 'status',
+      checkConfig: {
+        url: 'http://example.com/',
+        method: 'GET',
+        timeoutMs: 10_000,
+      },
+    });
+
+    expect(areHttpWatchConfigsEqual(implicitDefaults, explicitDefaults)).toBe(true);
+  });
+
+  it('detects semantic changes to compare mode and URL', () => {
+    const baseline = normalizeWatchConfig({
+      checkType: 'http',
+      compareMode: 'status',
+      checkConfig: { url: 'https://example.com/status' },
+    });
+    const changedMode = normalizeWatchConfig({
+      checkType: 'http',
+      compareMode: 'bodyHash',
+      checkConfig: { url: 'https://example.com/status' },
+    });
+    const changedUrl = normalizeWatchConfig({
+      checkType: 'http',
+      compareMode: 'status',
+      checkConfig: { url: 'https://example.com/health' },
+    });
+
+    expect(areHttpWatchConfigsEqual(baseline, changedMode)).toBe(false);
+    expect(areHttpWatchConfigsEqual(baseline, changedUrl)).toBe(false);
+  });
+
+  it('rejects invalid HTTP watch configuration inputs with stable errors', () => {
+    expect(() =>
+      normalizeWatchConfig({
+        checkType: 'http',
+        compareMode: 'status',
+        checkConfig: { url: 'ftp://example.com/status' },
+      })
+    ).toThrow('Watch configuration URL must use HTTP or HTTPS.');
+    expect(() =>
+      normalizeWatchConfig({
+        checkType: 'http',
+        compareMode: 'status',
+        checkConfig: { url: 'https://' },
+      })
+    ).toThrow('Watch configuration URL must be a valid URL.');
+    expect(() =>
+      normalizeWatchConfig({
+        checkType: 'http',
+        compareMode: 'status',
+        checkConfig: { url: 'https://example.com', timeoutMs: 1_000.5 },
+      })
+    ).toThrow('Watch configuration timeoutMs must be an integer between 1000 and 30000.');
+    expect(() =>
+      normalizeWatchConfig({
+        checkType: 'http',
+        compareMode: 'status',
+        checkConfig: { url: 'https://example.com', timeoutMs: 999 },
+      })
+    ).toThrow('Watch configuration timeoutMs must be an integer between 1000 and 30000.');
+    expect(() =>
+      normalizeWatchConfig({
+        checkType: 'http',
+        compareMode: 'status',
+        checkConfig: { url: 'https://example.com', timeoutMs: 30_001 },
+      })
+    ).toThrow('Watch configuration timeoutMs must be an integer between 1000 and 30000.');
+    expect(() =>
+      normalizeWatchConfig({
+        checkType: 'http',
+        compareMode: 'status',
+        checkConfig: { url: 'https://example.com', method: 'POST' },
+      })
+    ).toThrow('Watch configuration method must be GET or HEAD.');
+    expect(() =>
+      normalizeWatchConfig({
+        checkType: 'file',
+        compareMode: 'status',
+        checkConfig: { url: 'https://example.com' },
+      })
+    ).toThrow('Watch configuration checkType must be http.');
+  });
+
+  it('rejects a HEAD body hash watch', () => {
+    expect(() =>
+      normalizeWatchConfig({
+        checkType: 'http',
+        compareMode: 'bodyHash',
+        checkConfig: { url: 'https://example.com', method: 'HEAD' },
+      })
+    ).toThrow('Watch configuration cannot compare a HEAD response body hash.');
+  });
+
+  it('parses persisted HTTP watch configuration into none, valid, or invalid', () => {
+    expect(parsePersistedWatchConfig(null)).toEqual({ kind: 'none' });
+    expect(
+      parsePersistedWatchConfig(
+        JSON.stringify({
+          checkType: 'http',
+          compareMode: 'status',
+          checkConfig: { url: 'http://127.0.0.1:8080' },
+        })
+      )
+    ).toEqual({
+      kind: 'valid',
+      config: {
+        checkType: 'http',
+        compareMode: 'status',
+        checkConfig: {
+          url: 'http://127.0.0.1:8080/',
+          method: 'GET',
+          timeoutMs: 10_000,
+        },
+      },
+    });
+    expect(parsePersistedWatchConfig('{')).toEqual({
+      kind: 'invalid',
+      error: 'Invalid persisted HTTP watch configuration JSON.',
+    });
+    expect(parsePersistedWatchConfig(JSON.stringify({ checkType: 'http' }))).toEqual({
+      kind: 'invalid',
+      error: 'Watch configuration compareMode must be status or bodyHash.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add an HTTP-only `WatchTask` capability on top of the existing `ScheduledTaskManager`. A scheduled task becomes a WatchTask when it has a valid `watchConfig`. The scheduler pipeline changes from unconditional execution to:

```
timer → checkCondition() → persist state → changed?
  ├─ yes → start Agent session
  └─ no  → skip, reschedule
```

## Scope

- HTTP `status` and `bodyHash` comparison modes
- Null baseline: first successful check establishes baseline without starting Agent
- Persist-before-Agent: changed state written before Agent execution
- Agent failure does not retry the same observed change
- Malformed persisted config never falls through to ordinary execution
- WatchTask busy-trigger recovery: future repeat slot persisted during in-flight execution
- Production wiring in both headless and GUI constructors
- Minimum 60-second automatic interval, `runNow()` immediate

## Safety boundaries

- HTTP/HTTPS only, protocol revalidated after every redirect
- 10s default timeout (1-30s configurable), 1 MiB response body limit
- Max 3 followed redirects (manual, no auto-follow)
- No custom request headers, auth secrets, or response body persistence
- Localhost/private-network URLs allowed
- Node 22 built-ins only: `fetch`, `node:crypto`, `node:http`

## Out of scope

Command checker, file checker, Agent checker, UI forms, notifications, custom headers, retry/backoff. These are deferred to separate work.

## Test coverage

- 1166 tests passing (Vitest: `npm test`)
- `npm run lint`: 0 errors
- `npm run typecheck`: passes
- `npm run build`: passes
- Integration test with loopback HTTP server

Closes #304
Refs #274