### PR TITLE
fix(ci): finalize DeepSeek review retries

### DIFF
--- a/.github/scripts/deepseek-common.mjs
+++ b/.github/scripts/deepseek-common.mjs
@@ -343,9 +343,11 @@ export async function callDeepSeekJson({
 
   const parsed = parseJsonObject(content);
   if (!parsed || typeof parsed !== 'object') {
-    throw new Error(
+    const error = new Error(
       `DeepSeek returned non-JSON content: ${truncate(content, 1000, 'model output')}`
     );
+    error.modelOutput = content;
+    throw error;
   }
 
   return {
@@ -391,25 +393,34 @@ export async function callDeepSeekJsonWithRetries(options) {
     ...requestOptions
   } = options
   let lastError = null
+  let previousModelOutput = null
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const attemptMaxTokens = attempt === 1 ? maxTokens : Math.max(maxTokens, 16384)
+    const retryInstructions = [
+      'AUTOMATION RETRY NOTE:',
+      '- Return ONLY valid JSON.',
+      `- The JSON MUST include a non-empty string field named "${fieldName}".`,
+      '- Do not wrap the JSON in code fences.',
+      `- Do not return an empty, null, or missing "${fieldName}" field.`,
+    ]
     const attemptPrompt =
       attempt === 1
         ? userPrompt
-        : [
-            userPrompt,
-            '',
-            'AUTOMATION RETRY NOTE:',
-            '- Your previous response was invalid for automation.',
-            '- Return ONLY valid JSON.',
-            `- The JSON MUST include a non-empty string field named "${fieldName}".`,
-            '- Do not wrap the JSON in code fences.',
-            `- Do not return an empty, null, or missing "${fieldName}" field.`,
-          ].join('\n')
+        : previousModelOutput
+          ? [
+              'Finalize the prior model analysis below into the requested JSON response.',
+              'Do not repeat the analysis and do not inspect the pull request again.',
+              ...retryInstructions,
+              '',
+              'PRIOR MODEL ANALYSIS:',
+              truncate(previousModelOutput, 60000, 'prior model analysis'),
+            ].join('\n')
+          : [userPrompt, '', ...retryInstructions].join('\n')
 
+    let result = null
     try {
-      const result = await callDeepSeekJson({
+      result = await callDeepSeekJson({
         ...requestOptions,
         maxTokens: attemptMaxTokens,
         userPrompt: attemptPrompt,
@@ -417,6 +428,15 @@ export async function callDeepSeekJsonWithRetries(options) {
       assertNonEmptyParsedString(result.parsed, fieldName)
       return result
     } catch (error) {
+      const modelOutput =
+        typeof result?.content === 'string'
+          ? result.content
+          : typeof error?.modelOutput === 'string'
+            ? error.modelOutput
+            : null
+      if (modelOutput?.trim()) {
+        previousModelOutput = modelOutput
+      }
       lastError = error
       if (attempt >= maxAttempts || !isRetryableDeepSeekOutputError(error)) {
         throw error

--- a/tests/deepseek-common.test.ts
+++ b/tests/deepseek-common.test.ts
@@ -266,7 +266,7 @@ describe('deepseek-common structured response parsing', () => {
               {
                 message: {
                   content: '',
-                  reasoning_content: 'Analysis was truncated before the final JSON object.',
+                  reasoning_content: 'Analysis was truncated before the final JSON object.\n{}',
                   role: 'assistant',
                 },
               },
@@ -302,7 +302,7 @@ describe('deepseek-common structured response parsing', () => {
         effort: 'high',
         model: 'deepseek-v4-flash',
         systemPrompt: 'Review the pull request.',
-        userPrompt: 'Return JSON.',
+        userPrompt: 'ORIGINAL LARGE PR PROMPT',
       })
     ).resolves.toMatchObject({
       parsed: { body: 'No findings.' },
@@ -310,5 +310,10 @@ describe('deepseek-common structured response parsing', () => {
 
     const requestBodies = fetchMock.mock.calls.map(([, init]) => JSON.parse(String(init?.body)));
     expect(requestBodies.map((body) => body.max_tokens)).toEqual([8192, 16384]);
+    expect(requestBodies[1].messages[1].content).toContain('PRIOR MODEL ANALYSIS:');
+    expect(requestBodies[1].messages[1].content).toContain(
+      'Analysis was truncated before the final JSON object.'
+    );
+    expect(requestBodies[1].messages[1].content).not.toContain('ORIGINAL LARGE PR PROMPT');
   });
 });


### PR DESCRIPTION
## Summary
- preserve the previous DeepSeek model output when structured parsing fails
- make retries finalize that prior analysis into JSON instead of re-sending the full PR diff
- cover the empty-body/reasoning-content failure seen in PR #318

## Why
The review model repeatedly exhausted its response while analyzing a large PR. The fallback parser then found unrelated JSON examples inside the diff. Retrying the same large prompt repeated the failure. This keeps the analysis private and asks the retry only to produce the required JSON envelope.

## Validation
- `npx vitest run tests/deepseek-common.test.ts tests/codex-pr-review-context.test.ts` (14 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; 8 existing warnings)