### PR TITLE
fix(ci): expand DeepSeek retry output budget

### DIFF
--- a/.github/scripts/deepseek-common.mjs
+++ b/.github/scripts/deepseek-common.mjs
@@ -383,10 +383,17 @@ export function assertNonEmptyParsedString(parsed, fieldName = 'body') {
 }
 
 export async function callDeepSeekJsonWithRetries(options) {
-  const { maxAttempts = 3, fieldName = 'body', userPrompt, ...requestOptions } = options
+  const {
+    maxAttempts = 3,
+    fieldName = 'body',
+    maxTokens = 8192,
+    userPrompt,
+    ...requestOptions
+  } = options
   let lastError = null
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const attemptMaxTokens = attempt === 1 ? maxTokens : Math.max(maxTokens, 16384)
     const attemptPrompt =
       attempt === 1
         ? userPrompt
@@ -404,6 +411,7 @@ export async function callDeepSeekJsonWithRetries(options) {
     try {
       const result = await callDeepSeekJson({
         ...requestOptions,
+        maxTokens: attemptMaxTokens,
         userPrompt: attemptPrompt,
       })
       assertNonEmptyParsedString(result.parsed, fieldName)

--- a/tests/deepseek-common.test.ts
+++ b/tests/deepseek-common.test.ts
@@ -255,4 +255,60 @@ describe('deepseek-common structured response parsing', () => {
       body: 'Review mode: initial\n\nNo findings.',
     });
   });
+
+  it('raises the output token budget only after an invalid structured response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: '',
+                  reasoning_content: 'Analysis was truncated before the final JSON object.',
+                  role: 'assistant',
+                },
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: '',
+                  reasoning_content: '{"body":"No findings."}',
+                  role: 'assistant',
+                },
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { callDeepSeekJsonWithRetries } = await import('../.github/scripts/deepseek-common.mjs');
+
+    await expect(
+      callDeepSeekJsonWithRetries({
+        apiKey: 'test-key',
+        baseUrl: 'https://api.deepseek.com',
+        effort: 'high',
+        model: 'deepseek-v4-flash',
+        systemPrompt: 'Review the pull request.',
+        userPrompt: 'Return JSON.',
+      })
+    ).resolves.toMatchObject({
+      parsed: { body: 'No findings.' },
+    });
+
+    const requestBodies = fetchMock.mock.calls.map(([, init]) => JSON.parse(String(init?.body)));
+    expect(requestBodies.map((body) => body.max_tokens)).toEqual([8192, 16384]);
+  });
 });


### PR DESCRIPTION
## Summary

- keep the normal DeepSeek review output budget at 8,192 tokens
- raise retry attempts to at least 16,384 tokens only after an invalid structured response
- add regression coverage proving the first request stays at 8,192 and the retry expands to 16,384

## Root cause

After #319 taught the bot to read `reasoning_content`, PR #318 exposed a second failure: all three responses were truncated at roughly 34,900 characters before the model emitted its final JSON object. That aligns with the existing 8,192-token output cap. Retrying with the same cap could never recover.

## Validation

- `node --check .github/scripts/deepseek-common.mjs`
- `npx vitest run tests/deepseek-common.test.ts tests/codex-pr-review-context.test.ts` (14 passed)
- `npm run typecheck`

## Bootstrap note

This follow-up also repairs the active review bot, so it uses the repository's `bot-skip` bootstrap label. Once merged, PR #318 will be rerun with the expanded retry budget.
