### PR TITLE
feat(mcp): add Parallel Search preset

### DIFF
--- a/src/main/mcp/mcp-config-store.ts
+++ b/src/main/mcp/mcp-config-store.ts
@@ -30,6 +30,11 @@ export const MCP_SERVER_PRESETS: Record<string, Omit<MCPServerConfig, 'id' | 'en
       NOTION_TOKEN: 'Notion Internal Integration Token (get from notion.so/profile/integrations)',
     },
   },
+  'parallel-search': {
+    name: 'Parallel Search',
+    type: 'streamable-http',
+    url: 'https://search.parallel.ai/mcp',
+  },
   'software-development': {
     name: 'Software_Development',
     type: 'stdio',

--- a/tests/mcp-config-store-presets.test.ts
+++ b/tests/mcp-config-store-presets.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron-store', () => ({
+  default: class MockStore {
+    get(_key: string, fallback: unknown): unknown {
+      return fallback;
+    }
+
+    set(): void {}
+  },
+}));
+
+import { MCP_SERVER_PRESETS, mcpConfigStore } from '../src/main/mcp/mcp-config-store';
+
+describe('MCP server presets', () => {
+  it('provides anonymous Parallel Search as an opt-in Streamable HTTP server', () => {
+    expect(MCP_SERVER_PRESETS['parallel-search']).toEqual({
+      name: 'Parallel Search',
+      type: 'streamable-http',
+      url: 'https://search.parallel.ai/mcp',
+    });
+
+    expect(mcpConfigStore.createFromPreset('parallel-search')).toEqual({
+      id: expect.stringMatching(/^mcp-parallel-search-/),
+      enabled: false,
+      name: 'Parallel Search',
+      type: 'streamable-http',
+      url: 'https://search.parallel.ai/mcp',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add an opt-in Parallel Search MCP preset using the public Streamable HTTP endpoint. The preset remains disabled until a user selects and enables it.

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Refactor / performance (`refactor` / `perf`)
- [ ] Documentation (`docs`)
- [x] Tests (`test`)
- [ ] Build / CI (`build` / `ci`)
- [ ] Other: <!-- describe -->

## Checklist

- [x] Code follows the project style (TypeScript strict, ESLint, Prettier)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, etc.)
- [x] Self-review completed — no debug logs, no commented-out code
- [x] Tests added or updated for the changed behaviour
- [x] `npm run test` passes locally
- [x] `npm run lint` passes locally
- [x] UI changes tested on both macOS and Windows (or noted as platform-specific)
- [x] New user-facing strings added to i18n files (`en` + `zh`)

## Testing

- `npx vitest run tests/mcp-config-store-presets.test.ts`
- `npm run lint` (passes with 8 unrelated existing warnings)
- `npx tsc --noEmit`
- `npx vitest run` (153 files, 1,104 tests passed)
- `git diff --check`

There is no UI component or platform-specific behavior change. The preset name is configuration data rather than a translated renderer string, so no i18n files are required.

## Screenshots / recordings (if applicable)

Not applicable. This change adds preset data and a focused test without changing UI components or layout.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.